### PR TITLE
Clear cache api

### DIFF
--- a/api/ccache.go
+++ b/api/ccache.go
@@ -75,7 +75,7 @@ func (s *Server) ccacheDeletePropagate(ctx context.Context, req *models.CCacheDe
 		go func(peer cluster.Node) {
 			mu.Lock()
 			defer mu.Unlock()
-			peerResults[peer.Name] = s.ccacheDeleteRemote(ctx, req, peer)
+			peerResults[peer.GetName()] = s.ccacheDeleteRemote(ctx, req, peer)
 			wg.Done()
 		}(peer)
 	}
@@ -87,10 +87,10 @@ func (s *Server) ccacheDeletePropagate(ctx context.Context, req *models.CCacheDe
 func (s *Server) ccacheDeleteRemote(ctx context.Context, req *models.CCacheDelete, peer cluster.Node) models.CCacheDeleteResp {
 	var res models.CCacheDeleteResp
 
-	log.Debug("HTTP metricDelete calling %s/ccache/delete", peer.Name)
+	log.Debug("HTTP metricDelete calling %s/ccache/delete", peer.GetName())
 	buf, err := peer.Post(ctx, "ccacheDeleteRemote", "/ccache/delete", *req)
 	if err != nil {
-		log.Error(4, "HTTP ccacheDelete error querying %s/ccache/delete: %q", peer.Name, err)
+		log.Error(4, "HTTP ccacheDelete error querying %s/ccache/delete: %q", peer.GetName(), err)
 		if res.Errors == 0 {
 			res.FirstError = err.Error()
 		}
@@ -100,7 +100,7 @@ func (s *Server) ccacheDeleteRemote(ctx context.Context, req *models.CCacheDelet
 
 	err = json.Unmarshal(buf, &res)
 	if err != nil {
-		log.Error(4, "HTTP ccacheDelete error unmarshaling body from %s/ccache/delete: %q", peer.Name, err)
+		log.Error(4, "HTTP ccacheDelete error unmarshaling body from %s/ccache/delete: %q", peer.GetName(), err)
 		res.Errors++
 		return res
 	}

--- a/api/ccache.go
+++ b/api/ccache.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/grafana/metrictank/api/middleware"
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/response"
+	"github.com/grafana/metrictank/cluster"
+	"github.com/raintank/worldping-api/pkg/log"
+)
+
+func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) {
+	res := models.CCacheDeleteResp{}
+	code := 200
+
+	if req.Propagate {
+		res.Peers = s.ccacheDeletePropagate(ctx.Req.Context(), &req)
+		for _, peer := range res.Peers {
+			if peer.Errors > 0 {
+				code = 500
+			}
+		}
+	}
+
+	fullFlush := false
+	for _, pattern := range req.Patterns {
+		if pattern == "**" {
+			fullFlush = true
+		}
+	}
+
+	if fullFlush {
+		delResult := s.Cache.Reset()
+		res.DeletedSeries += delResult.Series
+		res.DeletedArchives += delResult.Archives
+	} else {
+		for _, pattern := range req.Patterns {
+			nodes, err := s.MetricIndex.Find(req.OrgId, pattern, 0)
+			if err != nil {
+				if res.Errors == 0 {
+					res.FirstError = err.Error()
+				}
+				res.Errors += 1
+				code = 500
+			} else {
+				for _, node := range nodes {
+					for _, def := range node.Defs {
+						delResult := s.Cache.DelMetric(def.Id)
+						res.DeletedSeries += delResult.Series
+						res.DeletedArchives += delResult.Archives
+					}
+				}
+			}
+		}
+	}
+	response.Write(ctx, response.NewJson(code, res, ""))
+}
+
+func (s *Server) ccacheDeletePropagate(ctx context.Context, req *models.CCacheDelete) map[string]models.CCacheDeleteResp {
+	// we never want to propagate more than once to avoid loops
+	req.Propagate = false
+
+	peers := cluster.Manager.MemberList()
+	peerResults := make(map[string]models.CCacheDeleteResp)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, peer := range peers {
+		if peer.IsLocal() {
+			continue
+		}
+		wg.Add(1)
+		go func(peer cluster.Node) {
+			mu.Lock()
+			defer mu.Unlock()
+			peerResults[peer.Name] = s.ccacheDeleteRemote(ctx, req, peer)
+			wg.Done()
+		}(peer)
+	}
+	wg.Wait()
+
+	return peerResults
+}
+
+func (s *Server) ccacheDeleteRemote(ctx context.Context, req *models.CCacheDelete, peer cluster.Node) models.CCacheDeleteResp {
+	var res models.CCacheDeleteResp
+
+	log.Debug("HTTP metricDelete calling %s/ccache/delete", peer.Name)
+	buf, err := peer.Post(ctx, "ccacheDeleteRemote", "/ccache/delete", *req)
+	if err != nil {
+		log.Error(4, "HTTP ccacheDelete error querying %s/ccache/delete: %q", peer.Name, err)
+		if res.Errors == 0 {
+			res.FirstError = err.Error()
+		}
+		res.Errors++
+		return res
+	}
+
+	err = json.Unmarshal(buf, &res)
+	if err != nil {
+		log.Error(4, "HTTP ccacheDelete error unmarshaling body from %s/ccache/delete: %q", peer.Name, err)
+		res.Errors++
+		return res
+	}
+
+	return res
+}

--- a/api/ccache.go
+++ b/api/ccache.go
@@ -48,7 +48,7 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 			} else {
 				for _, node := range nodes {
 					for _, def := range node.Defs {
-						delSeries, delArchives := s.Cache.DelMetric(def.Id)
+						delSeries, delArchives := s.Cache.DelMetric(def.NameWithTags())
 						res.DeletedSeries += delSeries
 						res.DeletedArchives += delArchives
 					}

--- a/api/ccache.go
+++ b/api/ccache.go
@@ -33,9 +33,9 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 	}
 
 	if fullFlush {
-		delResult := s.Cache.Reset()
-		res.DeletedSeries += delResult.Series
-		res.DeletedArchives += delResult.Archives
+		delSeries, delArchives := s.Cache.Reset()
+		res.DeletedSeries += delSeries
+		res.DeletedArchives += delArchives
 	} else {
 		for _, pattern := range req.Patterns {
 			nodes, err := s.MetricIndex.Find(req.OrgId, pattern, 0)
@@ -48,9 +48,9 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 			} else {
 				for _, node := range nodes {
 					for _, def := range node.Defs {
-						delResult := s.Cache.DelMetric(def.Id)
-						res.DeletedSeries += delResult.Series
-						res.DeletedArchives += delResult.Archives
+						delSeries, delArchives := s.Cache.DelMetric(def.Id)
+						res.DeletedSeries += delSeries
+						res.DeletedArchives += delArchives
 					}
 				}
 			}

--- a/api/ccache.go
+++ b/api/ccache.go
@@ -91,9 +91,7 @@ func (s *Server) ccacheDeleteRemote(ctx context.Context, req *models.CCacheDelet
 	buf, err := peer.Post(ctx, "ccacheDeleteRemote", "/ccache/delete", *req)
 	if err != nil {
 		log.Error(4, "HTTP ccacheDelete error querying %s/ccache/delete: %q", peer.GetName(), err)
-		if res.Errors == 0 {
-			res.FirstError = err.Error()
-		}
+		res.FirstError = err.Error()
 		res.Errors++
 		return res
 	}
@@ -101,8 +99,8 @@ func (s *Server) ccacheDeleteRemote(ctx context.Context, req *models.CCacheDelet
 	err = json.Unmarshal(buf, &res)
 	if err != nil {
 		log.Error(4, "HTTP ccacheDelete error unmarshaling body from %s/ccache/delete: %q", peer.GetName(), err)
+		res.FirstError = err.Error()
 		res.Errors++
-		return res
 	}
 
 	return res

--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -29,7 +29,8 @@ func newSrv(delSeries, delArchives int, key string) (*Server, *cache.MockCache) 
 	srv.BindBackendStore(store)
 
 	mockCache := cache.NewMockCache()
-	mockCache.DelMetricRes = cache.CCDelMetricResult{Series: delSeries, Archives: delArchives}
+	mockCache.DelMetricSeries = delSeries
+	mockCache.DelMetricArchives = delArchives
 	metrics := mdata.NewAggMetrics(store, mockCache, false, 0, 0, 0)
 	srv.BindMemoryStore(metrics)
 	srv.BindCache(mockCache)

--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -1,0 +1,226 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/response"
+	"github.com/grafana/metrictank/cluster"
+	"github.com/grafana/metrictank/conf"
+	"github.com/grafana/metrictank/idx/memory"
+	"github.com/grafana/metrictank/mdata"
+	"github.com/grafana/metrictank/mdata/cache"
+	"gopkg.in/raintank/schema.v1"
+)
+
+func newSrv(delSeries, delArchives int, key string) (*Server, *cache.MockCache) {
+	srv, _ := NewServer()
+	srv.RegisterRoutes()
+
+	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
+	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, true))
+
+	store := mdata.NewDevnullStore()
+	srv.BindBackendStore(store)
+
+	mockCache := cache.NewMockCache()
+	mockCache.DelMetricRes = cache.CCDelMetricResult{Series: delSeries, Archives: delArchives}
+	metrics := mdata.NewAggMetrics(store, mockCache, false, 0, 0, 0)
+	srv.BindMemoryStore(metrics)
+	srv.BindCache(mockCache)
+
+	metricIndex := memory.New()
+	metricIndex.AddOrUpdate(
+		&schema.MetricData{
+			Id:       key,
+			OrgId:    1,
+			Name:     "test.key",
+			Metric:   "test.key",
+			Interval: 10,
+			Value:    1,
+		},
+		0,
+	)
+	srv.BindMetricIndex(metricIndex)
+	return srv, mockCache
+}
+
+func TestMetricDelete(t *testing.T) {
+	cluster.Init("default", "test", time.Now(), "http", 6060)
+
+	delSeries := 3
+	delArchives := 10
+	testKey := "12345"
+
+	srv, cache := newSrv(delSeries, delArchives, testKey)
+	req, _ := json.Marshal(models.CCacheDelete{
+		Patterns:  []string{"test.*"},
+		OrgId:     1,
+		Propagate: false,
+	})
+
+	ts := httptest.NewServer(srv.Macaron)
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/ccache/delete", "application/json", bytes.NewReader(req))
+	if err != nil {
+		t.Fatalf("There was an error in the request: %s", err)
+	}
+
+	respParsed := models.CCacheDeleteResp{}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(res.Body)
+	json.Unmarshal(buf.Bytes(), &respParsed)
+
+	if len(cache.DelMetricKeys) != 1 || cache.DelMetricKeys[0] != testKey {
+		t.Fatalf("Expected that key %s has been deleted, but it has not", testKey)
+	}
+
+	if respParsed.DeletedSeries != delSeries || respParsed.DeletedArchives != delArchives {
+		t.Fatalf("Expected %d series and %d archives to get deleted, but got %d and %d", delSeries, delArchives, respParsed.DeletedSeries, respParsed.DeletedArchives)
+	}
+}
+
+func TestMetricDeleteWithErrorInPropagation(t *testing.T) {
+	manager := cluster.InitMock()
+
+	expectedDeletedSeries, expectedDeletedArchives := 0, 0
+
+	// define how many series/archives are getting deleted by peer 0
+	resp := models.CCacheDeleteResp{
+		Peers:           map[string]models.CCacheDeleteResp{"2": {Errors: 1}},
+		DeletedSeries:   1,
+		DeletedArchives: 1,
+		Errors:          1,
+	}
+
+	respEncoded := response.NewJson(500, resp, "")
+	buf, _ := respEncoded.Body()
+	manager.Peers = append(manager.Peers, cluster.NewMockNode(false, "0", buf))
+
+	// define how many series/archives are going to get deleted by this server
+	delSeries := 3
+	delArchives := 10
+	testKey := "12345"
+
+	// add up how many series/archives are expected to be deleted
+	expectedDeletedSeries += delSeries
+	expectedDeletedArchives += delArchives
+
+	srv, _ := newSrv(delSeries, delArchives, testKey)
+	req, err := json.Marshal(models.CCacheDelete{
+		Patterns:  []string{"test.*"},
+		OrgId:     1,
+		Propagate: true,
+	})
+
+	ts := httptest.NewServer(srv.Macaron)
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/ccache/delete", "application/json", bytes.NewReader(req))
+	if err != nil {
+		t.Fatalf("There was an error in the request: %s", err)
+	}
+
+	expectedCode := 500
+	if res.StatusCode != expectedCode {
+		buf2 := new(bytes.Buffer)
+		buf2.ReadFrom(res.Body)
+		respParsed := models.CCacheDeleteResp{}
+		json.Unmarshal(buf2.Bytes(), &respParsed)
+		t.Fatalf("Expected status code %d, but got %d:\n%+v", expectedCode, res.StatusCode, respParsed)
+	}
+}
+
+func TestMetricDeletePropagation(t *testing.T) {
+	manager := cluster.InitMock()
+
+	expectedDeletedSeries, expectedDeletedArchives := 0, 0
+
+	// define how many series/archives are getting deleted by peer 0
+	resp := models.CCacheDeleteResp{
+		DeletedSeries:   2,
+		DeletedArchives: 5,
+	}
+	expectedDeletedSeries += resp.DeletedSeries
+	expectedDeletedArchives += resp.DeletedArchives
+	respEncoded := response.NewJson(200, resp, "")
+	buf, _ := respEncoded.Body()
+	manager.Peers = append(manager.Peers, cluster.NewMockNode(false, "1", buf))
+
+	// define how many series/archives are getting deleted by peer 1
+	resp = models.CCacheDeleteResp{
+		Peers:           map[string]models.CCacheDeleteResp{"2": {Errors: 1}},
+		DeletedSeries:   1,
+		DeletedArchives: 1,
+	}
+
+	respEncoded = response.NewJson(200, resp, "")
+	buf, _ = respEncoded.Body()
+	// should be ignored because peer.IsLocal() is true
+	manager.Peers = append(manager.Peers, cluster.NewMockNode(true, "2", buf))
+
+	// define how many series/archives are getting deleted by peer 2
+	resp = models.CCacheDeleteResp{
+		Peers:           map[string]models.CCacheDeleteResp{"3": {Errors: 1}},
+		DeletedSeries:   1,
+		DeletedArchives: 3,
+	}
+	expectedDeletedSeries += resp.DeletedSeries
+	expectedDeletedArchives += resp.DeletedArchives
+	respEncoded = response.NewJson(200, resp, "")
+	buf, _ = respEncoded.Body()
+	manager.Peers = append(manager.Peers, cluster.NewMockNode(false, "3", buf))
+
+	// define how many series/archives are going to get deleted by this server
+	delSeries := 3
+	delArchives := 10
+	testKey := "12345"
+
+	// add up how many series/archives are expected to be deleted
+	expectedDeletedSeries += delSeries
+	expectedDeletedArchives += delArchives
+
+	srv, cache := newSrv(delSeries, delArchives, testKey)
+	req, err := json.Marshal(models.CCacheDelete{
+		Patterns:  []string{"test.*"},
+		OrgId:     1,
+		Propagate: true,
+	})
+
+	ts := httptest.NewServer(srv.Macaron)
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/ccache/delete", "application/json", bytes.NewReader(req))
+	if err != nil {
+		t.Fatalf("There was an error in the request: %s", err)
+	}
+
+	buf2 := new(bytes.Buffer)
+	buf2.ReadFrom(res.Body)
+	respParsed := models.CCacheDeleteResp{}
+	json.Unmarshal(buf2.Bytes(), &respParsed)
+
+	if len(cache.DelMetricKeys) != 1 || cache.DelMetricKeys[0] != testKey {
+		t.Fatalf("Expected that key %s has been deleted, but it has not", testKey)
+	}
+
+	deletedArchives := respParsed.DeletedArchives
+	deletedSeries := respParsed.DeletedSeries
+	for _, peer := range respParsed.Peers {
+		deletedArchives += peer.DeletedArchives
+		deletedSeries += peer.DeletedSeries
+	}
+
+	if deletedSeries != expectedDeletedSeries || deletedArchives != expectedDeletedArchives {
+		t.Fatalf(
+			"Expected %d series and %d archives to get deleted, but got %d and %d",
+			expectedDeletedSeries, expectedDeletedArchives, respParsed.DeletedSeries, respParsed.DeletedArchives,
+		)
+	}
+}

--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -38,10 +38,10 @@ func newSrv(delSeries, delArchives int, key string) (*Server, *cache.MockCache) 
 	metricIndex := memory.New()
 	metricIndex.AddOrUpdate(
 		&schema.MetricData{
-			Id:       key,
+			Id:       "123",
 			OrgId:    1,
-			Name:     "test.key",
-			Metric:   "test.key",
+			Name:     key,
+			Metric:   key,
 			Interval: 10,
 			Value:    1,
 		},
@@ -54,9 +54,9 @@ func newSrv(delSeries, delArchives int, key string) (*Server, *cache.MockCache) 
 func TestMetricDelete(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 
-	delSeries := 3
-	delArchives := 10
-	testKey := "12345"
+	delSeries := 1
+	delArchives := 3
+	testKey := "test.key"
 
 	srv, cache := newSrv(delSeries, delArchives, testKey)
 	req, _ := json.Marshal(models.CCacheDelete{
@@ -102,9 +102,9 @@ func TestMetricDeleteWithErrorInPropagation(t *testing.T) {
 	manager.Peers = append(manager.Peers, cluster.NewMockNode(false, "0", buf))
 
 	// define how many series/archives are going to get deleted by this server
-	delSeries := 3
-	delArchives := 10
-	testKey := "12345"
+	delSeries := 1
+	delArchives := 3
+	testKey := "test.key"
 
 	srv, _ := newSrv(delSeries, delArchives, testKey)
 	req, err := json.Marshal(models.CCacheDelete{
@@ -152,9 +152,9 @@ func TestMetricDeletePropagation(t *testing.T) {
 	}
 
 	// define how many series/archives are going to get deleted by this server
-	delSeries := 3
-	delArchives := 10
-	testKey := "12345"
+	delSeries := 1
+	delArchives := 3
+	testKey := "test.key"
 
 	// add up how many series/archives are expected to be deleted
 	expectedDeletedSeries += delSeries

--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -89,8 +89,6 @@ func TestMetricDelete(t *testing.T) {
 func TestMetricDeleteWithErrorInPropagation(t *testing.T) {
 	manager := cluster.InitMock()
 
-	expectedDeletedSeries, expectedDeletedArchives := 0, 0
-
 	// define how many series/archives are getting deleted by peer 0
 	resp := models.CCacheDeleteResp{
 		Peers:           map[string]models.CCacheDeleteResp{"2": {Errors: 1}},
@@ -108,16 +106,15 @@ func TestMetricDeleteWithErrorInPropagation(t *testing.T) {
 	delArchives := 10
 	testKey := "12345"
 
-	// add up how many series/archives are expected to be deleted
-	expectedDeletedSeries += delSeries
-	expectedDeletedArchives += delArchives
-
 	srv, _ := newSrv(delSeries, delArchives, testKey)
 	req, err := json.Marshal(models.CCacheDelete{
 		Patterns:  []string{"test.*"},
 		OrgId:     1,
 		Propagate: true,
 	})
+	if err != nil {
+		t.Fatalf("Unexpected error when marshaling json: %s", err)
+	}
 
 	ts := httptest.NewServer(srv.Macaron)
 	defer ts.Close()
@@ -192,6 +189,9 @@ func TestMetricDeletePropagation(t *testing.T) {
 		OrgId:     1,
 		Propagate: true,
 	})
+	if err != nil {
+		t.Fatalf("Unexpected error when marshaling json: %s", err)
+	}
 
 	ts := httptest.NewServer(srv.Macaron)
 	defer ts.Close()

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -47,7 +47,7 @@ func (s *Server) appStatus(ctx *middleware.Context) {
 func (s *Server) getClusterStatus(ctx *middleware.Context) {
 	status := models.ClusterStatus{
 		ClusterName: cluster.ClusterName,
-		NodeName:    cluster.Manager.ThisNode().Name,
+		NodeName:    cluster.Manager.ThisNode().GetName(),
 		Members:     cluster.Manager.MemberList(),
 	}
 	response.Write(ctx, response.NewJson(200, status, ""))
@@ -58,7 +58,7 @@ func (s *Server) postClusterMembers(ctx *middleware.Context, req models.ClusterM
 	var toJoin []string
 
 	for _, memberNode := range cluster.Manager.MemberList() {
-		memberNames[memberNode.Name] = struct{}{}
+		memberNames[memberNode.GetName()] = struct{}{}
 	}
 
 	for _, peerName := range req.Members {
@@ -231,11 +231,11 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 		wg.Add(1)
 		go func(peer cluster.Node) {
 			defer wg.Done()
-			log.Debug("HTTP Render querying %s%s", peer.Name, path)
+			log.Debug("HTTP Render querying %s%s", peer.GetName(), path)
 			buf, err := peer.Post(reqCtx, name, path, data)
 			if err != nil {
 				cancel()
-				log.Error(4, "HTTP Render error querying %s%s: %q", peer.Name, path, err)
+				log.Error(4, "HTTP Render error querying %s%s: %q", peer.GetName(), path, err)
 			}
 			responses <- struct {
 				data PeerResponse

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -563,7 +563,7 @@ func (s *Server) getSeriesCachedStore(ctx *requestContext, until uint32) ([]chun
 				}
 				// it's important that the itgens get added in chronological order,
 				// currently we rely on cassandra returning results in order
-				s.Cache.Add(key, prevts, itgen)
+				s.Cache.Add(key, ctx.Key, prevts, itgen)
 				prevts = itgen.Ts
 				iters = append(iters, *it)
 			}

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -145,7 +145,7 @@ func (s *Server) getTargets(ctx context.Context, reqs []models.Req) ([]models.Se
 		if req.Node.IsLocal() {
 			localReqs = append(localReqs, req)
 		} else {
-			remoteReqs[req.Node.Name] = append(remoteReqs[req.Node.Name], req)
+			remoteReqs[req.Node.GetName()] = append(remoteReqs[req.Node.GetName()], req)
 		}
 	}
 
@@ -204,7 +204,7 @@ func (s *Server) getTargetsRemote(ctx context.Context, remoteReqs map[string][]m
 	wg := sync.WaitGroup{}
 	wg.Add(len(remoteReqs))
 	for _, nodeReqs := range remoteReqs {
-		log.Debug("DP getTargetsRemote: handling %d reqs from %s", len(nodeReqs), nodeReqs[0].Node.Name)
+		log.Debug("DP getTargetsRemote: handling %d reqs from %s", len(nodeReqs), nodeReqs[0].Node.GetName())
 		go func(reqs []models.Req) {
 			defer wg.Done()
 			node := reqs[0].Node
@@ -218,11 +218,11 @@ func (s *Server) getTargetsRemote(ctx context.Context, remoteReqs map[string][]m
 			_, err = resp.UnmarshalMsg(buf)
 			if err != nil {
 				cancel()
-				log.Error(3, "DP getTargetsRemote: error unmarshaling body from %s/getdata: %q", node.Name, err)
+				log.Error(3, "DP getTargetsRemote: error unmarshaling body from %s/getdata: %q", node.GetName(), err)
 				responses <- getTargetsResp{nil, err}
 				return
 			}
-			log.Debug("DP getTargetsRemote: %s returned %d series", node.Name, len(resp.Series))
+			log.Debug("DP getTargetsRemote: %s returned %d series", node.GetName(), len(resp.Series))
 			responses <- getTargetsResp{resp.Series, nil}
 		}(nodeReqs)
 	}

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -419,7 +419,7 @@ func compareReqEqual(a, b models.Req) bool {
 	if a.Consolidator != b.Consolidator {
 		return false
 	}
-	if a.Node.Name != b.Node.Name {
+	if a.Node.GetName() != b.Node.GetName() {
 		return false
 	}
 	if a.Archive != b.Archive {

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -627,7 +627,7 @@ func TestGetSeriesCachedStore(t *testing.T) {
 				for i := 0; i < len(tc.Pattern); i++ {
 					itgen = chunk.NewBareIterGen(chunks[i].Series.Bytes(), chunks[i].Series.T0, span)
 					if pattern[i] == 'c' || pattern[i] == 'b' {
-						c.Add(metric, prevts, *itgen)
+						c.Add(metric, metric, prevts, *itgen)
 					}
 					if pattern[i] == 's' || pattern[i] == 'b' {
 						cwr := mdata.NewChunkWriteRequest(nil, metric, &chunks[i], 0, span, time.Now())

--- a/api/models/ccache.go
+++ b/api/models/ccache.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+type CCacheDelete struct {
+	Patterns  []string `json:"patterns" form:"patterns" binding:"Required"`
+	OrgId     int      `json:"orgId" form:"orgId" binding:"Required"`
+	Propagate bool     `json:"propagate" form:"propagate"`
+}
+
+func (cd CCacheDelete) Trace(span opentracing.Span) {
+	span.SetTag("patterns", cd.Patterns)
+	span.SetTag("org", cd.OrgId)
+	span.SetTag("propagate", cd.Propagate)
+}
+
+func (cd CCacheDelete) TraceDebug(span opentracing.Span) {
+}
+
+type CCacheDeleteResp struct {
+	Errors          int                         `json:"errors"`
+	FirstError      string                      `json:"firstError"`
+	DeletedSeries   int                         `json:"deletedSeries"`
+	DeletedArchives int                         `json:"deletedArchives"`
+	Peers           map[string]CCacheDeleteResp `json:"peers"`
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -45,6 +45,8 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/tags/autoComplete/tags", ready, bind(models.IndexAutoCompleteTags{})).Get(s.indexAutoCompleteTags).Post(s.indexAutoCompleteTags)
 	r.Combo("/index/tags/autoComplete/values", ready, bind(models.IndexAutoCompleteTagValues{})).Get(s.indexAutoCompleteTagValues).Post(s.indexAutoCompleteTagValues)
 
+	r.Combo("/ccache/delete", bind(models.CCacheDelete{})).Post(s.ccacheDelete).Get(s.ccacheDelete)
+
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)
 	})

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -32,7 +32,7 @@ var (
 )
 
 func Init(name, version string, started time.Time, apiScheme string, apiPort int) {
-	thisNode := Node{
+	thisNode := HTTPNode{
 		Name:          name,
 		ApiPort:       apiPort,
 		ApiScheme:     apiScheme,
@@ -85,32 +85,32 @@ func MembersForQuery() ([]Node, error) {
 	// priority
 	membersMap := make(map[int32]*partitionCandidates)
 	if thisNode.IsReady() {
-		for _, part := range thisNode.Partitions {
+		for _, part := range thisNode.GetPartitions() {
 			membersMap[part] = &partitionCandidates{
-				priority: thisNode.Priority,
+				priority: thisNode.GetPriority(),
 				nodes:    []Node{thisNode},
 			}
 		}
 	}
 
 	for _, member := range Manager.MemberList() {
-		if !member.IsReady() || member.Name == thisNode.Name {
+		if !member.IsReady() || member.GetName() == thisNode.GetName() {
 			continue
 		}
-		for _, part := range member.Partitions {
+		for _, part := range member.GetPartitions() {
 			if _, ok := membersMap[part]; !ok {
 				membersMap[part] = &partitionCandidates{
-					priority: member.Priority,
+					priority: member.GetPriority(),
 					nodes:    []Node{member},
 				}
 				continue
 			}
-			if membersMap[part].priority == member.Priority {
+			if membersMap[part].priority == member.GetPriority() {
 				membersMap[part].nodes = append(membersMap[part].nodes, member)
-			} else if membersMap[part].priority > member.Priority {
+			} else if membersMap[part].priority > member.GetPriority() {
 				// this node has higher priority (lower number) then previously seen candidates
 				membersMap[part] = &partitionCandidates{
-					priority: member.Priority,
+					priority: member.GetPriority(),
 					nodes:    []Node{member},
 				}
 			}
@@ -127,23 +127,23 @@ func MembersForQuery() ([]Node, error) {
 
 LOOP:
 	for _, candidates := range membersMap {
-		if candidates.nodes[0].Name == thisNode.Name {
-			if _, ok := selectedMembers[thisNode.Name]; !ok {
-				selectedMembers[thisNode.Name] = struct{}{}
+		if candidates.nodes[0].GetName() == thisNode.GetName() {
+			if _, ok := selectedMembers[thisNode.GetName()]; !ok {
+				selectedMembers[thisNode.GetName()] = struct{}{}
 				answer = append(answer, thisNode)
 			}
 			continue LOOP
 		}
 
 		for _, n := range candidates.nodes {
-			if _, ok := selectedMembers[n.Name]; ok {
+			if _, ok := selectedMembers[n.GetName()]; ok {
 				continue LOOP
 			}
 		}
 		// if no nodes have been selected yet then grab a
 		// random node from the set of available nodes
 		selected := candidates.nodes[rand.Intn(len(candidates.nodes))]
-		selectedMembers[selected.Name] = struct{}{}
+		selectedMembers[selected.GetName()] = struct{}{}
 		answer = append(answer, selected)
 	}
 

--- a/cluster/if.go
+++ b/cluster/if.go
@@ -1,0 +1,14 @@
+package cluster
+
+import (
+	"context"
+)
+
+type Node interface {
+	IsLocal() bool
+	IsReady() bool
+	GetPartitions() []int32
+	GetPriority() int
+	Post(context.Context, string, string, Traceable) ([]byte, error)
+	GetName() string
+}

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -64,15 +64,15 @@ type ClusterManager interface {
 
 type MemberlistManager struct {
 	sync.RWMutex
-	members  map[string]Node // all members in the cluster, including this node.
+	members  map[string]HTTPNode // all members in the cluster, including this node.
 	nodeName string
 	list     *memberlist.Memberlist
 	cfg      *memberlist.Config
 }
 
-func NewMemberlistManager(thisNode Node) *MemberlistManager {
+func NewMemberlistManager(thisNode HTTPNode) *MemberlistManager {
 	mgr := &MemberlistManager{
-		members: map[string]Node{
+		members: map[string]HTTPNode{
 			thisNode.Name: thisNode,
 		},
 		nodeName: thisNode.Name,
@@ -141,14 +141,22 @@ func (c *MemberlistManager) setList(list *memberlist.Memberlist) {
 }
 
 func (c *MemberlistManager) ThisNode() Node {
+	return c.thisNode()
+}
+
+func (c *MemberlistManager) thisNode() HTTPNode {
 	c.RLock()
 	defer c.RUnlock()
 	return c.members[c.nodeName]
 }
 
 func (c *MemberlistManager) MemberList() []Node {
+	return toIf(c.memberList())
+}
+
+func (c *MemberlistManager) memberList() []HTTPNode {
 	c.RLock()
-	list := make([]Node, len(c.members), len(c.members))
+	list := make([]HTTPNode, len(c.members), len(c.members))
 	i := 0
 	for _, p := range c.members {
 		list[i] = p
@@ -204,8 +212,8 @@ func (c *MemberlistManager) NotifyJoin(node *memberlist.Node) {
 	if len(node.Meta) == 0 {
 		return
 	}
-	log.Info("CLU manager: Node %s with address %s has joined the cluster", node.Name, node.Addr.String())
-	member := Node{}
+	log.Info("CLU manager: HTTPNode %s with address %s has joined the cluster", node.Name, node.Addr.String())
+	member := HTTPNode{}
 	err := json.Unmarshal(node.Meta, &member)
 	if err != nil {
 		log.Error(3, "CLU manager: Failed to decode node meta from %s: %s", node.Name, err.Error())
@@ -224,7 +232,7 @@ func (c *MemberlistManager) NotifyLeave(node *memberlist.Node) {
 	eventsLeave.Inc()
 	c.Lock()
 	defer c.Unlock()
-	log.Info("CLU manager: Node %s has left the cluster", node.Name)
+	log.Info("CLU manager: HTTPNode %s has left the cluster", node.Name)
 	delete(c.members, node.Name)
 	c.clusterStats()
 }
@@ -236,7 +244,7 @@ func (c *MemberlistManager) NotifyUpdate(node *memberlist.Node) {
 	if len(node.Meta) == 0 {
 		return
 	}
-	member := Node{}
+	member := HTTPNode{}
 	err := json.Unmarshal(node.Meta, &member)
 	if err != nil {
 		log.Error(3, "CLU manager: Failed to decode node meta from %s: %s", node.Name, err.Error())
@@ -256,7 +264,7 @@ func (c *MemberlistManager) NotifyUpdate(node *memberlist.Node) {
 		member.local = true
 	}
 	c.members[node.Name] = member
-	log.Info("CLU manager: Node %s at %s has been updated - %s", node.Name, node.Addr.String(), node.Meta)
+	log.Info("CLU manager: HTTPNode %s at %s has been updated - %s", node.Name, node.Addr.String(), node.Meta)
 	c.clusterStats()
 }
 
@@ -270,7 +278,7 @@ func (c *MemberlistManager) BroadcastUpdate() {
 
 // NodeMeta is used to retrieve meta-data about the current node
 // when broadcasting an alive message. It's length is limited to
-// the given byte size. This metadata is available in the Node structure.
+// the given byte size. This metadata is available in the HTTPNode structure.
 func (c *MemberlistManager) NodeMeta(limit int) []byte {
 	c.RLock()
 	meta, err := json.Marshal(c.members[c.nodeName])
@@ -410,10 +418,10 @@ func (c *MemberlistManager) Stop() {
 
 type SingleNodeManager struct {
 	sync.RWMutex
-	node Node
+	node HTTPNode
 }
 
-func NewSingleNodeManager(thisNode Node) *SingleNodeManager {
+func NewSingleNodeManager(thisNode HTTPNode) *SingleNodeManager {
 	return &SingleNodeManager{
 		node: thisNode,
 	}
@@ -463,15 +471,23 @@ func (m *SingleNodeManager) SetState(state NodeState) {
 }
 
 func (m *SingleNodeManager) ThisNode() Node {
+	return m.thisNode()
+}
+
+func (m *SingleNodeManager) thisNode() HTTPNode {
 	m.RLock()
 	defer m.RUnlock()
 	return m.node
 }
 
 func (m *SingleNodeManager) MemberList() []Node {
+	return toIf(m.memberList())
+}
+
+func (m *SingleNodeManager) memberList() []HTTPNode {
 	m.RLock()
 	defer m.RUnlock()
-	return []Node{m.node}
+	return []HTTPNode{m.node}
 }
 
 func (m *SingleNodeManager) Join(peers []string) (int, error) {
@@ -510,4 +526,12 @@ func (m *SingleNodeManager) SetPriority(prio int) {
 
 func (m *SingleNodeManager) Stop() {
 	return
+}
+
+func toIf(in []HTTPNode) []Node {
+	out := make([]Node, len(in))
+	for i, m := range in {
+		out[i] = m
+	}
+	return out
 }

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -471,10 +471,6 @@ func (m *SingleNodeManager) SetState(state NodeState) {
 }
 
 func (m *SingleNodeManager) ThisNode() Node {
-	return m.thisNode()
-}
-
-func (m *SingleNodeManager) thisNode() HTTPNode {
 	m.RLock()
 	defer m.RUnlock()
 	return m.node

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -1,0 +1,106 @@
+package cluster
+
+import (
+	"context"
+	"time"
+)
+
+type MockNode struct {
+	isLocal      bool
+	isReady      bool
+	name         string
+	postResponse []byte
+	partitions   []int32
+	priority     int
+}
+
+func (n *MockNode) IsLocal() bool {
+	return n.isLocal
+}
+
+func (n *MockNode) IsReady() bool {
+	return n.isReady
+}
+
+func (n *MockNode) GetPartitions() []int32 {
+	return n.partitions
+}
+
+func (n *MockNode) GetPriority() int {
+	return n.priority
+}
+
+func (n MockNode) Post(ctx context.Context, name, path string, body Traceable) ([]byte, error) {
+	return n.postResponse, nil
+}
+
+func (n *MockNode) GetName() string {
+	return n.name
+}
+
+func NewMockNode(isLocal bool, name string, postResponse []byte) *MockNode {
+	return &MockNode{
+		isLocal:      isLocal,
+		name:         name,
+		postResponse: postResponse,
+	}
+}
+
+type MockClusterManager struct {
+	Peers           []*MockNode
+	membersForQuery []*MockNode
+	thisNode        int
+	isPrimary       bool
+	isReady         bool
+	partitions      []int32
+}
+
+func (c *MockClusterManager) MemberList() []Node {
+	return mockToIf(c.Peers)
+}
+
+func (c *MockClusterManager) ThisNode() Node {
+	return c.Peers[c.thisNode]
+}
+
+func (c *MockClusterManager) Start()                     {}
+func (c *MockClusterManager) Stop()                      {}
+func (c *MockClusterManager) SetPriority(prio int)       {}
+func (c *MockClusterManager) SetPrimary(primary bool)    {}
+func (c *MockClusterManager) SetReady()                  {}
+func (c *MockClusterManager) SetReadyIn(t time.Duration) {}
+func (c *MockClusterManager) SetState(NodeState)         {}
+
+func (c *MockClusterManager) IsPrimary() bool {
+	return c.isPrimary
+}
+
+func (c *MockClusterManager) IsReady() bool {
+	return c.isReady
+}
+
+func (c *MockClusterManager) GetPartitions() []int32 {
+	return c.partitions
+}
+
+func (c *MockClusterManager) SetPartitions(partitions []int32) {
+	c.partitions = partitions
+}
+
+func (c *MockClusterManager) Join(peers []string) (int, error) {
+	return 0, nil
+}
+
+func InitMock() *MockClusterManager {
+	manager := &MockClusterManager{}
+	Manager = manager
+	return manager
+}
+
+func mockToIf(in []*MockNode) []Node {
+	out := make([]Node, len(in))
+	for i, m := range in {
+		out[i] = m
+	}
+	return out
+}

--- a/mdata/cache/accnt/flat_accnt.go
+++ b/mdata/cache/accnt/flat_accnt.go
@@ -51,6 +51,8 @@ type FlatAccntMet struct {
 // event types to be used in FlatAccntEvent
 const evnt_hit_chnk uint8 = 4
 const evnt_add_chnk uint8 = 5
+const evnt_del_met uint8 = 6
+const evnt_get_total uint8 = 7
 const evnt_stop uint8 = 100
 const evnt_reset uint8 = 101
 
@@ -72,6 +74,16 @@ type HitPayload struct {
 	ts     uint32
 }
 
+// payload to be sent with del metric event
+type DelMetPayload struct {
+	metric string
+}
+
+// payload to be sent with a get total request event
+type GetTotalPayload struct {
+	res_chan chan uint64
+}
+
 func NewFlatAccnt(maxSize uint64) *FlatAccnt {
 	accnt := FlatAccnt{
 		metrics: make(map[string]*FlatAccntMet),
@@ -84,6 +96,16 @@ func NewFlatAccnt(maxSize uint64) *FlatAccnt {
 
 	go accnt.eventLoop()
 	return &accnt
+}
+
+func (a *FlatAccnt) DelMetric(metric string) {
+	a.act(evnt_del_met, &DelMetPayload{metric})
+}
+
+func (a *FlatAccnt) GetTotal() uint64 {
+	res_chan := make(chan uint64)
+	a.act(evnt_get_total, &GetTotalPayload{res_chan})
+	return <-res_chan
 }
 
 func (a *FlatAccnt) AddChunk(metric string, ts uint32, size uint64) {
@@ -139,12 +161,19 @@ func (a *FlatAccnt) eventLoop() {
 						Ts:     payload.ts,
 					},
 				)
+			case evnt_del_met:
+				payload := event.pl.(*DelMetPayload)
+				a.delMet(payload.metric)
+			case evnt_get_total:
+				payload := event.pl.(*GetTotalPayload)
+				a.getTotal(payload.res_chan)
 			case evnt_stop:
 				return
 			case evnt_reset:
 				a.metrics = make(map[string]*FlatAccntMet)
 				a.total = 0
 				a.lru.reset()
+				cacheSizeUsed.SetUint64(a.total)
 			}
 
 			// evict until we're below the max
@@ -153,6 +182,30 @@ func (a *FlatAccnt) eventLoop() {
 			}
 		}
 	}
+}
+
+func (a *FlatAccnt) getTotal(res_chan chan uint64) {
+	res_chan <- a.total
+}
+
+func (a *FlatAccnt) delMet(metric string) {
+	met, ok := a.metrics[metric]
+	if !ok {
+		return
+	}
+
+	for ts := range met.chunks {
+		a.lru.del(
+			EvictTarget{
+				Metric: metric,
+				Ts:     ts,
+			},
+		)
+	}
+
+	a.total = a.total - met.total
+	cacheSizeUsed.SetUint64(a.total)
+	delete(a.metrics, metric)
 }
 
 func (a *FlatAccnt) add(metric string, ts uint32, size uint64) {

--- a/mdata/cache/accnt/flat_accnt_test.go
+++ b/mdata/cache/accnt/flat_accnt_test.go
@@ -117,8 +117,8 @@ func TestMetricDeleting(t *testing.T) {
 	resetCounters()
 	a := NewFlatAccnt(12)
 
-	var metric1 string = "metric1"
-	var metric2 string = "metric2"
+	metric1 := "metric1"
+	metric2 := "metric2"
 
 	a.AddChunk(metric1, 1, 2)
 	a.AddChunk(metric2, 1, 2)
@@ -132,11 +132,11 @@ func TestMetricDeleting(t *testing.T) {
 	total := a.GetTotal()
 	expect_total := uint64(6)
 	if total != expect_total {
-		t.Fatalf("Expected total to be %d, got %d", expect_total, total)
+		t.Fatalf("Expected total %d, got %d", expect_total, total)
 	}
 
 	if cacheSizeUsed.Peek() != expect_total {
-		t.Fatalf("Expected total to be %d, got %d", expect_total, total)
+		t.Fatalf("Expected total %d, got %d", expect_total, total)
 	}
 
 	if _, ok := a.metrics[metric1]; ok {

--- a/mdata/cache/accnt/flat_accnt_test.go
+++ b/mdata/cache/accnt/flat_accnt_test.go
@@ -4,10 +4,15 @@ import (
 	"testing"
 )
 
-func TestAddingEvicting(t *testing.T) {
-	a := NewFlatAccnt(10)
+func resetCounters() {
 	cacheChunkAdd.SetUint32(0)
 	cacheChunkEvict.SetUint32(0)
+	cacheSizeUsed.SetUint64(0)
+}
+
+func TestAddingEvicting(t *testing.T) {
+	resetCounters()
+	a := NewFlatAccnt(10)
 	evictQ := a.GetEvictQ()
 
 	// some test data
@@ -74,9 +79,8 @@ func TestAddingEvicting(t *testing.T) {
 }
 
 func TestLRUOrdering(t *testing.T) {
+	resetCounters()
 	a := NewFlatAccnt(6)
-	cacheChunkAdd.SetUint32(0)
-	cacheChunkEvict.SetUint32(0)
 	evictQ := a.GetEvictQ()
 
 	// some test data
@@ -110,8 +114,8 @@ func TestLRUOrdering(t *testing.T) {
 }
 
 func TestMetricDeleting(t *testing.T) {
+	resetCounters()
 	a := NewFlatAccnt(12)
-	cacheChunkAdd.SetUint32(0)
 
 	var metric1 string = "metric1"
 	var metric2 string = "metric2"

--- a/mdata/cache/accnt/if.go
+++ b/mdata/cache/accnt/if.go
@@ -6,9 +6,9 @@ package accnt
 // in the future if they just implement this interface.
 type Accnt interface {
 	GetEvictQ() chan *EvictTarget
-	AddChunk(string, uint32, uint64)
-	HitChunk(string, uint32)
-	DelMetric(string)
+	AddChunk(metric string, ts uint32, size uint64)
+	HitChunk(metric string, ts uint32)
+	DelMetric(metric string)
 	Stop()
 	Reset()
 }

--- a/mdata/cache/accnt/if.go
+++ b/mdata/cache/accnt/if.go
@@ -8,6 +8,7 @@ type Accnt interface {
 	GetEvictQ() chan *EvictTarget
 	AddChunk(string, uint32, uint64)
 	HitChunk(string, uint32)
+	DelMetric(string)
 	Stop()
 	Reset()
 }

--- a/mdata/cache/accnt/lru.go
+++ b/mdata/cache/accnt/lru.go
@@ -27,8 +27,8 @@ func (l *LRU) touch(key interface{}) {
 func (l *LRU) del(key interface{}) {
 	if ent, ok := l.items[key]; ok {
 		l.list.Remove(ent)
+		delete(l.items, key)
 	}
-	delete(l.items, key)
 }
 
 func (l *LRU) pop() interface{} {

--- a/mdata/cache/accnt/lru.go
+++ b/mdata/cache/accnt/lru.go
@@ -25,6 +25,9 @@ func (l *LRU) touch(key interface{}) {
 }
 
 func (l *LRU) del(key interface{}) {
+	if ent, ok := l.items[key]; ok {
+		l.list.Remove(ent)
+	}
 	delete(l.items, key)
 }
 

--- a/mdata/cache/accnt/lru.go
+++ b/mdata/cache/accnt/lru.go
@@ -24,6 +24,10 @@ func (l *LRU) touch(key interface{}) {
 	}
 }
 
+func (l *LRU) del(key interface{}) {
+	delete(l.items, key)
+}
+
 func (l *LRU) pop() interface{} {
 	ent := l.list.Back()
 	if ent == nil {

--- a/mdata/cache/accnt/lru_test.go
+++ b/mdata/cache/accnt/lru_test.go
@@ -63,3 +63,29 @@ func TestLRUNumeric(t *testing.T) {
 		t.Fatalf("expected nil, got %d", val)
 	}
 }
+
+func TestLRUDelete(t *testing.T) {
+	key1 := 1000
+	key2 := 1001
+
+	lru := NewLRU()
+	lru.touch(key1)
+	lru.touch(key2)
+
+	expectedSize := 2
+	if len(lru.items) != expectedSize || lru.list.Len() != expectedSize {
+		t.Fatalf("Expected lru to contain %d items, but have %d / %d", expectedSize, len(lru.items), lru.list.Len())
+	}
+
+	lru.del(key1)
+	expectedSize = 1
+	if len(lru.items) != expectedSize || lru.list.Len() != expectedSize {
+		t.Fatalf("Expected lru to contain %d items, but have %d / %d", expectedSize, len(lru.items), lru.list.Len())
+	}
+
+	lru.del(key2)
+	expectedSize = 0
+	if len(lru.items) != expectedSize || lru.list.Len() != expectedSize {
+		t.Fatalf("Expected lru to contain %d items, but have %d / %d", expectedSize, len(lru.items), lru.list.Len())
+	}
+}

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -23,13 +23,13 @@ func NewMockCache() *MockCache {
 	return &MockCache{}
 }
 
-func (mc *MockCache) Add(m, r string, t uint32, i chunk.IterGen) {
+func (mc *MockCache) Add(metric, rawMetric string, prev uint32, itergen chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()
 	mc.AddCount++
 }
 
-func (mc *MockCache) CacheIfHot(m string, t uint32, i chunk.IterGen) {
+func (mc *MockCache) CacheIfHot(metric string, prev uint32, itergen chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()
 	mc.CacheIfHotCount++
@@ -44,15 +44,15 @@ func (mc *MockCache) Stop() {
 	mc.StopCount++
 }
 
-func (mc *MockCache) Search(ctx context.Context, m string, f uint32, u uint32) *CCSearchResult {
+func (mc *MockCache) Search(ctx context.Context, metric string, from uint32, until uint32) *CCSearchResult {
 	mc.Lock()
 	defer mc.Unlock()
 	mc.SearchCount++
 	return nil
 }
 
-func (mc *MockCache) DelMetric(key string) (int, int) {
-	mc.DelMetricKeys = append(mc.DelMetricKeys, key)
+func (mc *MockCache) DelMetric(rawMetric string) (int, int) {
+	mc.DelMetricKeys = append(mc.DelMetricKeys, rawMetric)
 	return mc.DelMetricSeries, mc.DelMetricArchives
 }
 

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -9,13 +9,14 @@ import (
 
 type MockCache struct {
 	sync.Mutex
-	AddCount        int
-	CacheIfHotCount int
-	CacheIfHotCb    func()
-	StopCount       int
-	SearchCount     int
-	DelMetricRes    CCDelMetricResult
-	DelMetricKeys   []string
+	AddCount          int
+	CacheIfHotCount   int
+	CacheIfHotCb      func()
+	StopCount         int
+	SearchCount       int
+	DelMetricArchives int
+	DelMetricSeries   int
+	DelMetricKeys     []string
 }
 
 func NewMockCache() *MockCache {
@@ -52,11 +53,11 @@ func (mc *MockCache) Search(ctx context.Context, m string, f uint32, u uint32) *
 	return nil
 }
 
-func (mc *MockCache) DelMetric(key string) *CCDelMetricResult {
+func (mc *MockCache) DelMetric(key string) (int, int) {
 	mc.DelMetricKeys = append(mc.DelMetricKeys, key)
-	return &mc.DelMetricRes
+	return mc.DelMetricSeries, mc.DelMetricArchives
 }
 
-func (mc *MockCache) Reset() *CCDelMetricResult {
-	return &CCDelMetricResult{}
+func (mc *MockCache) Reset() (int, int) {
+	return mc.DelMetricSeries, mc.DelMetricArchives
 }

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/grafana/metrictank/mdata/chunk"
-	"sync"
 )
 
 type MockCache struct {
@@ -15,6 +14,14 @@ type MockCache struct {
 	CacheIfHotCb    func()
 	StopCount       int
 	SearchCount     int
+	DelMetricRes    CCDelMetricResult
+	DelMetricKeys   []string
+}
+
+func NewMockCache() *MockCache {
+	return &MockCache{
+		DelMetricKeys: make([]string, 0),
+	}
 }
 
 func (mc *MockCache) Add(m, r string, t uint32, i chunk.IterGen) {
@@ -38,9 +45,18 @@ func (mc *MockCache) Stop() {
 	mc.StopCount++
 }
 
-func (mc *MockCache) Search(m string, f uint32, u uint32) *CCSearchResult {
+func (mc *MockCache) Search(ctx context.Context, m string, f uint32, u uint32) *CCSearchResult {
 	mc.Lock()
 	defer mc.Unlock()
 	mc.SearchCount++
 	return nil
+}
+
+func (mc *MockCache) DelMetric(key string) *CCDelMetricResult {
+	mc.DelMetricKeys = append(mc.DelMetricKeys, key)
+	return &mc.DelMetricRes
+}
+
+func (mc *MockCache) Reset() *CCDelMetricResult {
+	return &CCDelMetricResult{}
 }

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -1,6 +1,9 @@
 package cache
 
 import (
+	"context"
+	"sync"
+
 	"github.com/grafana/metrictank/mdata/chunk"
 	"sync"
 )
@@ -14,7 +17,7 @@ type MockCache struct {
 	SearchCount     int
 }
 
-func (mc *MockCache) Add(m string, t uint32, i chunk.IterGen) {
+func (mc *MockCache) Add(m, r string, t uint32, i chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()
 	mc.AddCount++

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -20,9 +20,7 @@ type MockCache struct {
 }
 
 func NewMockCache() *MockCache {
-	return &MockCache{
-		DelMetricKeys: make([]string, 0),
-	}
+	return &MockCache{}
 }
 
 func (mc *MockCache) Add(m, r string, t uint32, i chunk.IterGen) {

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -132,7 +132,7 @@ func (c *CCache) Add(metric, rawMetric string, prev uint32, itergen chunk.IterGe
 	ccm, ok := c.metricCache[metric]
 	if !ok {
 		ccm = NewCCacheMetric()
-		ccm.Init(rawMetric, prev, itergen)
+		ccm.Init(uint8(len(metric)-len(rawMetric)), prev, itergen)
 		c.metricCache[metric] = ccm
 
 		// if we do not have this raw key yet, create the entry with the association
@@ -187,9 +187,10 @@ func (c *CCache) evict(target *accnt.EvictTarget) {
 		delete(c.metricCache, target.Metric)
 
 		// this key should alway be present, if not there there is a corruption of the state
-		delete(c.metricRawKeys[ccm.RawMetric], target.Metric)
-		if len(c.metricRawKeys[ccm.RawMetric]) == 0 {
-			delete(c.metricRawKeys, ccm.RawMetric)
+		rawMetric := target.Metric[:len(target.Metric)-int(ccm.SuffixLen)]
+		delete(c.metricRawKeys[rawMetric], target.Metric)
+		if len(c.metricRawKeys[rawMetric]) == 0 {
+			delete(c.metricRawKeys, rawMetric)
 		}
 	}
 }

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -135,15 +135,14 @@ func (c *CCache) Add(metric, rawMetric string, prev uint32, itergen chunk.IterGe
 		ccm.Init(rawMetric, prev, itergen)
 		c.metricCache[metric] = ccm
 
-		// if we do not have this raw key yet, create an entry for it
+		// if we do not have this raw key yet, create the entry with the association
 		ccms, ok := c.metricRawKeys[rawMetric]
 		if !ok {
-			ccms = make(map[string]struct{})
-			c.metricRawKeys[rawMetric] = ccms
-		}
-
-		// if we don't have it yet, associate the metric with this raw key
-		if _, ok = ccms[metric]; !ok {
+			c.metricRawKeys[rawMetric] = map[string]struct{}{
+				metric: {},
+			}
+		} else {
+			// otherwise, make sure the association exists
 			ccms[metric] = struct{}{}
 		}
 	} else {

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -19,6 +19,8 @@ type CCacheMetric struct {
 
 	// the list of chunk time stamps in ascending order
 	keys []uint32
+
+	RawMetric string
 }
 
 func NewCCacheMetric() *CCacheMetric {
@@ -27,7 +29,8 @@ func NewCCacheMetric() *CCacheMetric {
 	}
 }
 
-func (mc *CCacheMetric) Init(prev uint32, itergen chunk.IterGen) {
+func (mc *CCacheMetric) Init(rawMetric string, prev uint32, itergen chunk.IterGen) {
+	mc.RawMetric = rawMetric
 	mc.Add(prev, itergen)
 }
 
@@ -42,11 +45,16 @@ func (mc *CCacheMetric) Del(ts uint32) int {
 	prev := mc.chunks[ts].Prev
 	next := mc.chunks[ts].Next
 
-	if _, ok := mc.chunks[prev]; prev != 0 && ok {
-		mc.chunks[prev].Next = 0
+	if prev != 0 {
+		if _, ok := mc.chunks[prev]; ok {
+			mc.chunks[prev].Next = 0
+		}
 	}
-	if _, ok := mc.chunks[next]; next != 0 && ok {
-		mc.chunks[next].Prev = 0
+
+	if next != 0 {
+		if _, ok := mc.chunks[next]; ok {
+			mc.chunks[next].Prev = 0
+		}
 	}
 
 	delete(mc.chunks, ts)

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -20,7 +20,7 @@ type CCacheMetric struct {
 	// the list of chunk time stamps in ascending order
 	keys []uint32
 
-	RawMetric string
+	SuffixLen uint8
 }
 
 func NewCCacheMetric() *CCacheMetric {
@@ -29,8 +29,8 @@ func NewCCacheMetric() *CCacheMetric {
 	}
 }
 
-func (mc *CCacheMetric) Init(rawMetric string, prev uint32, itergen chunk.IterGen) {
-	mc.RawMetric = rawMetric
+func (mc *CCacheMetric) Init(suffixLen uint8, prev uint32, itergen chunk.IterGen) {
+	mc.SuffixLen = suffixLen
 	mc.Add(prev, itergen)
 }
 

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -562,12 +562,12 @@ func testMetricDelete(t *testing.T, cc *CCache) {
 	delSeries, delArchives := cc.DelMetric(rawMetric1)
 	expectDelSeries := 1
 	if delSeries != expectDelSeries {
-		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delSeries)
+		t.Fatalf("Expected exactly %d deleted series, but got %d", expectDelSeries, delSeries)
 	}
 
 	expectDelArchives := 2
 	if delArchives != expectDelArchives {
-		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delArchives)
+		t.Fatalf("Expected exactly %d deleted archives, but got %d", expectDelArchives, delArchives)
 	}
 
 	// check if metric1_1 returns no results anymore
@@ -576,7 +576,7 @@ func testMetricDelete(t *testing.T, cc *CCache) {
 		t.Fatalf("Expected to have %d values, got %d", 0, len(res.Start))
 	}
 
-	// check if metric1_1 returns no results anymore
+	// check if metric1_2 returns no results anymore
 	res = cc.Search(test.NewContext(), metric1_2, 1000, uint32(1000+itgenCount*len(values)))
 	if len(res.Start) != 0 {
 		t.Fatalf("Expected to have %d values, got %d", 0, len(res.Start))
@@ -604,12 +604,12 @@ func testMetricDelete(t *testing.T, cc *CCache) {
 	delSeries, delArchives = cc.Reset()
 	expectDelSeries = 2
 	if delSeries != expectDelSeries {
-		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delSeries)
+		t.Fatalf("Expected exactly deleted %d series, but got %d", expectDelSeries, delSeries)
 	}
 
 	expectDelArchives = 3
 	if delArchives != expectDelArchives {
-		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delArchives)
+		t.Fatalf("Expected exactly deleted %d archives, but got %d", expectDelArchives, delArchives)
 	}
 
 	// check if metric1_1 returns no results anymore

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/metrictank/test"
 )
 
+// getItgen returns an IterGen which holds a chunk which has directly encoded all values
 func getItgen(t *testing.T, values []uint32, ts uint32, spanaware bool) chunk.IterGen {
 	var b []byte
 	buf := new(bytes.Buffer)

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -611,4 +611,23 @@ func testMetricDelete(t *testing.T, cc *CCache) {
 	if delArchives != expectDelArchives {
 		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delArchives)
 	}
+
+	// check if metric1_1 returns no results anymore
+	res = cc.Search(test.NewContext(), metric1_1, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != 0 {
+		t.Fatalf("Expected to have %d values, got %d", 0, len(res.Start))
+	}
+
+	// check if metric1_1 returns no results anymore
+	res = cc.Search(test.NewContext(), metric1_2, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != 0 {
+		t.Fatalf("Expected to have %d values, got %d", 0, len(res.Start))
+	}
+
+	// check if metric2_1 returns no results anymore
+	res = cc.Search(test.NewContext(), metric2_1, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != 0 {
+		t.Fatalf("Expected to have %d values, got %d", 0, len(res.Start))
+	}
+
 }

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -503,7 +503,21 @@ func testSearchDisconnectedWithGapStartEnd(t *testing.T, spanaware, ascending bo
 	}
 }
 
+func TestReset(t *testing.T) {
+	cc := NewCCache()
+
+	// .Reset() is being called at the end of testMetricDelete()
+	testMetricDelete(t, cc)
+	testMetricDelete(t, cc)
+	testMetricDelete(t, cc)
+}
+
 func TestMetricDelete(t *testing.T) {
+	cc := NewCCache()
+	testMetricDelete(t, cc)
+}
+
+func testMetricDelete(t *testing.T, cc *CCache) {
 	var res *CCSearchResult
 
 	rawMetric1 := "some.tree.metric1"
@@ -511,7 +525,6 @@ func TestMetricDelete(t *testing.T) {
 	metric1_2 := "some.tree.metric1_600_sum"
 	rawMetric2 := "some.tree.metric2"
 	metric2_1 := "some.tree.metric2_6000_cnt"
-	cc := NewCCache()
 	values := []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	itgenCount := 10
 	itgens := make([]chunk.IterGen, 0, itgenCount)

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -545,15 +545,15 @@ func TestMetricDelete(t *testing.T) {
 	}
 
 	// now delete metric1_1, but leave metric2_1
-	delRes := cc.DelMetric(rawMetric1)
+	delSeries, delArchives := cc.DelMetric(rawMetric1)
 	expectDelSeries := 1
-	if delRes.Series != expectDelSeries {
-		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delRes.Series)
+	if delSeries != expectDelSeries {
+		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delSeries)
 	}
 
 	expectDelArchives := 2
-	if delRes.Archives != expectDelArchives {
-		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delRes.Archives)
+	if delArchives != expectDelArchives {
+		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delArchives)
 	}
 
 	// check if metric1_1 returns no results anymore
@@ -587,14 +587,14 @@ func TestMetricDelete(t *testing.T) {
 	}
 
 	// now reset the whole metric cache
-	delRes = cc.Reset()
+	delSeries, delArchives = cc.Reset()
 	expectDelSeries = 2
-	if delRes.Series != expectDelSeries {
-		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delRes.Series)
+	if delSeries != expectDelSeries {
+		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delSeries)
 	}
 
 	expectDelArchives = 3
-	if delRes.Archives != expectDelArchives {
-		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delRes.Archives)
+	if delArchives != expectDelArchives {
+		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delArchives)
 	}
 }

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -42,11 +42,11 @@ func getConnectedChunks(t *testing.T, metric string) *CCache {
 	itgen4 := getItgen(t, values, 1015, false)
 	itgen5 := getItgen(t, values, 1020, false)
 
-	cc.Add(metric, 0, itgen1)
-	cc.Add(metric, 1000, itgen2)
-	cc.Add(metric, 1005, itgen3)
-	cc.Add(metric, 1010, itgen4)
-	cc.Add(metric, 1015, itgen5)
+	cc.Add(metric, metric, 0, itgen1)
+	cc.Add(metric, metric, 1000, itgen2)
+	cc.Add(metric, metric, 1005, itgen3)
+	cc.Add(metric, metric, 1010, itgen4)
+	cc.Add(metric, metric, 1015, itgen5)
 
 	return cc
 }
@@ -61,8 +61,8 @@ func TestAddIfHotWithoutPrevTsOnHotMetric(t *testing.T) {
 	itgen2 := getItgen(t, values, 1005, false)
 	itgen3 := getItgen(t, values, 1010, false)
 
-	cc.Add(metric, 0, itgen1)
-	cc.Add(metric, 1000, itgen2)
+	cc.Add(metric, metric, 0, itgen1)
+	cc.Add(metric, metric, 1000, itgen2)
 
 	cc.CacheIfHot(metric, 0, itgen3)
 
@@ -95,7 +95,7 @@ func TestAddIfHotWithoutPrevTsOnColdMetric(t *testing.T) {
 	itgen1 := getItgen(t, values, 1000, false)
 	itgen3 := getItgen(t, values, 1010, false)
 
-	cc.Add(metric, 0, itgen1)
+	cc.Add(metric, metric, 0, itgen1)
 
 	cc.CacheIfHot(metric, 0, itgen3)
 
@@ -121,8 +121,8 @@ func TestAddIfHotWithPrevTsOnHotMetric(t *testing.T) {
 	itgen2 := getItgen(t, values, 1005, false)
 	itgen3 := getItgen(t, values, 1010, false)
 
-	cc.Add(metric, 0, itgen1)
-	cc.Add(metric, 1000, itgen2)
+	cc.Add(metric, metric, 0, itgen1)
+	cc.Add(metric, metric, 1000, itgen2)
 
 	cc.CacheIfHot(metric, 1005, itgen3)
 
@@ -155,7 +155,7 @@ func TestAddIfHotWithPrevTsOnColdMetric(t *testing.T) {
 	itgen1 := getItgen(t, values, 1000, false)
 	itgen3 := getItgen(t, values, 1010, false)
 
-	cc.Add(metric, 0, itgen1)
+	cc.Add(metric, metric, 0, itgen1)
 
 	cc.CacheIfHot(metric, 1005, itgen3)
 
@@ -179,8 +179,8 @@ func TestConsecutiveAdding(t *testing.T) {
 	itgen1 := getItgen(t, values, 1000, false)
 	itgen2 := getItgen(t, values, 1005, false)
 
-	cc.Add(metric, 0, itgen1)
-	cc.Add(metric, 1000, itgen2)
+	cc.Add(metric, metric, 0, itgen1)
+	cc.Add(metric, metric, 1000, itgen2)
 
 	mc := cc.metricCache[metric]
 	chunk1, ok := mc.chunks[1000]
@@ -216,9 +216,9 @@ func TestDisconnectedAdding(t *testing.T) {
 	itgen2 := getItgen(t, values, 1005, true)
 	itgen3 := getItgen(t, values, 1010, true)
 
-	cc.Add(metric, 0, itgen1)
-	cc.Add(metric, 0, itgen2)
-	cc.Add(metric, 0, itgen3)
+	cc.Add(metric, metric, 0, itgen1)
+	cc.Add(metric, metric, 0, itgen2)
+	cc.Add(metric, metric, 0, itgen3)
 
 	res := cc.Search(test.NewContext(), metric, 900, 1015)
 
@@ -250,9 +250,9 @@ func TestDisconnectedAddingByGuessing(t *testing.T) {
 	itgen2 := getItgen(t, values, 1005, false)
 	itgen3 := getItgen(t, values, 1010, false)
 
-	cc.Add(metric, 0, itgen1)
-	cc.Add(metric, 1000, itgen2)
-	cc.Add(metric, 0, itgen3)
+	cc.Add(metric, metric, 0, itgen1)
+	cc.Add(metric, metric, 1000, itgen2)
+	cc.Add(metric, metric, 0, itgen3)
 
 	res := cc.Search(test.NewContext(), metric, 900, 1015)
 
@@ -380,19 +380,19 @@ func testSearchDisconnectedStartEnd(t *testing.T, spanaware, ascending bool) {
 			cc.Reset()
 
 			if ascending {
-				cc.Add(metric, 0, itgen1)
-				cc.Add(metric, 1000, itgen2)
-				cc.Add(metric, 1010, itgen3)
-				cc.Add(metric, 0, itgen4)
-				cc.Add(metric, 1030, itgen5)
-				cc.Add(metric, 1040, itgen6)
+				cc.Add(metric, metric, 0, itgen1)
+				cc.Add(metric, metric, 1000, itgen2)
+				cc.Add(metric, metric, 1010, itgen3)
+				cc.Add(metric, metric, 0, itgen4)
+				cc.Add(metric, metric, 1030, itgen5)
+				cc.Add(metric, metric, 1040, itgen6)
 			} else {
-				cc.Add(metric, 0, itgen6)
-				cc.Add(metric, 0, itgen5)
-				cc.Add(metric, 0, itgen4)
-				cc.Add(metric, 0, itgen3)
-				cc.Add(metric, 0, itgen2)
-				cc.Add(metric, 0, itgen1)
+				cc.Add(metric, metric, 0, itgen6)
+				cc.Add(metric, metric, 0, itgen5)
+				cc.Add(metric, metric, 0, itgen4)
+				cc.Add(metric, metric, 0, itgen3)
+				cc.Add(metric, metric, 0, itgen2)
+				cc.Add(metric, metric, 0, itgen1)
 			}
 
 			res = cc.Search(test.NewContext(), metric, from, until)
@@ -456,19 +456,19 @@ func testSearchDisconnectedWithGapStartEnd(t *testing.T, spanaware, ascending bo
 			cc.Reset()
 
 			if ascending {
-				cc.Add(metric, 0, itgen1)
-				cc.Add(metric, 1000, itgen2)
-				cc.Add(metric, 1010, itgen3)
-				cc.Add(metric, 0, itgen4)
-				cc.Add(metric, 1040, itgen5)
-				cc.Add(metric, 1050, itgen6)
+				cc.Add(metric, metric, 0, itgen1)
+				cc.Add(metric, metric, 1000, itgen2)
+				cc.Add(metric, metric, 1010, itgen3)
+				cc.Add(metric, metric, 0, itgen4)
+				cc.Add(metric, metric, 1040, itgen5)
+				cc.Add(metric, metric, 1050, itgen6)
 			} else {
-				cc.Add(metric, 0, itgen6)
-				cc.Add(metric, 0, itgen5)
-				cc.Add(metric, 0, itgen4)
-				cc.Add(metric, 0, itgen3)
-				cc.Add(metric, 0, itgen2)
-				cc.Add(metric, 0, itgen1)
+				cc.Add(metric, metric, 0, itgen6)
+				cc.Add(metric, metric, 0, itgen5)
+				cc.Add(metric, metric, 0, itgen4)
+				cc.Add(metric, metric, 0, itgen3)
+				cc.Add(metric, metric, 0, itgen2)
+				cc.Add(metric, metric, 0, itgen1)
 			}
 
 			res = cc.Search(test.NewContext(), metric, from, until)
@@ -500,5 +500,101 @@ func testSearchDisconnectedWithGapStartEnd(t *testing.T, spanaware, ascending bo
 				t.Fatalf("from %d, until %d: expected Until to be %d but got %d", from, until, 1030, res.Until)
 			}
 		}
+	}
+}
+
+func TestMetricDelete(t *testing.T) {
+	var res *CCSearchResult
+
+	rawMetric1 := "some.tree.metric1"
+	metric1_1 := "some.tree.metric1_600_cnt"
+	metric1_2 := "some.tree.metric1_600_sum"
+	rawMetric2 := "some.tree.metric2"
+	metric2_1 := "some.tree.metric2_6000_cnt"
+	cc := NewCCache()
+	values := []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	itgenCount := 10
+	itgens := make([]chunk.IterGen, 0, itgenCount)
+	for i := 1000; i < 1000+itgenCount*len(values); i = i + len(values) {
+		itgens = append(itgens, getItgen(t, values, uint32(i), true))
+	}
+
+	// add two metrics with itgenCount chunks each
+	for _, itgen := range itgens {
+		cc.Add(metric1_1, rawMetric1, 0, itgen)
+		cc.Add(metric1_2, rawMetric1, 0, itgen)
+		cc.Add(metric2_1, rawMetric2, 0, itgen)
+	}
+
+	// check if Search returns them all for metric1_1
+	res = cc.Search(test.NewContext(), metric1_1, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != itgenCount {
+		t.Fatalf("Expected to have %d values, got %d", itgenCount, len(res.Start))
+	}
+
+	// check if Search returns them all for metric1_2
+	res = cc.Search(test.NewContext(), metric1_2, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != itgenCount {
+		t.Fatalf("Expected to have %d values, got %d", itgenCount, len(res.Start))
+	}
+
+	// check if Search returns them all for metric2_1
+	res = cc.Search(test.NewContext(), metric2_1, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != itgenCount {
+		t.Fatalf("Expected to have %d values, got %d", itgenCount, len(res.Start))
+	}
+
+	// now delete metric1_1, but leave metric2_1
+	delRes := cc.DelMetric(rawMetric1)
+	expectDelSeries := 1
+	if delRes.Series != expectDelSeries {
+		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delRes.Series)
+	}
+
+	expectDelArchives := 2
+	if delRes.Archives != expectDelArchives {
+		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delRes.Archives)
+	}
+
+	// check if metric1_1 returns no results anymore
+	res = cc.Search(test.NewContext(), metric1_1, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != 0 {
+		t.Fatalf("Expected to have %d values, got %d", 0, len(res.Start))
+	}
+
+	// check if metric1_1 returns no results anymore
+	res = cc.Search(test.NewContext(), metric1_2, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != 0 {
+		t.Fatalf("Expected to have %d values, got %d", 0, len(res.Start))
+	}
+
+	// but metric2_1 should still be there
+	res = cc.Search(test.NewContext(), metric2_1, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != itgenCount {
+		t.Fatalf("Expected to have %d values, got %d", itgenCount, len(res.Start))
+	}
+
+	// now add metric1_1 and metric1_2 again
+	for _, itgen := range itgens {
+		cc.Add(metric1_1, rawMetric1, 0, itgen)
+		cc.Add(metric1_2, rawMetric1, 0, itgen)
+	}
+
+	// and check if it gets returned by Search again
+	res = cc.Search(test.NewContext(), metric1_1, 1000, uint32(1000+itgenCount*len(values)))
+	if len(res.Start) != itgenCount {
+		t.Fatalf("Expected to have %d values, got %d", itgenCount, len(res.Start))
+	}
+
+	// now reset the whole metric cache
+	delRes = cc.Reset()
+	expectDelSeries = 2
+	if delRes.Series != expectDelSeries {
+		t.Fatalf("Expected exactly %d series to get deleted, but got %d", expectDelSeries, delRes.Series)
+	}
+
+	expectDelArchives = 3
+	if delRes.Archives != expectDelArchives {
+		t.Fatalf("Expected exactly %d archives to get deleted, but got %d", expectDelArchives, delRes.Archives)
 	}
 }

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -11,17 +11,12 @@ type Cache interface {
 	CacheIfHot(metric string, prev uint32, itergen chunk.IterGen)
 	Stop()
 	Search(ctx context.Context, metric string, from, until uint32) *CCSearchResult
-	DelMetric(rawMetric string) *CCDelMetricResult
-	Reset() *CCDelMetricResult
+	DelMetric(rawMetric string) (int, int)
+	Reset() (int, int)
 }
 
 type CachePusher interface {
 	CacheIfHot(metric string, prev uint32, itergen chunk.IterGen)
-}
-
-type CCDelMetricResult struct {
-	Series   int
-	Archives int
 }
 
 type CCSearchResult struct {

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -7,14 +7,21 @@ import (
 )
 
 type Cache interface {
-	Add(string, uint32, chunk.IterGen)
+	Add(string, string, uint32, chunk.IterGen)
 	CacheIfHot(string, uint32, chunk.IterGen)
 	Stop()
 	Search(context.Context, string, uint32, uint32) *CCSearchResult
+	DelMetric(string) *CCDelMetricResult
+	Reset() *CCDelMetricResult
 }
 
 type CachePusher interface {
 	CacheIfHot(string, uint32, chunk.IterGen)
+}
+
+type CCDelMetricResult struct {
+	Series   int
+	Archives int
 }
 
 type CCSearchResult struct {

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -7,16 +7,16 @@ import (
 )
 
 type Cache interface {
-	Add(string, string, uint32, chunk.IterGen)
-	CacheIfHot(string, uint32, chunk.IterGen)
+	Add(metric, rawMetric string, prev uint32, itergen chunk.IterGen)
+	CacheIfHot(metric string, prev uint32, itergen chunk.IterGen)
 	Stop()
-	Search(context.Context, string, uint32, uint32) *CCSearchResult
-	DelMetric(string) *CCDelMetricResult
+	Search(ctx context.Context, metric string, from, until uint32) *CCSearchResult
+	DelMetric(rawMetric string) *CCDelMetricResult
 	Reset() *CCDelMetricResult
 }
 
 type CachePusher interface {
-	CacheIfHot(string, uint32, chunk.IterGen)
+	CacheIfHot(metric string, prev uint32, itergen chunk.IterGen)
 }
 
 type CCDelMetricResult struct {

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -54,3 +54,7 @@ func (g *Gauge64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	buf = WriteUint64(buf, prefix, []byte("gauge64"), val, now)
 	return buf
 }
+
+func (c *Gauge64) Peek() uint64 {
+	return atomic.LoadUint64(&c.val)
+}


### PR DESCRIPTION
Adds an API endpoint to clear the cache by metric name, including all the chunks of associated aggregations.

https://github.com/raintank/metrictank/issues/547