### PR TITLE
Tag index

### DIFF
--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -291,3 +291,7 @@ create-keyspace = false
 ### in-memory only
 [memory-idx]
 enabled = false
+# enables/disables querying based on tags
+tag-support = false
+# size of regular expression cache in tag query evaluation
+match-cache-size = 1000

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -291,3 +291,7 @@ create-keyspace = true
 ### in-memory only
 [memory-idx]
 enabled = false
+# enables/disables querying based on tags
+tag-support = false
+# size of regular expression cache in tag query evaluation
+match-cache-size = 1000

--- a/docs/CONTRIBUTING
+++ b/docs/CONTRIBUTING
@@ -15,3 +15,4 @@ When contributing PR's:
    (example: `docker/docker-cluster/metrictank.ini` is the same as metrictank-sample.ini except for the options that support the use case of running metrictank in a cluster)
    Use `scripts/sync-configs.sh` which helps with the process of updating all configs based on metrictank-sample.ini.
 9. PR's will only be merged if all tests pass
+10. Any errors which can be recovered from sanely, must do so. And must trigger a high-level recovery metric (see other recovered_errors metrics) and an error message describing the problem.

--- a/docs/config.md
+++ b/docs/config.md
@@ -350,6 +350,10 @@ create-keyspace = true
 ```
 [memory-idx]
 enabled = false
+# enables/disables querying based on tags
+tag-support = false
+# size of regular expression cache in tag query evaluation
+match-cache-size = 1000
 ```
 
 # storage-schemas.conf

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -29,6 +29,7 @@ If you expect consistent or predictable load, you may also want to monitor:
 
 * `metrictank.stats.$environment.$instance.store.cassandra.chunk_operations.save_ok.counter32`: number of saved chunks (based on your chunkspan settings)
 * `metrictank.stats.$environment.$instance.api.request_handle.values.rate32` : rate per second of render requests
