### PR TITLE
WIP/ on hold Cass scan refactor

### DIFF
--- a/mdata/cwr.go
+++ b/mdata/cwr.go
@@ -7,8 +7,7 @@ import (
 )
 
 type ChunkReadRequest struct {
-	month     uint32
-	sortKey   uint32
+	sortKey   int
 	q         string
 	p         []interface{}
 	timestamp time.Time

--- a/mdata/store_cassandra.go
+++ b/mdata/store_cassandra.go
@@ -367,7 +367,6 @@ func (c *cassandraStore) Search(key string, start, end uint32) ([]iter.Iter, err
 
 	if start_month == end_month {
 		// we need a selection of the row between startTs and endTs
-		row_key = fmt.Sprintf("%s_%d", key, start_month/Month_sec)
 		query(1, "SELECT data FROM metric WHERE key = ? AND ts > ? AND ts < ? ORDER BY ts ASC", row_key, start, end)
 	} else {
 		// get row_keys for each row we need to query.
@@ -419,7 +418,10 @@ func (c *cassandraStore) Search(key string, start, end uint32) ([]iter.Iter, err
 	}
 
 	cassToIterDuration.Value(time.Now().Sub(pre))
-	cassRowsPerResponse.Value(int64(len(outcomes)))
+
+	// each query hits a different row, except for start_month we used 2 queries (and outcomes)
+	cassRowsPerResponse.Value(int64(len(outcomes) - 1))
+
 	log.Debug("CS: searchCassandra(): %d outcomes (queries), %d total iters", len(outcomes), len(iters))
 	return iters, nil
 }


### PR DESCRIPTION
seems to work OK, not extensively tested. seems to perform same as https://github.com/raintank/metrictank/pull/344 (tested with retries 0)

putting this on hold because:
1) hoping to get more clarification from knowledgeable people about right way forward https://groups.google.com/forum/#!topic/gocql/CbERzX_zvOc (2 main concerns: parallelizing scanning by putting in same routine as exec query and getting the iter, and whether or not to restrict read concurrency - e.g. a worker pool - or just fire each query immediately)
2) we will be rolling out new cassandra metrics and dashboard in prod which will clarify whether our issues are due to cassandra or the way MT talks to cassandra.
