### PR TITLE
only persist chunks asynchronously

### DIFF
--- a/metric_tank/aggmetric.go
+++ b/metric_tank/aggmetric.go
@@ -492,10 +492,11 @@ func (a *AggMetric) GC(chunkMinTs, metricMinTs uint32) bool {
 			if currentChunk.LastWrite < metricMinTs {
 				return true
 			}
+		} else {
+			// chunk has not been written to in a while. Lets persist it.
+			log.Info("Found stale Chunk, persisting it to Cassandra. key: %s T0: %d", a.Key, currentChunk.T0)
+			a.persist(a.CurrentChunkPos)
 		}
-		// chunk has not been written to in a while. Lets persist it.
-		log.Info("Found stale Chunk, persisting it to Cassandra. key: %s T0: %d", a.Key, currentChunk.T0)
-		a.persist(a.CurrentChunkPos)
 	}
 	return false
 }

--- a/metric_tank/aggmetric.go
+++ b/metric_tank/aggmetric.go
@@ -395,7 +395,7 @@ func (a *AggMetric) persist(pos int) {
 	// last-to-first ensuring that older data is added to the store
 	// before newer data.
 	for pendingChunk >= 0 {
-		log.Debug("adding chunk %d/%d (%s:%d) to write queue.", pendingChunk/len(pending), a.Key, maxT0)
+		log.Debug("adding chunk %d/%d (%s:%d) to write queue.", pendingChunk, len(pending), a.Key, maxT0)
 		a.store.Add(pending[pendingChunk])
 		pending[pendingChunk].chunk.Saving = true
 		pendingChunk--

--- a/metric_tank/aggmetric.go
+++ b/metric_tank/aggmetric.go
@@ -345,47 +345,42 @@ func (a *AggMetric) addAggregators(ts uint32, val float64) {
 	}
 }
 
-// write a chunk to peristant storage. This should only be called while holding a.Lock()
+// write chunks to persistent storage. This should only be called while holding a.Lock()
+// pos is the pos of the most recent chunk that is safe to be persisted (no longer being written to)
+// typically the one just before the current one.
 func (a *AggMetric) persist(pos int) {
-	pre := time.Now()
-	chunk := a.Chunks[pos]
-	chunk.Finish()
 	if !clusterStatus.IsPrimary() {
 		log.Debug("node is not primary, not saving chunk.")
 		return
 	}
+	pre := time.Now()
 
 	// create an array of chunks that need to be sent to the writeQueue.
-	pending := make([]*ChunkWriteRequest, 1)
-	// add the current chunk to the list of chunks to send to the writeQueue
-	pending[0] = &ChunkWriteRequest{
-		key:       a.Key,
-		chunk:     chunk,
-		ttl:       a.ttl,
-		timestamp: time.Now(),
-	}
+	pending := make([]*ChunkWriteRequest, 0)
 
-	// if we recently became the primary, there may be older chunks
-	// that the old primary did not save.  We should check for those
-	// and save them.
-	previousPos := pos - 1
-	if previousPos < 0 {
-		previousPos += len(a.Chunks)
-	}
-	previousChunk := a.Chunks[previousPos]
-	for (previousChunk.T0 < chunk.T0) && !previousChunk.Saved && !previousChunk.Saving {
-		log.Debug("old chunk needs saving. Adding %s:%d to writeQueue", a.Key, previousChunk.T0)
+	// see if we need to save the given chunk or any of the chunks before it
+	// (older chunks may not have been saved yet due to discrepancies between GC
+	// rate and rate of a metric filling up (perhaps its backfilled at a fast rate)
+	// or due to an older primary crashing and having failed to save a bunch of chunks
+	maxT0 := a.Chunks[pos].T0
+	startPos := pos
+	for chunk := a.Chunks[pos]; chunk.T0 <= maxT0 && !chunk.Saved && !chunk.Saving; {
+		log.Debug("old chunk needs saving. Adding %s:%d to writeQueue", a.Key, chunk.T0)
+		chunk.Finish()
 		pending = append(pending, &ChunkWriteRequest{
 			key:       a.Key,
-			chunk:     previousChunk,
+			chunk:     chunk,
 			ttl:       a.ttl,
 			timestamp: time.Now(),
 		})
-		previousPos--
-		if previousPos < 0 {
-			previousPos += len(a.Chunks)
+		pos--
+		if pos < 0 {
+			pos += len(a.Chunks)
 		}
-		previousChunk = a.Chunks[previousPos]
+		if pos == startPos {
+			// cycle is complete
+			break
+		}
 	}
 
 	log.Debug("sending %d chunks to write queue", len(pending))
@@ -400,7 +395,7 @@ func (a *AggMetric) persist(pos int) {
 	// last-to-first ensuring that older data is added to the store
 	// before newer data.
 	for pendingChunk >= 0 {
-		log.Debug("adding chunk %d/%d (%s:%d) to write queue.", pendingChunk/len(pending), a.Key, chunk.T0)
+		log.Debug("adding chunk %d/%d (%s:%d) to write queue.", pendingChunk/len(pending), a.Key, maxT0)
 		a.store.Add(pending[pendingChunk])
 		pending[pendingChunk].chunk.Saving = true
 		pendingChunk--
@@ -449,9 +444,6 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 		metricsTooOld.Inc(1)
 		return
 	} else {
-		// persist the chunk. If the writeQueue is full, then this will block.
-		a.persist(a.CurrentChunkPos)
-
 		a.CurrentChunkPos++
 		if a.CurrentChunkPos >= int(a.NumChunks) {
 			a.CurrentChunkPos = 0
@@ -496,6 +488,15 @@ func (a *AggMetric) GC(chunkMinTs, metricMinTs uint32) bool {
 			// chunk has not been written to in a while. Lets persist it.
 			log.Info("Found stale Chunk, persisting it to Cassandra. key: %s T0: %d", a.Key, currentChunk.T0)
 			a.persist(a.CurrentChunkPos)
+		}
+	} else {
+		// current chunk is still recent enough, but let's see if we have to persist any older chunks
+		pos := a.CurrentChunkPos - 1
+		if pos == -1 {
+			pos += len(a.Chunks)
+		}
+		if a.Chunks[pos] != nil {
+			a.persist(pos)
 		}
 	}
 	return false

--- a/metric_tank/aggmetrics.go
+++ b/metric_tank/aggmetrics.go
@@ -63,6 +63,7 @@ func (ms *AggMetrics) GC() {
 		}
 		ms.RUnlock()
 		for _, key := range keys {
+			gcMetric.Inc(1)
 			ms.RLock()
 			a := ms.Metrics[key]
 			ms.RUnlock()

--- a/metric_tank/aggmetrics.go
+++ b/metric_tank/aggmetrics.go
@@ -46,10 +46,13 @@ func NewAggMetrics(store Store, chunkSpan, numChunks, chunkMaxStale, metricMaxSt
 // periodically scan chunks and close any that have not received data in a while
 // TODO instrument occurences and duration of GC
 func (ms *AggMetrics) GC() {
-	ticker := time.Tick(time.Duration(*gcInterval) * time.Second)
-	for now := range ticker {
+	for {
+		unix := time.Duration(time.Now().UnixNano())
+		period := time.Duration(*gcInterval) * time.Second
+		diff := period - (unix % period)
+		time.Sleep(diff + time.Minute)
 		log.Info("checking for stale chunks that need persisting.")
-		now := uint32(now.Unix())
+		now := uint32(time.Now().Unix())
 		chunkMinTs := now - (now % ms.chunkSpan) - uint32(ms.chunkMaxStale)
 		metricMinTs := now - (now % ms.chunkSpan) - uint32(ms.metricMaxStale)
 

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -53,7 +53,7 @@ var (
 	statsdAddr = flag.String("statsd-addr", "localhost:8125", "statsd address")
 	statsdType = flag.String("statsd-type", "standard", "statsd type: standard or datadog")
 
-	gcInterval     = flag.Int("gc-interval", 3600, "Interval in seconds to run garbage collection job.")
+	gcInterval     = flag.Int("gc-interval", 600, "Interval in seconds to run garbage collection job.  You probably want to run this at least as often as your smallest chunkSpan, and track whether it can keep up")
 	chunkMaxStale  = flag.Int("chunk-max-stale", 3600, "max age in seconds for a chunk before to be considered stale and to be persisted to Cassandra.")
 	metricMaxStale = flag.Int("metric-max-stale", 21600, "max age in seconds for a metric before to be considered stale and to be purged from memory.")
 

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -87,6 +87,7 @@ var metricDefCacheHit met.Count
 var metricDefCacheMiss met.Count
 var metricsReceived met.Count
 var metricsTooOld met.Count
+var gcMetric met.Count
 var cassRowsPerResponse met.Meter
 var cassChunksPerRow met.Meter
 var cassWriteQueueSize met.Gauge
@@ -323,6 +324,7 @@ func initMetrics(stats met.Backend) {
 	metricDefCacheMiss = stats.NewCount("metricmeta_cache.miss")
 	metricsReceived = stats.NewCount("metrics_received")
 	metricsTooOld = stats.NewCount("metrics_too_old")
+	gcMetric = stats.NewCount("gc_metric")
 	cassRowsPerResponse = stats.NewMeter("cassandra.rows_per_response", 0)
 	cassChunksPerRow = stats.NewMeter("cassandra.chunks_per_row", 0)
 	cassWriteQueueSize = stats.NewGauge("cassandra.write_queue.size", int64(*cassandraWriteQueueSize))


### PR DESCRIPTION
i suspect that calling persist() when we step into a new chunkspan
is an operation that:
1) is called for a whole lot of metrics at nearly the same time
2) creates a lot of lock contention by simultaneously trying to add
   to the store/write queues

I don't have hard facts to prove this yet.
But this approach removes this assumed burden and instead relies
solely on the GC tasks to persist chunks.
At least the GC does this metric by metric.
You may want to increase your GC frequency to ~ chunkSpan

we loose the NSQ backpressure on full-queue, perhaps it could be
re-added.  With this approach it becomes more a matter of verifying
GC can keep up, which will need a bit more instrumentation.