+* `metrictank.stats.$environment.$instance.recovered_errors.*.*.*` : any internal errors that were recovered from automatically (should be 0. If not, please create an issue)
 
 
 

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -113,6 +113,6 @@ type MetricIndex interface {
 	List(int) []Archive
 	Prune(int, time.Time) ([]Archive, error)
 	TagList(int) []string
-	Tag(int, string) map[string]uint32
-	IdsByTagExpressions(int, []string) ([]string, error)
+	Tag(int, string, int64) map[string]uint32
+	IdsByTagExpressions(int, []string, int64) ([]string, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -145,19 +145,20 @@ Interface
   error encountered.
 
 * TagList(int) []string:
-  Returns a list of all tag keys associated with the metrics of a given organization.o
+  This method returns a list of all tag keys associated with the metrics of a given
+  organization.
 
 * Tag(int, string, int64) map[string]uint32:
-  Returns a list of all values associated with a given tag key in the given org. The
-  occurences of each value is counted and the count is referred to by the series ids
-  in the returned map. If the third parameter is > 0 then the metrics will be filtered
-  and only those of which the LastUpdate time is >= the from timestamp will be
-  considered while the others are being ignored.
+  This method returns a list of all values associated with a given tag key in the
+  given org. The occurences of each value is counted and the count is referred to by
+  the series ids in the returned map. If the third parameter is > 0 then the metrics
+  will be filtered and only those of which the LastUpdate time is >= the from
+  timestamp will be considered while the others are being ignored.
 
 * IdsByTagExpression(int, []string, int64) ([]string, error):
-  Takes a list of expressions in the format key=value.
+  This method takes a list of expressions in the format key=value.
   The allowed operators are: =, !=, =~, !=~.
-  Returns a slice of IDs that match the given conditions, the conditions are
+  It returns a slice of IDs that match the given conditions, the conditions are
   logically AND-ed. If the third argument is > 0 then the results will be filtered
   and only those where the LastUpdate time is >= from will be returned as results.
 */

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -155,7 +155,7 @@ Interface
   will be filtered and only those of which the LastUpdate time is >= the from
   timestamp will be considered while the others are being ignored.
 
-* IdsByTagExpression(int, []string, int64) ([]string, error):
+* FindByTag(int, []string, int64) ([]string, error):
   This method takes a list of expressions in the format key<operator>value.
   The allowed operators are: =, !=, =~, !=~.
   It returns a slice of IDs that match the given conditions, the conditions are
@@ -175,5 +175,5 @@ type MetricIndex interface {
 	Prune(int, time.Time) ([]Archive, error)
 	TagList(int) []string
 	Tag(int, string, int64) map[string]uint32
-	IdsByTagExpressions(int, []string, int64) (map[MetricID]struct{}, error)
+	FindByTag(int, []string, int64) (map[MetricID]struct{}, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -67,7 +67,7 @@ func (id *MetricID) FromString(s string) error {
 	return nil
 }
 
-func (id *MetricID) ToString() string {
+func (id *MetricID) String() string {
 	return fmt.Sprintf("%d.%016x%016x", id.org, id.part1, id.part2)
 }
 

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -156,7 +156,7 @@ Interface
   timestamp will be considered while the others are being ignored.
 
 * IdsByTagExpression(int, []string, int64) ([]string, error):
-  This method takes a list of expressions in the format key=value.
+  This method takes a list of expressions in the format key<operator>value.
   The allowed operators are: =, !=, =~, !=~.
   It returns a slice of IDs that match the given conditions, the conditions are
   logically AND-ed. If the third argument is > 0 then the results will be filtered

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -101,7 +101,25 @@ Interface
   passed is -1, then the all orgs should be examined for stale metrics to be deleted.
   The method returns a list of the metricDefinitions deleted from the index and any
   error encountered.
+
+* TagList(int) []string:
+  Returns a list of all tag keys associated with the metrics of a given organization.o
+
+* Tag(int, string, int64) map[string]uint32:
+  Returns a list of all values associated with a given tag key in the given org. The
+  occurences of each value is counted and the count is referred to by the series ids
+  in the returned map. If the third parameter is > 0 then the metrics will be filtered
+  and only those of which the LastUpdate time is >= the from timestamp will be
+  considered while the others are being ignored.
+
+* IdsByTagExpression(int, []string, int64) ([]string, error):
+  Takes a list of expressions in the format key=value.
+  The allowed operators are: =, !=, =~, !=~.
+  Returns a slice of IDs that match the given conditions, the conditions are
+  logically AND-ed. If the third argument is > 0 then the results will be filtered
+  and only those where the LastUpdate time is >= from will be returned as results.
 */
+
 type MetricIndex interface {
 	Init() error
 	Stop()

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -68,7 +68,7 @@ func (id *MetricID) FromString(s string) error {
 }
 
 func (id *MetricID) String() string {
-	return fmt.Sprintf("%d.%032x", id.org, id.key)
+	return fmt.Sprintf("%d.%x", id.org, id.key)
 }
 
 // used primarily by tests, for convenience

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -132,5 +132,5 @@ type MetricIndex interface {
 	Prune(int, time.Time) ([]Archive, error)
 	TagList(int) []string
 	Tag(int, string, int64) map[string]uint32
-	IdsByTagExpressions(int, []string, int64) ([]string, error)
+	IdsByTagExpressions(int, []string, int64) (map[string]struct{}, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -112,7 +112,7 @@ type MetricIndex interface {
 	Find(int, string, int64) ([]Node, error)
 	List(int) []Archive
 	Prune(int, time.Time) ([]Archive, error)
-	TagList(int, uint32) []string
+	TagList(int) []string
 	Tag(int, string) map[string]uint32
 	IdsByTagExpressions(int, []string) ([]string, error)
 }

--- a/idx/idx_test.go
+++ b/idx/idx_test.go
@@ -1,0 +1,42 @@
+package idx
+
+import (
+	"testing"
+)
+
+func TestMetricIDStringConversion(t *testing.T) {
+	id := MetricID{}
+	testIDs := []string{
+		"1.abcdefabcdef12340123456789abcdef",
+		"12345.00000000000000000000000000000000",
+		"12345.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+
+	for _, idStr := range testIDs {
+		err := id.FromString(idStr)
+		if err != nil {
+			t.Fatalf("Error parsing id %s: %s", idStr, err)
+		}
+		idStr2 := id.ToString()
+		if idStr != idStr2 {
+			t.Fatalf("Converted id string has changed: %s %s", idStr, idStr2)
+		}
+	}
+}
+
+func TestMetricIDStringConversionErrors(t *testing.T) {
+	id := MetricID{}
+	testIDs := []string{
+		"abc.00000000000000000000000000000000",
+		"1.1111111111111111111111111111111",
+		"1.111111111111111111111111111111111",
+		"1.g1111111111111111111111111111111",
+	}
+
+	for _, idStr := range testIDs {
+		err := id.FromString(idStr)
+		if err == nil {
+			t.Fatalf("Expected error, but didn't get one with %s", idStr)
+		}
+	}
+}

--- a/idx/idx_test.go
+++ b/idx/idx_test.go
@@ -17,7 +17,7 @@ func TestMetricIDStringConversion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error parsing id %s: %s", idStr, err)
 		}
-		idStr2 := id.ToString()
+		idStr2 := id.String()
 		if idStr != idStr2 {
 			t.Fatalf("Converted id string has changed: %s %s", idStr, idStr2)
 		}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -147,9 +147,9 @@ func (m *MemoryIdx) Update(entry idx.Archive) {
 	m.Unlock()
 }
 
-// reads the tags of a given metric definition and creates the
-// corresponding tag index entries to refer to it.
-// assumes a lock is already held.
+// indexTags reads the tags of a given metric definition and creates the
+// corresponding tag index entries to refer to it. It assumes a lock is
+// already held.
 func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 	tags, ok := m.Tags[def.OrgId]
 	if !ok {
@@ -187,9 +187,8 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 	}
 }
 
-// takes a given metric definition and removes all references
-// to it from the tag index.
-// assumes a lock is already held.
+// deindexTags takes a given metric definition and removes all references
+// to it from the tag index. It assumes a lock is already held.
 func (m *MemoryIdx) deindexTags(def *schema.MetricDefinition) {
 	tags, ok := m.Tags[def.OrgId]
 	if !ok {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -454,8 +454,7 @@ func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) (map[
 		return nil, err
 	}
 
-	seriesMap := m.idsByTagQuery(orgId, query)
-	return seriesMap, nil
+	return m.idsByTagQuery(orgId, query), nil
 }
 
 func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) TagIDs {
@@ -467,9 +466,7 @@ func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) TagIDs {
 		return nil
 	}
 
-	res := query.Run(tree, m.DefById)
-
-	return res
+	return query.Run(tree, m.DefById)
 }
 
 func (m *MemoryIdx) Find(orgId int, pattern string, from int64) ([]idx.Node, error) {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -162,7 +162,7 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 			// should never happen because every tag in the index
 			// must have a valid format
 			InvalidTagInIndex.Inc()
-			log.Error(3, "memory-idx: Tag %s has an invalid format", tag)
+			log.Error(3, "memory-idx: Tag %q of id %q has an invalid format", tag, def.Id)
 			continue
 		}
 
@@ -182,7 +182,7 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 			// should never happen because all IDs in the index must have
 			// a valid format
 			CorruptIndex.Inc()
-			log.Error(3, "memory-idx: ID %s has invalid format", def.Id)
+			log.Error(3, "memory-idx: ID %q has invalid format", def.Id)
 			continue
 		}
 		tags[tagName][tagValue][id] = struct{}{}
@@ -203,7 +203,7 @@ func (m *MemoryIdx) deindexTags(def *schema.MetricDefinition) {
 			// should never happen because every tag in the index
 			// must have a valid format
 			InvalidTagInIndex.Inc()
-			log.Error(3, "memory-idx: Tag %s has an invalid format", tag)
+			log.Error(3, "memory-idx: Tag %q of id %q has an invalid format", tag, def.Id)
 			continue
 		}
 
@@ -215,7 +215,7 @@ func (m *MemoryIdx) deindexTags(def *schema.MetricDefinition) {
 			// should never happen because all IDs in the index must have
 			// a valid format
 			CorruptIndex.Inc()
-			log.Error(3, "memory-idx: ID %s has invalid format", def.Id)
+			log.Error(3, "memory-idx: ID %q has invalid format", def.Id)
 			continue
 		}
 		delete(tags[tagName][tagValue], id)
@@ -400,7 +400,7 @@ func (m *MemoryIdx) Tag(orgId int, tag string, from int64) map[string]uint32 {
 				// should never happen because every ID that is in the tag index
 				// must be present in the byId lookup table
 				CorruptIndex.Inc()
-				log.Error(3, "memory-idx: ID %s is in tag index but not in the byId lookup table", id.String())
+				log.Error(3, "memory-idx: ID %q is in tag index but not in the byId lookup table", id.String())
 				continue
 			}
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -207,14 +207,6 @@ func (m *MemoryIdx) deindexTags(def *schema.MetricDefinition) {
 		tagName := tagSplits[0]
 		tagValue := tagSplits[1]
 
-		if _, ok = tags[tagName]; !ok {
-			continue
-		}
-
-		if _, ok = tags[tagName][tagValue]; !ok {
-			continue
-		}
-
 		id, err := idx.NewMetricIDFromString(def.Id)
 		if err != nil {
 			// should never happen because all IDs in the index must have

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -433,10 +433,11 @@ func (m *MemoryIdx) TagList(orgId int) []string {
 		return nil
 	}
 
-	results := make([]string, 0, len(tags))
-
+	results := make([]string, len(tags))
+	i := 0
 	for k := range tags {
-		results = append(results, k)
+		results[i] = k
+		i++
 	}
 
 	return results

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -442,7 +442,7 @@ func (m *MemoryIdx) TagList(orgId int) []string {
 	return results
 }
 
-func (m *MemoryIdx) IdsByTagExpressions(orgId int, expressions []string, from int64) (map[idx.MetricID]struct{}, error) {
+func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) (map[idx.MetricID]struct{}, error) {
 	query, err := NewTagQuery(expressions, from)
 	if err != nil {
 		return nil, err

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -379,7 +379,7 @@ func (m *MemoryIdx) GetPath(orgId int, path string) []idx.Archive {
 
 func (m *MemoryIdx) Tag(orgId int, tag string, from int64) map[string]uint32 {
 	if !tagSupport {
-		log.Debug("memory-idx: received tag query, but tag support is disabled")
+		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil
 	}
 
@@ -422,7 +422,7 @@ func (m *MemoryIdx) Tag(orgId int, tag string, from int64) map[string]uint32 {
 
 func (m *MemoryIdx) TagList(orgId int) []string {
 	if !tagSupport {
-		log.Debug("memory-idx: received tag query, but tag support is disabled")
+		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil
 	}
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -157,7 +157,9 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 	for _, tag := range def.Tags {
 		tagSplits := strings.SplitN(tag, "=", 2)
 		if len(tagSplits) < 2 {
-			// invalid
+			// should never happen because every tag in the index
+			// must have a valid format
+			InvalidTagInIndex.Inc()
 			continue
 		}
 
@@ -174,7 +176,9 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 
 		id, err := idx.NewMetricIDFromString(def.Id)
 		if err != nil {
-			// invalid id
+			// should never happen because all IDs in the index must have
+			// a valid format
+			CorruptIndex.Inc()
 			continue
 		}
 		tags[tagName][tagValue][id] = struct{}{}
@@ -193,7 +197,9 @@ func (m *MemoryIdx) deindexTags(def *schema.MetricDefinition) {
 	for _, tag := range def.Tags {
 		tagSplits := strings.SplitN(tag, "=", 2)
 		if len(tagSplits) < 2 {
-			// invalid
+			// should never happen because every tag in the index
+			// must have a valid format
+			InvalidTagInIndex.Inc()
 			continue
 		}
 
@@ -210,7 +216,9 @@ func (m *MemoryIdx) deindexTags(def *schema.MetricDefinition) {
 
 		id, err := idx.NewMetricIDFromString(def.Id)
 		if err != nil {
-			// invalid id
+			// should never happen because all IDs in the index must have
+			// a valid format
+			CorruptIndex.Inc()
 			continue
 		}
 		delete(tags[tagName][tagValue], id)
@@ -392,7 +400,9 @@ func (m *MemoryIdx) Tag(orgId int, tag string, from int64) map[string]uint32 {
 			var def *idx.Archive
 			var ok bool
 			if def, ok = m.DefById[id.ToString()]; !ok {
-				// corrupt index
+				// should never happen because every ID that is in the tag index
+				// must be present in the byId lookup table
+				CorruptIndex.Inc()
 				continue
 			}
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -50,8 +50,8 @@ var (
 func ConfigSetup() {
 	memoryIdx := flag.NewFlagSet("memory-idx", flag.ExitOnError)
 	memoryIdx.BoolVar(&Enabled, "enabled", false, "")
-	memoryIdx.BoolVar(&tagSupport, "tag-support", false, "")
-	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "")
+	memoryIdx.BoolVar(&tagSupport, "tag-support", false, "enables/disables querying based on tags")
+	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
 	globalconf.Register("memory-idx", memoryIdx)
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -448,11 +448,11 @@ func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) (map[
 		return nil, err
 	}
 
-	seriesMap := m.IdsByTagQuery(orgId, query)
+	seriesMap := m.idsByTagQuery(orgId, query)
 	return seriesMap, nil
 }
 
-func (m *MemoryIdx) IdsByTagQuery(orgId int, query TagQuery) TagIDs {
+func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) TagIDs {
 	m.RLock()
 	defer m.RUnlock()
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -42,8 +42,9 @@ var (
 	// metric idx.metrics_active is the number of currently known metrics in the index
 	statMetricsActive = stats.NewGauge32("idx.metrics_active")
 
-	Enabled    bool
-	tagSupport bool
+	Enabled        bool
+	matchCacheSize int
+	tagSupport     bool
 )
 
 func ConfigSetup() {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -51,6 +51,7 @@ func ConfigSetup() {
 	memoryIdx := flag.NewFlagSet("memory-idx", flag.ExitOnError)
 	memoryIdx.BoolVar(&Enabled, "enabled", false, "")
 	memoryIdx.BoolVar(&tagSupport, "tag-support", false, "")
+	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "")
 	globalconf.Register("memory-idx", memoryIdx)
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -380,7 +380,7 @@ func (m *MemoryIdx) Tag(orgId int, tag string) map[string]uint32 {
 	return result
 }
 
-func (m *MemoryIdx) TagList(orgId int, from uint32) []string {
+func (m *MemoryIdx) TagList(orgId int) []string {
 	if !tagSupport {
 		log.Debug("memory-idx: received tag query, but tag support is disabled")
 		return nil

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -57,8 +57,9 @@ type Tree struct {
 	Items map[string]*Node // key is the full path of the node.
 }
 
-// key -> value -> id
-type TagIndex map[string]map[string]map[string]struct{}
+type TagIDs map[string]struct{}   // set of ids
+type TagValue map[string]TagIDs   // value -> set of ids
+type TagIndex map[string]TagValue // key -> list of values
 
 type Node struct {
 	Path     string
@@ -163,11 +164,11 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 		tagValue := tagSplits[1]
 
 		if _, ok = tags[tagName]; !ok {
-			tags[tagName] = make(map[string]map[string]struct{})
+			tags[tagName] = make(TagValue)
 		}
 
 		if _, ok = tags[tagName][tagValue]; !ok {
-			tags[tagName][tagValue] = make(map[string]struct{})
+			tags[tagName][tagValue] = make(TagIDs)
 		}
 
 		tags[tagName][tagValue][def.Id] = struct{}{}
@@ -435,7 +436,7 @@ func (m *MemoryIdx) IdsByTagExpressions(orgId int, expressions []string, from in
 	return res, nil
 }
 
-func (m *MemoryIdx) IdsByTagQuery(orgId int, query TagQuery) map[string]struct{} {
+func (m *MemoryIdx) IdsByTagQuery(orgId int, query TagQuery) TagIDs {
 	m.RLock()
 	defer m.RUnlock()
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -444,6 +444,11 @@ func (m *MemoryIdx) TagList(orgId int) []string {
 }
 
 func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) (map[idx.MetricID]struct{}, error) {
+	if !tagSupport {
+		log.Warn("memory-idx: received tag query, but tag support is disabled")
+		return nil, nil
+	}
+
 	query, err := NewTagQuery(expressions, from)
 	if err != nil {
 		return nil, err

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -467,10 +467,7 @@ func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) TagIDs {
 		return nil
 	}
 
-	res, err := query.Run(tree, m.DefById)
-	if err != nil {
-		return nil
-	}
+	res := query.Run(tree, m.DefById)
 
 	return res
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -147,6 +147,7 @@ func (m *MemoryIdx) Update(entry idx.Archive) {
 
 // reads the tags of a given metric definition and creates the
 // corresponding tag index entries to refer to it.
+// assumes a lock is already held.
 func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 	tags, ok := m.Tags[def.OrgId]
 	if !ok {
@@ -177,6 +178,7 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 
 // takes a given metric definition and removes all references
 // to it from the tag index.
+// assumes a lock is already held.
 func (m *MemoryIdx) deindexTags(def *schema.MetricDefinition) {
 	tags, ok := m.Tags[def.OrgId]
 	if !ok {
@@ -422,18 +424,14 @@ func (m *MemoryIdx) TagList(orgId int) []string {
 	return results
 }
 
-func (m *MemoryIdx) IdsByTagExpressions(orgId int, expressions []string, from int64) ([]string, error) {
+func (m *MemoryIdx) IdsByTagExpressions(orgId int, expressions []string, from int64) (map[string]struct{}, error) {
 	query, err := NewTagQuery(expressions, from)
 	if err != nil {
 		return nil, err
 	}
 
 	seriesMap := m.IdsByTagQuery(orgId, query)
-	res := make([]string, 0, len(seriesMap))
-	for s := range seriesMap {
-		res = append(res, s)
-	}
-	return res, nil
+	return seriesMap, nil
 }
 
 func (m *MemoryIdx) IdsByTagQuery(orgId int, query TagQuery) TagIDs {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -401,7 +401,7 @@ func (m *MemoryIdx) Tag(orgId int, tag string, from int64) map[string]uint32 {
 		for id := range ids {
 			var def *idx.Archive
 			var ok bool
-			if def, ok = m.DefById[id.ToString()]; !ok {
+			if def, ok = m.DefById[id.String()]; !ok {
 				// should never happen because every ID that is in the tag index
 				// must be present in the byId lookup table
 				CorruptIndex.Inc()

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -295,7 +295,7 @@ func ixFindByTag(org, q int) {
 	if len(series) != tagQueries[q].ExpectedResults {
 		for s := range series {
 			memoryIdx := ix.(*MemoryIdx)
-			fmt.Println(memoryIdx.DefById[s].Tags)
+			fmt.Println(memoryIdx.DefById[s.ToString()].Tags)
 		}
 		panic(fmt.Sprintf("%+v expected %d got %d results instead", tagQueries[q].Expressions, tagQueries[q].ExpectedResults, len(series)))
 	}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -95,8 +95,6 @@ func TestMain(m *testing.M) {
 	_tagSupport := tagSupport
 	defer func() { tagSupport = _tagSupport }()
 	tagSupport = true
-
-	Init()
 	os.Exit(m.Run())
 }
 
@@ -245,11 +243,7 @@ func BenchmarkConcurrent4Find(b *testing.B) {
 	if ix == nil {
 		Init()
 	}
-
 	queryCount := len(queries)
-	if ix == nil {
-		Init()
-	}
 
 	ch := make(chan testQ)
 	for i := 0; i < 4; i++ {
@@ -273,11 +267,7 @@ func BenchmarkConcurrent8Find(b *testing.B) {
 	if ix == nil {
 		Init()
 	}
-
 	queryCount := len(queries)
-	if ix == nil {
-		Init()
-	}
 
 	ch := make(chan testQ)
 	for i := 0; i < 8; i++ {
@@ -312,6 +302,9 @@ func ixFindByTag(org, q int) {
 }
 
 func BenchmarkTagFindSimpleIntersect(b *testing.B) {
+	if ix == nil {
+		Init()
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -322,6 +315,9 @@ func BenchmarkTagFindSimpleIntersect(b *testing.B) {
 }
 
 func BenchmarkTagFindRegexIntersect(b *testing.B) {
+	if ix == nil {
+		Init()
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -332,6 +328,9 @@ func BenchmarkTagFindRegexIntersect(b *testing.B) {
 }
 
 func BenchmarkTagFindMatchingAndFiltering(b *testing.B) {
+	if ix == nil {
+		Init()
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -342,6 +341,9 @@ func BenchmarkTagFindMatchingAndFiltering(b *testing.B) {
 }
 
 func BenchmarkTagFindMatchingAndFilteringWithRegex(b *testing.B) {
+	if ix == nil {
+		Init()
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -352,7 +354,11 @@ func BenchmarkTagFindMatchingAndFilteringWithRegex(b *testing.B) {
 }
 
 func BenchmarkTagQueryFilterAndIntersect(b *testing.B) {
+	if ix == nil {
+		Init()
+	}
 	q := tagQuery{Expressions: []string{"direction!=~read", "device!=", "host=~host9[0-9]0", "dc=dc1", "disk!=disk1", "metric=disk_time"}, ExpectedResults: 90}
+
 	b.ReportAllocs()
 	b.ResetTimer()
 

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -299,7 +299,7 @@ func BenchmarkConcurrent8Find(b *testing.B) {
 }
 
 func ixFindByTag(org, q int) {
-	series, err := ix.IdsByTagExpressions(org, tagQueries[q].Expressions)
+	series, err := ix.IdsByTagExpressions(org, tagQueries[q].Expressions, 0)
 	if err != nil {
 		panic(err)
 	}
@@ -358,7 +358,7 @@ func BenchmarkTagQueryFilterAndIntersect(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		series, err := ix.IdsByTagExpressions(1, q.Expressions)
+		series, err := ix.IdsByTagExpressions(1, q.Expressions, 0)
 		if err != nil {
 			panic(err)
 		}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -293,7 +293,7 @@ func ixFindByTag(org, q int) {
 		panic(err)
 	}
 	if len(series) != tagQueries[q].ExpectedResults {
-		for _, s := range series {
+		for s := range series {
 			memoryIdx := ix.(*MemoryIdx)
 			fmt.Println(memoryIdx.DefById[s].Tags)
 		}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -348,3 +348,22 @@ func BenchmarkTagFindMatchingAndFilteringRegex1(b *testing.B) {
 		ixFindByTag(1, 6)
 	}
 }
+
+func BenchmarkTagQueryFilterAndIntersect(b *testing.B) {
+	q := tagQuery{Expressions: []string{"direction!=~read", "host=~host9[0-9]0", "dc=dc1", "disk!=disk1", "metric=disk_time"}, ExpectedResults: 90}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		series, err := ix.IdsByTagExpressions(1, q.Expressions)
+		if err != nil {
+			panic(err)
+		}
+		if len(series) != q.ExpectedResults {
+			for _, s := range series {
+				fmt.Println(s)
+			}
+			panic(fmt.Sprintf("%+v expected %d got %d results instead", q.Expressions, q.ExpectedResults, len(series)))
+		}
+	}
+}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -104,48 +104,52 @@ func Init() {
 
 	var data *schema.MetricData
 
-	for _, series := range cpuMetrics(5, 1000, 0, 32, "collectd") {
+	for i, series := range cpuMetrics(5, 1000, 0, 32, "collectd") {
 		data = &schema.MetricData{
 			Name:     series.Name,
 			Metric:   series.Name,
 			Tags:     series.Tags,
 			Interval: 10,
 			OrgId:    1,
+			Time:     int64(i + 100),
 		}
 		data.SetId()
 		ix.AddOrUpdate(data, 1)
 	}
-	for _, series := range diskMetrics(5, 1000, 0, 10, "collectd") {
+	for i, series := range diskMetrics(5, 1000, 0, 10, "collectd") {
 		data = &schema.MetricData{
 			Name:     series.Name,
 			Metric:   series.Name,
 			Tags:     series.Tags,
 			Interval: 10,
 			OrgId:    1,
+			Time:     int64(i + 100),
 		}
 		data.SetId()
 		ix.AddOrUpdate(data, 1)
 	}
 	// orgId has 1,680,000 series
 
-	for _, series := range cpuMetrics(5, 100, 950, 32, "collectd") {
+	for i, series := range cpuMetrics(5, 100, 950, 32, "collectd") {
 		data = &schema.MetricData{
 			Name:     series.Name,
 			Metric:   series.Name,
 			Tags:     series.Tags,
 			Interval: 10,
 			OrgId:    2,
+			Time:     int64(i + 100),
 		}
 		data.SetId()
 		ix.AddOrUpdate(data, 1)
 	}
-	for _, series := range diskMetrics(5, 100, 950, 10, "collectd") {
+	for i, series := range diskMetrics(5, 100, 950, 10, "collectd") {
 		data = &schema.MetricData{
 			Name:     series.Name,
 			Metric:   series.Name,
 			Tags:     series.Tags,
 			Interval: 10,
 			OrgId:    2,
+			Time:     int64(i + 100),
 		}
 		data.SetId()
 		ix.AddOrUpdate(data, 1)
@@ -363,7 +367,7 @@ func BenchmarkTagQueryFilterAndIntersect(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		series, err := ix.IdsByTagExpressions(1, q.Expressions, 0)
+		series, err := ix.IdsByTagExpressions(1, q.Expressions, 150000)
 		if err != nil {
 			panic(err)
 		}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -350,7 +350,7 @@ func BenchmarkTagFindMatchingAndFilteringRegex1(b *testing.B) {
 }
 
 func BenchmarkTagQueryFilterAndIntersect(b *testing.B) {
-	q := tagQuery{Expressions: []string{"direction!=~read", "host=~host9[0-9]0", "dc=dc1", "disk!=disk1", "metric=disk_time"}, ExpectedResults: 90}
+	q := tagQuery{Expressions: []string{"direction!=~read", "device!=", "host=~host9[0-9]0", "dc=dc1", "disk!=disk1", "metric=disk_time"}, ExpectedResults: 90}
 	b.ReportAllocs()
 	b.ResetTimer()
 

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -299,7 +299,7 @@ func ixFindByTag(b *testing.B, org, q int) {
 	if len(series) != tagQueries[q].ExpectedResults {
 		for s := range series {
 			memoryIdx := ix.(*MemoryIdx)
-			b.Log(memoryIdx.DefById[s.ToString()].Tags)
+			b.Log(memoryIdx.DefById[s.String()].Tags)
 		}
 		b.Fatalf("%+v expected %d got %d results instead", tagQueries[q].Expressions, tagQueries[q].ExpectedResults, len(series))
 	}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	//"sync"
 	"testing"
 
 	"github.com/grafana/metrictank/idx"

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -314,11 +314,9 @@ func ixFindByTag(org, q int) {
 func BenchmarkTagFindSimpleIntersect(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	fmt.Println("bench count ", b.N)
 	for n := 0; n < b.N; n++ {
 		q := n % 2
 		org := (n % 2) + 1
-		fmt.Println("running ", q)
 		ixFindByTag(org, q)
 	}
 }
@@ -326,11 +324,9 @@ func BenchmarkTagFindSimpleIntersect(b *testing.B) {
 func BenchmarkTagFindRegexIntersect(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	fmt.Println("bench count ", b.N)
 	for n := 0; n < b.N; n++ {
 		q := (n % 2) + 2
 		org := (n % 2) + 1
-		fmt.Println("running ", q)
 		ixFindByTag(org, q)
 	}
 }
@@ -342,7 +338,6 @@ func BenchmarkConcurrent8TagFind(b *testing.B) {
 		wg.Add(1)
 		go func() {
 			for q := range ch {
-				fmt.Println("running ", q.q)
 				ixFindByTag(q.org, q.q)
 			}
 			wg.Done()

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -291,7 +291,7 @@ func BenchmarkConcurrent8Find(b *testing.B) {
 }
 
 func ixFindByTag(b *testing.B, org, q int) {
-	series, err := ix.IdsByTagExpressions(org, tagQueries[q].Expressions, 0)
+	series, err := ix.FindByTag(org, tagQueries[q].Expressions, 0)
 	if err != nil {
 		panic(err)
 	}
@@ -366,7 +366,7 @@ func BenchmarkTagQueryFilterAndIntersect(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		series, err := ix.IdsByTagExpressions(1, q.Expressions, 150000)
+		series, err := ix.FindByTag(1, q.Expressions, 150000)
 		if err != nil {
 			b.Fatalf(err.Error())
 		}
@@ -386,7 +386,7 @@ func BenchmarkTagQueryFilterAndIntersectOnlyRegex(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		series, err := ix.IdsByTagExpressions(1, q.Expressions, 0)
+		series, err := ix.FindByTag(1, q.Expressions, 0)
 		if err != nil {
 			b.Fatalf(err.Error())
 		}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -206,7 +206,7 @@ func Init() {
 
 		// matching and filtering by regular expressions
 		{Expressions: []string{"dc=dc1", "host=host666", "cpu!=~cpu[0-9]{2}", "device!=~d.*"}, ExpectedResults: 80},
-		{Expressions: []string{"dc=dc1", "host!=~host10[0-9]{2}", "device!=~c.*"}, ExpectedResults: 1500},
+		{Expressions: []string{"dc=dc1", "host!=~host10[0-9]{2}", "device!=~c.*"}, ExpectedResults: 4000},
 	}
 }
 
@@ -305,7 +305,8 @@ func ixFindByTag(org, q int) {
 	}
 	if len(series) != tagQueries[q].ExpectedResults {
 		for _, s := range series {
-			fmt.Println(s)
+			memoryIdx := ix.(*MemoryIdx)
+			fmt.Println(memoryIdx.DefById[s].Tags)
 		}
 		panic(fmt.Sprintf("%+v expected %d got %d results instead", tagQueries[q].Expressions, tagQueries[q].ExpectedResults, len(series)))
 	}
@@ -341,11 +342,13 @@ func BenchmarkTagFindMatchingAndFiltering(b *testing.B) {
 	}
 }
 
-func BenchmarkTagFindMatchingAndFilteringRegex1(b *testing.B) {
+func BenchmarkTagFindMatchingAndFilteringWithRegex(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		ixFindByTag(1, 6)
+		q := (n % 2) + 6
+		org := (n % 2) + 1
+		ixFindByTag(org, q)
 	}
 }
 

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -91,8 +91,7 @@ func diskMetrics(dcCount, hostCount, hostOffset, diskCount int, prefix string) [
 }
 
 func TestMain(m *testing.M) {
-	_tagSupport := tagSupport
-	defer func() { tagSupport = _tagSupport }()
+	defer func(t bool) { tagSupport = t }(tagSupport)
 	tagSupport = true
 	os.Exit(m.Run())
 }

--- a/idx/memory/stats.go
+++ b/idx/memory/stats.go
@@ -3,9 +3,18 @@ package memory
 import "github.com/grafana/metrictank/stats"
 
 var (
-	// how many times a corrupt index has been detected
-	CorruptIndex = stats.NewCounter32("idx.memory.corrupt-index")
+	// metric recovered_errors.idx.memory.corrupt-index is how many times
+	// a corruption has been detected in one of the internal index structures
+	// each time this happens, an error is logged with more details.
+	corruptIndex = stats.NewCounter32("recovered_errors.idx.memory.corrupt-index")
 
-	// how many times an invalid tag has been found inside the index
-	InvalidTagInIndex = stats.NewCounter32("idx.memory.invalid-tag-in-index")
+	// metric recovered_errors.idx.memory.invalid-id is how many times
+	// an invalid metric id is encountered.
+	// each time this happens, an error is logged with more details.
+	invalidId = stats.NewCounter32("recovered_errors.idx.memory.invalid-id")
+
+	// metric recovered_errors.idx.memory.invalid-tag is how many times
+	// an invalid tag for a metric is encountered.
+	// each time this happens, an error is logged with more details.
+	invalidTag = stats.NewCounter32("recovered_errors.idx.memory.invalid-tag")
 )

--- a/idx/memory/stats.go
+++ b/idx/memory/stats.go
@@ -1,0 +1,11 @@
+package memory
+
+import "github.com/grafana/metrictank/stats"
+
+var (
+	// how many times a corrupt index has been detected
+	CorruptIndex = stats.NewCounter32("idx.memory.corrupt-index")
+
+	// how many times an invalid tag has been found inside the index
+	InvalidTagInIndex = stats.NewCounter32("idx.memory.invalid-tag-in-index")
+)

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -65,13 +65,13 @@ func parseExpression(expr string) expression {
 	key := expr[:pos]
 
 	// if !
-	if expr[pos] == 33 {
+	if len(expr) > pos && expr[pos] == 33 {
 		not = true
 		pos++
 	}
 
 	// expecting a =
-	if expr[pos] != 61 {
+	if len(expr) <= pos || expr[pos] != 61 {
 		return expression{operator: PARSING_ERROR}
 	}
 	pos++

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -247,7 +247,9 @@ func (q *TagQuery) filterByNotEqual(resultSet TagIDs, index TagIndex, byId map[s
 			var def *idx.Archive
 			var ok bool
 			if def, ok = byId[id.ToString()]; !ok {
-				// corrupt index
+				// should never happen because every ID in the tag index
+				// must be present in the byId lookup table
+				CorruptIndex.Inc()
 				delete(resultSet, id)
 				continue IDS
 			}
@@ -302,7 +304,9 @@ func (q *TagQuery) filterByMatch(expressions []kv, skipMatch int, resultSet TagI
 			var def *idx.Archive
 			var ok bool
 			if def, ok = byId[id.ToString()]; !ok {
-				// corrupt index
+				// should never happen because every ID in the tag index
+				// must be present in the byId lookup table
+				CorruptIndex.Inc()
 				delete(resultSet, id)
 				continue IDS
 			}
@@ -320,7 +324,9 @@ func (q *TagQuery) filterByMatch(expressions []kv, skipMatch int, resultSet TagI
 			for _, tag := range def.Tags {
 				tagSplits := strings.SplitN(tag, "=", 2)
 				if len(tagSplits) != 2 {
-					// corrupt index
+					// should never happen because every tag in the index
+					// must have a valid format
+					InvalidTagInIndex.Inc()
 					delete(resultSet, id)
 					continue IDS
 				}
@@ -350,7 +356,9 @@ func (q *TagQuery) filterByFrom(resultSet TagIDs, byId map[string]*idx.Archive) 
 		var def *idx.Archive
 		var ok bool
 		if def, ok = byId[id.ToString()]; !ok {
-			// corrupt index
+			// should never happen because every ID in the tag index
+			// must be present in the byId lookup table
+			CorruptIndex.Inc()
 			delete(resultSet, id)
 			continue
 		}

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -387,9 +387,9 @@ func (q *TagQuery) Run(index TagIndex, byId map[string]*idx.Archive) (TagIDs, er
 	}
 
 	// filter the resultSet by the from condition and all other expressions given.
-	// the order of those filters should to be increasing by the cpu required
-	// to process them. that way the most cpu intesive filters only get applied
-	// to the smallest possible resultSet
+	// filters should be in ascending order by the cpu required to process them,
+	// that way the most cpu intensive filters only get applied to the smallest
+	// possible resultSet.
 	q.filterByFrom(resultSet, byId)
 	q.filterByEqual(skipEqual, resultSet, index)
 	q.filterByNotEqual(resultSet, index, byId)

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -301,6 +301,7 @@ func (q *TagQuery) filterByMatch(resultSet TagIDs, byId map[string]*idx.Archive,
 				continue IDS
 			}
 
+		TAGS:
 			for _, tag := range def.Tags {
 				// length of key doesn't match
 				if len(tag) <= len(e.key)+1 || tag[len(e.key)] != 61 {
@@ -315,7 +316,9 @@ func (q *TagQuery) filterByMatch(resultSet TagIDs, byId map[string]*idx.Archive,
 
 				// reduce regex matching by looking up cached non-matches
 				if _, ok := notMatchingTags[value]; ok {
-					continue
+					// each key should only be present once per `def`, so if
+					// the key matches but the value doesn't we can skip the def
+					break TAGS
 				}
 
 				// reduce regex matching by looking up cached matches

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/grafana/metrictank/idx"
+	"github.com/raintank/worldping-api/pkg/log"
 )
 
 var (
@@ -301,6 +302,7 @@ func (q *TagQuery) filterByMatch(expressions []kv, skipMatch int, resultSet TagI
 				// should never happen because every ID in the tag index
 				// must be present in the byId lookup table
 				CorruptIndex.Inc()
+				log.Error(3, "memory-idx: ID %s is in tag index but not in the byId lookup table", id.String())
 				delete(resultSet, id)
 				continue IDS
 			}
@@ -360,6 +362,7 @@ func (q *TagQuery) filterByFrom(resultSet TagIDs, byId map[string]*idx.Archive) 
 			// should never happen because every ID in the tag index
 			// must be present in the byId lookup table
 			CorruptIndex.Inc()
+			log.Error(3, "memory-idx: ID %s is in tag index but not in the byId lookup table", id.String())
 			delete(resultSet, id)
 			continue
 		}

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -239,8 +239,17 @@ func (q *TagQuery) filterByEqual(expressions []kv, skipEqual int, resultSet TagI
 			continue
 		}
 
+		indexIds := index[e.key][e.value]
+
+		// shortcut if key=value combo does not exist at all
+		if len(indexIds) == 0 && !not {
+			for id := range resultSet {
+				delete(resultSet, id)
+			}
+		}
+
 		for id := range resultSet {
-			if _, ok := index[e.key][e.value][id]; ok == not {
+			if _, ok := indexIds[id]; ok == not {
 				delete(resultSet, id)
 			}
 		}

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -386,22 +386,20 @@ func (q *TagQuery) Run(index TagIndex, byId map[string]*idx.Archive) TagIDs {
 
 	if q.startWith == EQUAL {
 		resultSet = q.getInitialByEqual(index, q.equal[0])
+		q.equal = q.equal[1:]
 	} else {
 		resultSet = q.getInitialByMatch(index, q.match[0])
+		q.match = q.match[1:]
 	}
 
 	// filter the resultSet by the from condition and all other expressions given.
 	// filters should be in ascending order by the cpu required to process them,
 	// that way the most cpu intensive filters only get applied to the smallest
 	// possible resultSet.
-	if len(q.equal) > 1 {
-		q.filterByEqual(resultSet, index, q.equal[1:], false)
-	}
+	q.filterByEqual(resultSet, index, q.equal, false)
 	q.filterByEqual(resultSet, index, q.notEqual, true)
 	q.filterByFrom(resultSet, byId)
-	if len(q.match) > 1 {
-		q.filterByMatch(resultSet, byId, q.match[1:], false)
-	}
+	q.filterByMatch(resultSet, byId, q.match, false)
 	q.filterByMatch(resultSet, byId, q.notMatch, true)
 	return resultSet
 }

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -159,8 +159,8 @@ func NewTagQuery(expressions []string, from int64) (TagQuery, error) {
 	return q, nil
 }
 
-func (q *TagQuery) getInitialByMatch(index TagIndex) (int, map[string]struct{}, error) {
-	resultSet := make(map[string]struct{})
+func (q *TagQuery) getInitialByMatch(index TagIndex) (int, TagIDs, error) {
+	resultSet := make(TagIDs)
 	lowestCount := math.MaxUint32
 	startId := 0
 
@@ -200,8 +200,8 @@ func (q *TagQuery) getInitialByMatch(index TagIndex) (int, map[string]struct{}, 
 	return startId, resultSet, nil
 }
 
-func (q *TagQuery) getInitialByEqual(index TagIndex) (int, map[string]struct{}) {
-	resultSet := make(map[string]struct{})
+func (q *TagQuery) getInitialByEqual(index TagIndex) (int, TagIDs) {
+	resultSet := make(TagIDs)
 	lowestCount := math.MaxUint32
 	startId := 0
 
@@ -222,7 +222,7 @@ func (q *TagQuery) getInitialByEqual(index TagIndex) (int, map[string]struct{}) 
 	return startId, resultSet
 }
 
-func (q *TagQuery) filterByEqual(skipEqual int, resultSet map[string]struct{}, index TagIndex) {
+func (q *TagQuery) filterByEqual(skipEqual int, resultSet TagIDs, index TagIndex) {
 	for i, e := range q.equal {
 		if i == skipEqual {
 			continue
@@ -236,7 +236,7 @@ func (q *TagQuery) filterByEqual(skipEqual int, resultSet map[string]struct{}, i
 	}
 }
 
-func (q *TagQuery) filterByNotEqual(resultSet map[string]struct{}, index TagIndex, byId map[string]*idx.Archive) {
+func (q *TagQuery) filterByNotEqual(resultSet TagIDs, index TagIndex, byId map[string]*idx.Archive) {
 	for _, e := range q.notEqual {
 		fullTag := e.key + "=" + e.value
 	IDS:
@@ -258,7 +258,7 @@ func (q *TagQuery) filterByNotEqual(resultSet map[string]struct{}, index TagInde
 	}
 }
 
-func (q *TagQuery) filterByMatch(skipMatch int, resultSet map[string]struct{}, byId map[string]*idx.Archive) error {
+func (q *TagQuery) filterByMatch(skipMatch int, resultSet TagIDs, byId map[string]*idx.Archive) error {
 	for i, e := range q.match {
 		if i == skipMatch {
 			continue
@@ -278,7 +278,7 @@ func (q *TagQuery) filterByMatch(skipMatch int, resultSet map[string]struct{}, b
 			}
 		}
 
-		matchingTags := make(map[string]struct{})
+		matchingTags := make(TagIDs)
 	IDS:
 		for id := range resultSet {
 			var def *idx.Archive
@@ -315,7 +315,7 @@ func (q *TagQuery) filterByMatch(skipMatch int, resultSet map[string]struct{}, b
 	return nil
 }
 
-func (q *TagQuery) filterByNotMatch(resultSet map[string]struct{}, byId map[string]*idx.Archive) error {
+func (q *TagQuery) filterByNotMatch(resultSet TagIDs, byId map[string]*idx.Archive) error {
 	for _, e := range q.notMatch {
 		var shortCut bool
 		var re *regexp.Regexp
@@ -331,7 +331,7 @@ func (q *TagQuery) filterByNotMatch(resultSet map[string]struct{}, byId map[stri
 			}
 		}
 
-		matchingTags := make(map[string]struct{})
+		matchingTags := make(TagIDs)
 	IDS:
 		for id := range resultSet {
 			var def *idx.Archive
@@ -369,7 +369,7 @@ func (q *TagQuery) filterByNotMatch(resultSet map[string]struct{}, byId map[stri
 	return nil
 }
 
-func (q *TagQuery) filterByFrom(resultSet map[string]struct{}, byId map[string]*idx.Archive) {
+func (q *TagQuery) filterByFrom(resultSet TagIDs, byId map[string]*idx.Archive) {
 	if q.from <= 0 {
 		return
 	}
@@ -389,9 +389,9 @@ func (q *TagQuery) filterByFrom(resultSet map[string]struct{}, byId map[string]*
 	}
 }
 
-func (q *TagQuery) Run(index TagIndex, byId map[string]*idx.Archive) (map[string]struct{}, error) {
+func (q *TagQuery) Run(index TagIndex, byId map[string]*idx.Archive) (TagIDs, error) {
 	var skipMatch, skipEqual = -1, -1
-	var resultSet map[string]struct{}
+	var resultSet TagIDs
 	var err error
 
 	// find the best expression to start with

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -141,7 +141,7 @@ func NewTagQuery(expressions []string, from int64) (TagQuery, error) {
 			}
 		} else {
 			// always anchor all regular expressions at the beginning
-			if (e.operator == MATCH || e.operator == NOT_MATCH) && len(e.value) > 0 && e.value[0] != byte('^') {
+			if (e.operator == MATCH || e.operator == NOT_MATCH) && e.value[0] != byte('^') {
 				e.value = "^" + e.value
 			}
 

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -289,7 +289,7 @@ func (q *TagQuery) filterByMatch(expressions []kv, skipMatch int, resultSet TagI
 		for id := range resultSet {
 			var def *idx.Archive
 			var ok bool
-			if def, ok = byId[id.ToString()]; !ok {
+			if def, ok = byId[id.String()]; !ok {
 				// should never happen because every ID in the tag index
 				// must be present in the byId lookup table
 				CorruptIndex.Inc()
@@ -352,7 +352,7 @@ func (q *TagQuery) filterByFrom(resultSet TagIDs, byId map[string]*idx.Archive) 
 	for id := range resultSet {
 		var def *idx.Archive
 		var ok bool
-		if def, ok = byId[id.ToString()]; !ok {
+		if def, ok = byId[id.String()]; !ok {
 			// should never happen because every ID in the tag index
 			// must be present in the byId lookup table
 			CorruptIndex.Inc()

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -47,12 +47,14 @@ func parseExpression(expr string) expression {
 
 	// scan up to operator to get key
 	for ; pos < len(expr); pos++ {
-		// ! || =
-		if expr[pos] == 33 || expr[pos] == 61 {
-			// key must not be empty
-			if pos == 0 {
-				return expression{operator: PARSING_ERROR}
-			}
+		// =
+		if expr[pos] == 61 {
+			break
+		}
+
+		// !
+		if expr[pos] == 33 {
+			not = true
 			break
 		}
 
@@ -62,11 +64,15 @@ func parseExpression(expr string) expression {
 		}
 	}
 
+	// key must not be empty
+	if pos == 0 {
+		return expression{operator: PARSING_ERROR}
+	}
+
 	key := expr[:pos]
 
-	// if !
-	if len(expr) > pos && expr[pos] == 33 {
-		not = true
+	// shift over the ! character
+	if not {
 		pos++
 	}
 

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -317,14 +317,20 @@ func (q *TagQuery) filterByMatch(resultSet TagIDs, byId map[string]*idx.Archive,
 					continue
 				}
 
+				if e.key != tag[:len(e.key)] {
+					continue
+				}
+
+				value := tag[len(e.key)+1:]
+
 				// reduce regex matching by looking up cached non-matches
-				if _, ok := notMatchingTags[tag]; ok {
+				if _, ok := notMatchingTags[value]; ok {
 					continue
 				}
 
 				// value == nil means that this expression can be short cut
 				// by not evaluating it
-				if e.key == tag[:len(e.key)] && (e.value == nil || e.value.MatchString(tag[len(e.key)+1:])) {
+				if e.value == nil || e.value.MatchString(value) {
 					if len(matchingTags) < matchCacheSize {
 						matchingTags[tag] = struct{}{}
 					}
@@ -334,7 +340,7 @@ func (q *TagQuery) filterByMatch(resultSet TagIDs, byId map[string]*idx.Archive,
 					continue IDS
 				} else {
 					if len(notMatchingTags) < matchCacheSize {
-						notMatchingTags[tag] = struct{}{}
+						notMatchingTags[value] = struct{}{}
 					}
 				}
 			}

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -302,7 +302,7 @@ func (q *TagQuery) filterByMatch(expressions []kv, skipMatch int, resultSet TagI
 				// should never happen because every ID in the tag index
 				// must be present in the byId lookup table
 				CorruptIndex.Inc()
-				log.Error(3, "memory-idx: ID %s is in tag index but not in the byId lookup table", id.String())
+				log.Error(3, "memory-idx: ID %q is in tag index but not in the byId lookup table", id.String())
 				delete(resultSet, id)
 				continue IDS
 			}
@@ -362,7 +362,7 @@ func (q *TagQuery) filterByFrom(resultSet TagIDs, byId map[string]*idx.Archive) 
 			// should never happen because every ID in the tag index
 			// must be present in the byId lookup table
 			CorruptIndex.Inc()
-			log.Error(3, "memory-idx: ID %s is in tag index but not in the byId lookup table", id.String())
+			log.Error(3, "memory-idx: ID %q is in tag index but not in the byId lookup table", id.String())
 			delete(resultSet, id)
 			continue
 		}

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -241,7 +241,7 @@ func (q *TagQuery) filterByEqual(expressions []kv, skipEqual int, resultSet TagI
 		}
 
 		for id := range resultSet {
-			if _, ok := index[e.key][e.value][id]; (!ok && !not) || (ok && not) {
+			if _, ok := index[e.key][e.value][id]; ok == not {
 				delete(resultSet, id)
 			}
 		}

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -302,16 +302,6 @@ func (q *TagQuery) filterByMatch(resultSet TagIDs, byId map[string]*idx.Archive,
 			}
 
 			for _, tag := range def.Tags {
-				// reduce regex matching by looking up cached matches
-				if _, ok := matchingTags[tag]; ok {
-					if not {
-						delete(resultSet, id)
-					}
-					continue IDS
-				}
-			}
-
-			for _, tag := range def.Tags {
 				// length of key doesn't match
 				if len(tag) <= len(e.key)+1 || tag[len(e.key)] != 61 {
 					continue
@@ -328,11 +318,19 @@ func (q *TagQuery) filterByMatch(resultSet TagIDs, byId map[string]*idx.Archive,
 					continue
 				}
 
+				// reduce regex matching by looking up cached matches
+				if _, ok := matchingTags[value]; ok {
+					if not {
+						delete(resultSet, id)
+					}
+					continue IDS
+				}
+
 				// value == nil means that this expression can be short cut
 				// by not evaluating it
 				if e.value == nil || e.value.MatchString(value) {
 					if len(matchingTags) < matchCacheSize {
-						matchingTags[tag] = struct{}{}
+						matchingTags[value] = struct{}{}
 					}
 					if not {
 						delete(resultSet, id)

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -39,8 +39,8 @@ type TagQuery struct {
 	notMatch []kv
 }
 
-// returns expression,
-// in case of error the operator will be PARSING_ERROR
+// parseExpression returns an expression that's been generated from the given
+// string, in case of error the operator will be PARSING_ERROR.
 func parseExpression(expr string) expression {
 	var pos int
 	regex, not := false, false
@@ -223,10 +223,10 @@ func (q *TagQuery) getInitialByEqual(index TagIndex) (int, TagIDs) {
 	return startId, resultSet
 }
 
-// filters a list of metric ids by the given expressions. if "not" is true it will
-// remove all ids of which at least one expression is equal to one of its tags.
-// if "not" is false the functionality is inverted, so it removes all the ids
-// where no tag is equal to at least one of the expressions.
+// filterByEqual filters a list of metric ids by the given expressions. if "not"
+// is true it will remove all ids of which at least one expression is equal to
+// one of its tags. if "not" is false the functionality is inverted, so it
+// removes all the ids where no tag is equal to at least one of the expressions.
 //
 // expressions: the list of key & value pairs
 // skipEqual:   an integer specifying an expression index that should be skipped
@@ -248,8 +248,8 @@ func (q *TagQuery) filterByEqual(expressions []kv, skipEqual int, resultSet TagI
 	}
 }
 
-// filters a list of metric ids by the given expressions. it is assumed that the
-// given expressions are all based on regular expressions.
+// filterByMatch filters a list of metric ids by the given expressions. it is
+// assumed that the given expressions are all based on regular expressions.
 //
 // expressions: the list of key & value pairs
 // skipMatch:   an integer specifying an expression index that should be skipped

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -207,7 +207,9 @@ func (q *TagQuery) getInitialByMatch(index TagIndex) (int, TagIDs) {
 		}
 	}
 
-	// shortcut if value == nil
+	// shortcut if value == nil.
+	// this will simply match any value, like ^.+. since we know that every value
+	// in the index must not be empty, we can skip the matching.
 	if q.match[startId].value == nil {
 		for _, ids := range index[q.match[startId].key] {
 			for id := range ids {

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -295,7 +295,7 @@ func (q *TagQuery) filterByMatch(resultSet TagIDs, byId map[string]*idx.Archive,
 			if def, ok = byId[id.String()]; !ok {
 				// should never happen because every ID in the tag index
 				// must be present in the byId lookup table
-				CorruptIndex.Inc()
+				corruptIndex.Inc()
 				log.Error(3, "memory-idx: ID %q is in tag index but not in the byId lookup table", id.String())
 				delete(resultSet, id)
 				continue IDS
@@ -360,7 +360,7 @@ func (q *TagQuery) filterByFrom(resultSet TagIDs, byId map[string]*idx.Archive) 
 		if def, ok = byId[id.String()]; !ok {
 			// should never happen because every ID in the tag index
 			// must be present in the byId lookup table
-			CorruptIndex.Inc()
+			corruptIndex.Inc()
 			log.Error(3, "memory-idx: ID %q is in tag index but not in the byId lookup table", id.String())
 			delete(resultSet, id)
 			continue

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -246,7 +246,7 @@ func (q *TagQuery) filterByNotEqual(resultSet TagIDs, index TagIndex, byId map[s
 		for id := range resultSet {
 			var def *idx.Archive
 			var ok bool
-			if def, ok = byId[id]; !ok {
+			if def, ok = byId[id.ToString()]; !ok {
 				// corrupt index
 				delete(resultSet, id)
 				continue IDS
@@ -296,12 +296,12 @@ func (q *TagQuery) filterByMatch(expressions []kv, skipMatch int, resultSet TagI
 		// this is based on the assumption that many matching tags will be repeated
 		// over multiple series, so there's no need to run the regex for each of them
 		// because once we know that a tag matches we can just compare strings
-		matchingTags := make(TagIDs)
+		matchingTags := make(map[string]struct{})
 	IDS:
 		for id := range resultSet {
 			var def *idx.Archive
 			var ok bool
-			if def, ok = byId[id]; !ok {
+			if def, ok = byId[id.ToString()]; !ok {
 				// corrupt index
 				delete(resultSet, id)
 				continue IDS
@@ -349,7 +349,7 @@ func (q *TagQuery) filterByFrom(resultSet TagIDs, byId map[string]*idx.Archive) 
 	for id := range resultSet {
 		var def *idx.Archive
 		var ok bool
-		if def, ok = byId[id]; !ok {
+		if def, ok = byId[id.ToString()]; !ok {
 			// corrupt index
 			delete(resultSet, id)
 			continue

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -377,9 +377,9 @@ func (q *TagQuery) Run(index TagIndex, byId map[string]*idx.Archive) (TagIDs, er
 	// filters should be in ascending order by the cpu required to process them,
 	// that way the most cpu intensive filters only get applied to the smallest
 	// possible resultSet.
-	q.filterByFrom(resultSet, byId)
 	q.filterByEqual(q.equal, skipEqual, resultSet, index, false)
 	q.filterByEqual(q.notEqual, -1, resultSet, index, true)
+	q.filterByFrom(resultSet, byId)
 	err = q.filterByMatch(q.match, skipMatch, resultSet, byId, false)
 	if err != nil {
 		return nil, err

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -85,10 +85,7 @@ func queryAndCompareResults(t *testing.T, q TagQuery, expectedData TagIDs) {
 	t.Helper()
 	tagIdx, byId := getTestIndex(t)
 
-	res, err := q.Run(tagIdx, byId)
-	if err != nil {
-		t.Fatalf("Unexpected error when running query: %q", err)
-	}
+	res := q.Run(tagIdx, byId)
 
 	if !reflect.DeepEqual(expectedData, res) {
 		t.Fatalf("Returned data does not match expected data:\nExpected: %+v\nGot: %+v", expectedData, res)
@@ -161,25 +158,25 @@ func TestTagExpressionQueryByTagWithFrom(t *testing.T) {
 	tagIdx, byId := getTestIndex(t)
 
 	q, _ := NewTagQuery([]string{"key1=value1"}, 4)
-	res, _ := q.Run(tagIdx, byId)
+	res := q.Run(tagIdx, byId)
 	if len(res) != 1 {
 		t.Fatalf("Expected %d results, but got %d", 1, len(res))
 	}
 
 	q, _ = NewTagQuery([]string{"key1=value1"}, 3)
-	res, _ = q.Run(tagIdx, byId)
+	res = q.Run(tagIdx, byId)
 	if len(res) != 2 {
 		t.Fatalf("Expected %d results, but got %d", 2, len(res))
 	}
 
 	q, _ = NewTagQuery([]string{"key1=value1"}, 2)
-	res, _ = q.Run(tagIdx, byId)
+	res = q.Run(tagIdx, byId)
 	if len(res) != 3 {
 		t.Fatalf("Expected %d results, but got %d", 3, len(res))
 	}
 
 	q, _ = NewTagQuery([]string{"key1=value1"}, 1)
-	res, _ = q.Run(tagIdx, byId)
+	res = q.Run(tagIdx, byId)
 	if len(res) != 4 {
 		t.Fatalf("Expected %d results, but got %d", 4, len(res))
 	}

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -60,7 +60,7 @@ func getTestIndex(t *testing.T) (TagIndex, map[string]*idx.Archive) {
 	byId := make(map[string]*idx.Archive)
 
 	for _, d := range data {
-		idStr := d.id.ToString()
+		idStr := d.id.String()
 		byId[idStr] = &idx.Archive{}
 		byId[idStr].Tags = d.tags
 		byId[idStr].LastUpdate = d.lastUpdate
@@ -229,7 +229,7 @@ func TestGetByTag(t *testing.T) {
 		ids[i], _ = idx.NewMetricIDFromString(fmt.Sprintf(idString, i))
 		mds[i].Metric = fmt.Sprintf("metric.%d", i)
 		mds[i].Name = mds[i].Metric
-		mds[i].Id = ids[i].ToString()
+		mds[i].Id = ids[i].String()
 		mds[i].OrgId = 1
 		mds[i].Interval = 1
 		mds[i].Time = 12345

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -355,6 +355,7 @@ func TestExpressionParsing(t *testing.T) {
 		key        string
 		value      string
 		operator   int
+		err        error
 	}
 
 	testCases := []testCase{
@@ -363,58 +364,62 @@ func TestExpressionParsing(t *testing.T) {
 			key:        "key",
 			value:      "value",
 			operator:   EQUAL,
+			err:        nil,
 		}, {
 			expression: "key!=",
 			key:        "key",
 			value:      "",
 			operator:   NOT_EQUAL,
+			err:        nil,
 		}, {
 			expression: "key=",
 			key:        "key",
 			value:      "",
 			operator:   EQUAL,
+			err:        nil,
 		}, {
 			expression: "key=~",
 			key:        "key",
 			value:      "",
 			operator:   MATCH,
+			err:        nil,
 		}, {
 			expression: "key=~v_alue",
 			key:        "key",
 			value:      "v_alue",
 			operator:   MATCH,
+			err:        nil,
 		}, {
 			expression: "k!=~v",
 			key:        "k",
 			value:      "v",
 			operator:   NOT_MATCH,
+			err:        nil,
 		}, {
 			expression: "key!!=value",
-			key:        "",
-			value:      "",
-			operator:   PARSING_ERROR,
+			err:        errInvalidQuery,
 		}, {
 			expression: "key==value",
 			key:        "key",
 			value:      "=value",
 			operator:   EQUAL,
+			err:        nil,
 		}, {
 			expression: "key=~=value",
 			key:        "key",
 			value:      "=value",
 			operator:   MATCH,
+			err:        nil,
 		}, {
 			expression: "key",
-			key:        "",
-			value:      "",
-			operator:   PARSING_ERROR,
+			err:        errInvalidQuery,
 		},
 	}
 
 	for _, tc := range testCases {
-		expression := parseExpression(tc.expression)
-		if expression.key != tc.key || expression.value != tc.value || expression.operator != tc.operator {
-			t.Fatalf("Expected the values %s, %s, %d, but got %s, %s, %d", tc.key, tc.value, tc.operator, expression.key, expression.value, expression.operator)
+		expression, err := parseExpression(tc.expression)
+		if err != tc.err || (err == nil && (expression.key != tc.key || expression.value != tc.value || expression.operator != tc.operator)) {
+			t.Fatalf("Expected the values %s, %s, %d, %q, but got %s, %s, %d, %q", tc.key, tc.value, tc.operator, tc.err, expression.key, expression.value, expression.operator, err)
 		}
 	}
 }

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -315,10 +315,10 @@ func TestExpressionParsing(t *testing.T) {
 
 func BenchmarkExpressionParsing(b *testing.B) {
 	expressions := [][]string{
-		[]string{"key=value", "key!=value"},
-		[]string{"key=~value", "key!=~value"},
-		[]string{"key1=~", "key2=~"},
-		[]string{"key1!=~aaa", "key2=~abc"},
+		{"key=value", "key!=value"},
+		{"key=~value", "key!=~value"},
+		{"key1=~", "key2=~"},
+		{"key1!=~aaa", "key2=~abc"},
 	}
 
 	b.ReportAllocs()

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -310,3 +310,20 @@ func TestExpressionParsing(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkExpressionParsing(b *testing.B) {
+	expressions := [][]string{
+		[]string{"key=value", "key!=value"},
+		[]string{"key=~value", "key!=~value"},
+		[]string{"key1=~", "key2=~"},
+		[]string{"key1!=~aaa", "key2=~abc"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < 4; i++ {
+			NewTagQuery(expressions[i])
+		}
+	}
+}

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -287,7 +287,7 @@ func TestGetByTag(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Got an unexpected error with query %s: %s", tc.expressions, err)
 		}
-		res := ix.IdsByTagQuery(1, tagQuery)
+		res := ix.idsByTagQuery(1, tagQuery)
 		if len(res) != len(tc.expectation) {
 			t.Fatalf("Result does not match expectation for expressions %+v\nGot:\n%+v\nExpected:\n%+v\n", tc.expressions, res, tc.expectation)
 		}
@@ -319,7 +319,7 @@ func TestDeleteTaggedSeries(t *testing.T) {
 	}
 
 	tagQuery, _ := NewTagQuery([]string{"key1=value1", "key2=value2"}, 0)
-	res := ix.IdsByTagQuery(orgId, tagQuery)
+	res := ix.idsByTagQuery(orgId, tagQuery)
 
 	if len(res) != 1 {
 		t.Fatalf("Expected to get 1 result, but got %d", len(res))
@@ -338,7 +338,7 @@ func TestDeleteTaggedSeries(t *testing.T) {
 		t.Fatalf("Expected 1 metric to get deleted, but got %d", len(deleted))
 	}
 
-	res = ix.IdsByTagQuery(orgId, tagQuery)
+	res = ix.idsByTagQuery(orgId, tagQuery)
 
 	if len(res) != 0 {
 		t.Fatalf("Expected to get 0 results, but got %d", len(res))

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -403,6 +403,11 @@ func TestExpressionParsing(t *testing.T) {
 			key:        "key",
 			value:      "=value",
 			operator:   MATCH,
+		}, {
+			expression: "key",
+			key:        "",
+			value:      "",
+			operator:   PARSING_ERROR,
 		},
 	}
 

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -408,9 +408,9 @@ func TestExpressionParsing(t *testing.T) {
 			operator:   PARSING_ERROR,
 		}, {
 			expression: "key==value",
-			key:        "",
-			value:      "",
-			operator:   PARSING_ERROR,
+			key:        "key",
+			value:      "=value",
+			operator:   EQUAL,
 		}, {
 			expression: "key=~=value",
 			key:        "key",

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -151,9 +151,7 @@ func TestQueryByTagWithUnequalEmpty(t *testing.T) {
 }
 
 func TestQueryByTagInvalidQuery(t *testing.T) {
-	q, _ := NewTagQuery([]string{"key!=value1"}, 0)
-	tagIdx, byId := getTestIndex(t)
-	_, err := q.Run(tagIdx, byId)
+	_, err := NewTagQuery([]string{"key!=value1"}, 0)
 	if err != errInvalidQuery {
 		t.Fatalf("Expected an error, but didn't get it")
 	}

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -108,7 +108,9 @@ func TestQueryByTagWithUnequalEmpty(t *testing.T) {
 }
 
 func TestQueryByTagInvalidQuery(t *testing.T) {
-	_, err := NewTagQuery([]string{"key!=value1"})
+	q, _ := NewTagQuery([]string{"key!=value1"})
+	tagIdx, byId := getTestIndex()
+	_, err := q.Run(tagIdx, byId)
 	if err != errInvalidQuery {
 		t.Fatalf("Expected an error, but didn't get it")
 	}
@@ -304,9 +306,9 @@ func TestExpressionParsing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		k, v, o := parseExpression(tc.expression)
-		if k != tc.key || v != tc.value || o != tc.operator {
-			t.Fatalf("Expected the values %s, %s, %d, but got %s, %s, %d", tc.key, tc.value, tc.operator, k, v, o)
+		expression := parseExpression(tc.expression)
+		if expression.key != tc.key || expression.value != tc.value || expression.operator != tc.operator {
+			t.Fatalf("Expected the values %s, %s, %d, but got %s, %s, %d", tc.key, tc.value, tc.operator, expression.key, expression.value, expression.operator)
 		}
 	}
 }

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -101,8 +101,6 @@ func TestQueryByTagSimpleEqual(t *testing.T) {
 	expect := make(TagIDs)
 	expect[ids[1]] = struct{}{}
 	expect[ids[3]] = struct{}{}
-	/*expect["id2"] = struct{}{}
-	expect["id4"] = struct{}{}*/
 	queryAndCompareResults(t, q, expect)
 }
 
@@ -110,8 +108,6 @@ func TestQueryByTagSimplePattern(t *testing.T) {
 	ids := getTestIDs(t)
 	q, _ := NewTagQuery([]string{"key4=~value[43]", "key3=~value[1-3]"}, 0)
 	expect := make(TagIDs)
-	/*expect["id7"] = struct{}{}
-	expect["id4"] = struct{}{}*/
 	expect[ids[6]] = struct{}{}
 	expect[ids[3]] = struct{}{}
 	queryAndCompareResults(t, q, expect)
@@ -121,9 +117,6 @@ func TestQueryByTagSimpleUnequal(t *testing.T) {
 	ids := getTestIDs(t)
 	q, _ := NewTagQuery([]string{"key1=value1", "key4!=value4"}, 0)
 	expect := make(TagIDs)
-	/*expect["id1"] = struct{}{}
-	expect["id2"] = struct{}{}
-	expect["id4"] = struct{}{}*/
 	expect[ids[0]] = struct{}{}
 	expect[ids[1]] = struct{}{}
 	expect[ids[3]] = struct{}{}
@@ -134,7 +127,6 @@ func TestQueryByTagSimpleNotPattern(t *testing.T) {
 	ids := getTestIDs(t)
 	q, _ := NewTagQuery([]string{"key1=~value?", "key4!=~value[0-9]", "key2!=~va.+"}, 0)
 	expect := make(TagIDs)
-	//expect["id2"] = struct{}{}
 	expect[ids[1]] = struct{}{}
 	queryAndCompareResults(t, q, expect)
 }
@@ -143,9 +135,6 @@ func TestQueryByTagWithEqualEmpty(t *testing.T) {
 	ids := getTestIDs(t)
 	q, _ := NewTagQuery([]string{"key1=value1", "key2=", "key2=~"}, 0)
 	expect := make(TagIDs)
-	/*expect["id2"] = struct{}{}
-	expect["id3"] = struct{}{}
-	expect["id4"] = struct{}{}*/
 	expect[ids[1]] = struct{}{}
 	expect[ids[2]] = struct{}{}
 	expect[ids[3]] = struct{}{}
@@ -156,8 +145,6 @@ func TestQueryByTagWithUnequalEmpty(t *testing.T) {
 	ids := getTestIDs(t)
 	q, _ := NewTagQuery([]string{"key1=value1", "key3!=", "key3!=~"}, 0)
 	expect := make(TagIDs)
-	/*expect["id2"] = struct{}{}
-	expect["id4"] = struct{}{}*/
 	expect[ids[1]] = struct{}{}
 	expect[ids[3]] = struct{}{}
 	queryAndCompareResults(t, q, expect)

--- a/input/carbon/carbon.go
+++ b/input/carbon/carbon.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"io"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/grafana/metrictank/cluster"
@@ -181,16 +182,16 @@ func (c *Carbon) handle(conn net.Conn) {
 			log.Error(4, "carbon-in: invalid metric: %s", err.Error())
 			continue
 		}
-		name := string(key)
+		nameSplits := strings.Split(string(key), ";")
 		md := &schema.MetricData{
-			Name:     name,
-			Metric:   name,
-			Interval: c.intervalGetter.GetInterval(name),
+			Name:     nameSplits[0],
+			Metric:   nameSplits[0],
+			Interval: c.intervalGetter.GetInterval(nameSplits[0]),
 			Value:    val,
 			Unit:     "unknown",
 			Time:     int64(ts),
 			Mtype:    "gauge",
-			Tags:     []string{},
+			Tags:     nameSplits[1:],
 			OrgId:    1, // admin org
 		}
 		md.SetId()

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	maxSize        uint64
-	cacheMetricBug = stats.NewCounter32("cache.ops.metric.searchForward-bug-surpressed")
+	maxSize      uint64
+	searchFwdBug = stats.NewCounter32("recovered_errors.cache.metric.searchForwardBug")
 )
 
 func init() {

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -208,7 +208,7 @@ func (mc *CCacheMetric) searchForward(ctx context.Context, metric string, from, 
 			log.Warn("CCacheMetric: suspected bug suppressed. searchForward(%q, %d, %d, res) ts is %d while Next is %d", metric, from, until, ts, mc.chunks[ts].Next)
 			span := opentracing.SpanFromContext(ctx)
 			span.SetTag("searchForwardBug", true)
-			cacheMetricBug.Inc()
+			searchFwdBug.Inc()
 			break
 		}
 	}

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -294,3 +294,7 @@ create-keyspace = true
 ### in-memory only
 [memory-idx]
 enabled = false
+# enables/disables querying based on tags
+tag-support = false
+# size of regular expression cache in tag query evaluation
+match-cache-size = 1000

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -291,3 +291,7 @@ create-keyspace = true
 ### in-memory only
 [memory-idx]
 enabled = false
+# enables/disables querying based on tags
+tag-support = false
+# size of regular expression cache in tag query evaluation
+match-cache-size = 1000

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -291,3 +291,7 @@ create-keyspace = true
 ### in-memory only
 [memory-idx]
 enabled = false
+# enables/disables querying based on tags
+tag-support = false
+# size of regular expression cache in tag query evaluation
+match-cache-size = 1000

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -585,10 +585,10 @@
 			"revisionTime": "2016-07-14T10:00:31Z"
 		},
 		{
-			"checksumSHA1": "coHpC7KbWRXTjC0JM/bwnBn8zmY=",
+			"checksumSHA1": "RcxQU1xxRElWcoMLYi4Cl6F5QXM=",
 			"path": "gopkg.in/raintank/schema.v1",
-			"revision": "a323316458b5df84827551e9b6b5f61cb2de423b",
-			"revisionTime": "2017-01-12T12:37:55Z"
+			"revision": "68fc00d6506890a1cd6e79332697047bb03ee172",
+			"revisionTime": "2017-10-13T17:11:03Z"
 		},
 		{
 			"checksumSHA1": "MjwLYwIckCtBwXhQMt5ji/L5lJA=",


### PR DESCRIPTION
Adds a tag index, together with the functions to query it. 
It does not expose any API endpoints yet, those will follow in a separate PR (from branch https://github.com/grafana/metrictank/compare/tag_api_endpoints).