### PR TITLE
fix centos6/amzn rpm packager

### DIFF
--- a/scripts/config/upstart-0.6.5/metrictank.conf
+++ b/scripts/config/upstart-0.6.5/metrictank.conf
@@ -29,6 +29,6 @@ script
   [ -r "/etc/default/metrictank" ] && . "/etc/default/metrictank"
   [ -r "/etc/sysconfig/metrictank" ] && . "/etc/sysconfig/metrictank"
   set +a
-  exec chroot --userspec root:root / /usr/sbin/metrictank "/etc/metrictank/metrictank.ini" >> /var/log/metrictank-stdout.log 2>> /var/log/metrictank-stderr.log
+  exec chroot --userspec root:root / /usr/sbin/metrictank "-config=/etc/metrictank/metrictank.ini" >> /var/log/metrictank-stdout.log 2>> /var/log/metrictank-stderr.log
 end script
 

--- a/scripts/config/upstart-0.6.5/metrictank.conf
+++ b/scripts/config/upstart-0.6.5/metrictank.conf
@@ -29,6 +29,6 @@ script
   [ -r "/etc/default/metrictank" ] && . "/etc/default/metrictank"
   [ -r "/etc/sysconfig/metrictank" ] && . "/etc/sysconfig/metrictank"
   set +a
-  exec chroot --userspec root:root / /usr/bin/metrictank "/etc/metrictank/metrictank.ini" >> /var/log/metrictank-stdout.log 2>> /var/log/metrictank-stderr.log
+  exec chroot --userspec root:root / /usr/sbin/metrictank "/etc/metrictank/metrictank.ini" >> /var/log/metrictank-stdout.log 2>> /var/log/metrictank-stderr.log
 end script
 

--- a/scripts/config/upstart-0.6.5/metrictank.conf
+++ b/scripts/config/upstart-0.6.5/metrictank.conf
@@ -21,5 +21,14 @@ limit nofile 102400 102400
 #limit sigpending <softlimit> <hardlimit>
 #limit stack <softlimit> <hardlimit>
 
+### NOTE: logging does not work on the older version of upstart without a redirect as explained here http://upstart.ubuntu.com/cookbook/#versions-of-upstart-older-than-1-4 
+script
+  # When loading default and sysconfig files, we use `set -a` to make
+  # all variables automatically into environment variables.
+  set -a
+  [ -r "/etc/default/metrictank" ] && . "/etc/default/metrictank"
+  [ -r "/etc/sysconfig/metrictank" ] && . "/etc/sysconfig/metrictank"
+  set +a
+  exec chroot --userspec root:root / /usr/bin/metrictank "/etc/metrictank/metrictank.ini" >> /var/log/metrictank-stdout.log 2>> /var/log/metrictank-stderr.log
+end script
 
-exec chroot --userspec root:root / /usr/sbin/metrictank "-config=/etc/metrictank/metrictank.ini"


### PR DESCRIPTION


```
rpm -qlp git/metrictank-tehlers/build/sysvinit/metrictank-0.7.0-beta1-138-gf1868cc.el6.x86_64.rpm
/etc/init.d/metrictank
/etc/raintank/metrictank.ini
/etc/raintank/storage-schemas.conf
/etc/sysconfig/metrictank
/usr/sbin/metrictank

```