### PR TITLE
use Context's properly to stop executing when a request is canceled

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -158,7 +158,8 @@ func (s *Server) indexList(ctx *middleware.Context, req models.IndexList) {
 }
 
 func (s *Server) getData(ctx *middleware.Context, request models.GetData) {
-	series, err := s.getTargetsLocal(ctx.Req.Context(), request.Requests)
+	reqCtx, cancel := context.WithCancel(ctx.Req.Context())
+	series, err := s.getTargetsLocal(reqCtx, cancel, request.Requests)
 	if err != nil {
 		// the only errors returned are from us catching panics, so we should treat them
 		// all as internalServerErrors

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -158,8 +157,7 @@ func (s *Server) indexList(ctx *middleware.Context, req models.IndexList) {
 }
 
 func (s *Server) getData(ctx *middleware.Context, request models.GetData) {
-	reqCtx, cancel := context.WithCancel(ctx.Req.Context())
-	series, err := s.getTargetsLocal(reqCtx, cancel, request.Requests)
+	series, err := s.getTargetsLocal(ctx.Req.Context(), request.Requests)
 	if err != nil {
 		// the only errors returned are from us catching panics, so we should treat them
 		// all as internalServerErrors

--- a/api/config.go
+++ b/api/config.go
@@ -27,6 +27,8 @@ var (
 	fallbackGraphite string
 	timeZoneStr      string
 
+	getTargetsConcurrency int
+
 	graphiteProxy *httputil.ReverseProxy
 	timeZone      *time.Location
 )
@@ -45,6 +47,7 @@ func ConfigSetup() {
 	apiCfg.BoolVar(&multiTenant, "multi-tenant", true, "require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed")
 	apiCfg.StringVar(&fallbackGraphite, "fallback-graphite-addr", "http://localhost:8080", "in case our /render endpoint does not support the requested processing, proxy the request to this graphite")
 	apiCfg.StringVar(&timeZoneStr, "time-zone", "local", "timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone")
+	apiCfg.IntVar(&getTargetsConcurrency, "get-targets-concurrency", 20, "maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.")
 	globalconf.Register("http", apiCfg)
 }
 

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -301,7 +301,7 @@ LOOP:
 }
 
 func (s *Server) getTarget(ctx context.Context, req models.Req) (points []schema.Point, interval uint32, err error) {
-	doRecover(&err)
+	defer doRecover(&err)
 	readRollup := req.Archive != 0 // do we need to read from a downsampled series?
 	normalize := req.AggNum > 1    // do we need to normalize points at runtime?
 	// normalize is runtime consolidation but only for the purpose of bringing high-res

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -368,7 +368,10 @@ func TestGetSeriesFixed(t *testing.T) {
 				metric.Add(40+offset, 50) // this point will always be quantized to 50
 				req := models.NewReq(name, name, name, from, to, 1000, 10, consolidation.Avg, 0, cluster.Manager.ThisNode(), 0, 0)
 				req.ArchInterval = 10
-				points := srv.getSeriesFixed(test.NewContext(), req, consolidation.None)
+				points, err := srv.getSeriesFixed(test.NewContext(), req, consolidation.None)
+				if err != nil {
+					t.Errorf("case %q - error: %s", name, err)
+				}
 				if !reflect.DeepEqual(expected, points) {
 					t.Errorf("case %q - exp: %v - got %v", name, expected, points)
 				}
@@ -637,7 +640,10 @@ func TestGetSeriesCachedStore(t *testing.T) {
 				req := reqRaw(metric, from, to, span, 1, consolidation.None, 0, 0)
 				req.ArchInterval = 1
 				ctx := newRequestContext(test.NewContext(), &req, consolidation.None)
-				iters := srv.getSeriesCachedStore(ctx, to)
+				iters, err := srv.getSeriesCachedStore(ctx, to)
+				if err != nil {
+					t.Fatalf("Pattern %s From %d To %d: error %s", pattern, from, to, err)
+				}
 
 				// expecting the first returned timestamp to be the T0 of the chunk containing "from"
 				expectResFrom := from - (from % span)

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -119,6 +119,12 @@ func (s *Server) findSeries(ctx context.Context, orgId int, patterns []string, s
 func (s *Server) findSeriesLocal(ctx context.Context, orgId int, patterns []string, seenAfter int64) ([]Series, error) {
 	result := make([]Series, 0)
 	for _, pattern := range patterns {
+		select {
+		case <-ctx.Done():
+			//request canceled
+			return nil, nil
+		default:
+		}
 		_, span := tracing.NewSpan(ctx, s.Tracer, "findSeriesLocal")
 		span.SetTag("org", orgId)
 		span.SetTag("pattern", pattern)

--- a/api/response/error.go
+++ b/api/response/error.go
@@ -51,3 +51,5 @@ func (r *ErrorResp) Headers() (headers map[string]string) {
 	headers = map[string]string{"content-type": "text/plain"}
 	return headers
 }
+
+var RequestCanceledErr = NewError(499, "request canceled")

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -23,7 +23,8 @@ var (
 	httpTimeout        time.Duration
 	minAvailableShards int
 
-	client http.Client
+	client    http.Client
+	transport *http.Transport
 )
 
 func ConfigSetup() {
@@ -57,17 +58,17 @@ func ConfigProcess() {
 	clusterPort = addr.Port
 
 	Mode = ModeType(mode)
-
+	transport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   time.Second * 5,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: time.Second,
+	}
 	client = http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			Proxy:           http.ProxyFromEnvironment,
-			Dial: (&net.Dialer{
-				Timeout:   time.Second * 5,
-				KeepAlive: 30 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout: time.Second,
-		},
-		Timeout: httpTimeout,
+		Transport: transport,
+		Timeout:   httpTimeout,
 	}
 }

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -152,17 +152,45 @@ func (n Node) Post(ctx context.Context, name, path string, body Traceable) (ret 
 		log.Error(3, "CLU failed to inject span into headers: %s", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
-	rsp, err := client.Do(req)
-	if err != nil {
-		log.Error(3, "CLU Node: %s unreachable. %s", n.Name, err.Error())
-		return nil, NewError(http.StatusServiceUnavailable, fmt.Errorf("cluster node unavailable"))
+
+	c := make(chan struct {
+		r   *http.Response
+		err error
+	}, 1)
+
+	go func() {
+		rsp, err := client.Do(req)
+		c <- struct {
+			r   *http.Response
+			err error
+		}{rsp, err}
+	}()
+
+	// wait for either our results from the http request or if out context has been canceled
+	// then abort the http request.
+	select {
+	case <-ctx.Done():
+		log.Debug("CLU Node: context canceled. terminating request to peer %s", n.Name)
+		transport.CancelRequest(req)
+		<-c // Wait for client.Do but ignore result
+	case resp := <-c:
+		err := resp.err
+		rsp := resp.r
+		if err != nil {
+			tags.Error.Set(span, true)
+			log.Error(3, "CLU Node: %s unreachable. %s", n.Name, err.Error())
+			return nil, NewError(http.StatusServiceUnavailable, fmt.Errorf("cluster node unavailable"))
+		}
+		return handleResp(rsp)
 	}
-	return handleResp(rsp)
+
+	return nil, nil
 }
 
 func handleResp(rsp *http.Response) ([]byte, error) {
 	defer rsp.Body.Close()
 	if rsp.StatusCode != 200 {
+		ioutil.ReadAll(rsp.Body)
 		return nil, NewError(rsp.StatusCode, fmt.Errorf(rsp.Status))
 	}
 	return ioutil.ReadAll(rsp.Body)

--- a/consolidation/consolidate.go
+++ b/consolidation/consolidate.go
@@ -1,8 +1,21 @@
 package consolidation
 
 import (
+	"context"
+
 	"gopkg.in/raintank/schema.v1"
 )
+
+// ConsolidateContext wraps a Consolidate() call with a context.Context condition
+func ConsolidateContext(ctx context.Context, in []schema.Point, aggNum uint32, consolidator Consolidator) []schema.Point {
+	select {
+	case <-ctx.Done():
+		//request canceled
+		return nil
+	default:
+	}
+	return Consolidate(in, aggNum, consolidator)
+}
 
 // Consolidate consolidates `in`, aggNum points at a time via the given function
 // note: the returned slice repurposes in's backing array.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -146,6 +146,8 @@ fallback-graphite-addr = http://graphite
 log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
+# maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.
+get-targets-concurrency = 20
 
 ## metric data inputs ##
 

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -146,6 +146,8 @@ fallback-graphite-addr = http://graphite
 log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
+# maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.
+get-targets-concurrency = 20
 
 ## metric data inputs ##
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -187,6 +187,8 @@ fallback-graphite-addr = http://localhost:8080
 log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
+# maximum number of concurrent threads for fetching data on the local node
+get-targets-concurrency = 20
 ```
 
 ## metric data inputs ##

--- a/mdata/cwr.go
+++ b/mdata/cwr.go
@@ -1,6 +1,7 @@
 package mdata
 
 import (
+	"context"
 	"time"
 
 	"github.com/grafana/metrictank/mdata/chunk"
@@ -13,6 +14,7 @@ type ChunkReadRequest struct {
 	p         []interface{}
 	timestamp time.Time
 	out       chan outcome
+	ctx       context.Context
 }
 
 type ChunkWriteRequest struct {

--- a/mdata/store_cassandra.go
+++ b/mdata/store_cassandra.go
@@ -44,7 +44,7 @@ var (
 	errReadQueueFull  = errors.New("the read queue is full")
 	errReadTooOld     = errors.New("the read is too old")
 	errTableNotFound  = errors.New("table for given TTL not found")
-	errCxtCanceled    = errors.New("context canceled")
+	errCtxCanceled    = errors.New("context canceled")
 
 	// metric store.cassandra.get.exec is the duration of getting from cassandra store
 	cassGetExecDuration = stats.NewLatencyHistogram15s32("store.cassandra.get.exec")
@@ -421,7 +421,7 @@ func (c *CassandraStore) processReadQueue() {
 		select {
 		case <-crr.ctx.Done():
 			//request canceled
-			crr.out <- outcome{err: errCxtCanceled}
+			crr.out <- outcome{err: errCtxCanceled}
 			continue
 		default:
 		}
@@ -541,7 +541,7 @@ LOOP:
 			return nil, nil
 		case o := <-results:
 			if o.err != nil {
-				if o.err == errCxtCanceled {
+				if o.err == errCtxCanceled {
 					// context was canceled, return immediately.
 					return nil, nil
 				}

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -149,6 +149,8 @@ fallback-graphite-addr = http://localhost:8080
 log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
+# maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.
+get-targets-concurrency = 20
 
 ## metric data inputs ##
 

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -146,6 +146,8 @@ fallback-graphite-addr = http://graphite
 log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
+# maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.
+get-targets-concurrency = 20
 
 ## metric data inputs ##
 

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -146,6 +146,8 @@ fallback-graphite-addr = http://localhost:8080
 log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
+# maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.
+get-targets-concurrency = 20
 
 ## metric data inputs ##
 


### PR DESCRIPTION
- The ctx was already being passed between the different methods
  within the query pipeline, but the context was never being inspected
  to see if it had been canceled. This commit fixes that.
- Now when an error occurs, whether that error is local or on a remote
  peer, the request is immediately canceled.
- if the client disconnects before a response is returned (whether
  that is due to a timeout or the client canceling the request), that
  cancelation will propagate throught and abort any work.