### PR TITLE
better mutex and block pprof endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -71,9 +71,11 @@ func NewServer() (*Server, error) {
 	m := macaron.New()
 	m.Use(macaron.Logger())
 	m.Use(macaron.Recovery())
-	// route pprof to where it belongs
+	// route pprof to where it belongs, except for our own extensions
 	m.Use(func(ctx *macaron.Context) {
-		if strings.HasPrefix(ctx.Req.URL.Path, "/debug/") {
+		if strings.HasPrefix(ctx.Req.URL.Path, "/debug/") &&
+			!strings.HasPrefix(ctx.Req.URL.Path, "/debug/pprof/block") &&
+			!strings.HasPrefix(ctx.Req.URL.Path, "/debug/pprof/mutex") {
 			http.DefaultServeMux.ServeHTTP(ctx.Resp, ctx.Req.Request)
 		}
 	})

--- a/api/pprof.go
+++ b/api/pprof.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"net/http"
+	"runtime"
+	rpprof "runtime/pprof"
+	"strconv"
+	"time"
+)
+
+// blockhandler writes out a blocking profile
+// similar to the standard library handler,
+// except it allows to specify a rate.
+// The profiler aims to sample an average of one blocking event
+// per rate nanoseconds spent blocked.
+//
+// To include every blocking event in the profile, pass rate = 1.
+// Defaults to 10k (10 microseconds)
+func blockHandler(w http.ResponseWriter, r *http.Request) {
+	debug, _ := strconv.Atoi(r.FormValue("debug"))
+	sec, _ := strconv.ParseInt(r.FormValue("seconds"), 10, 64)
+	if sec == 0 {
+		sec = 30
+	}
+	rate, _ := strconv.Atoi(r.FormValue("rate"))
+	if rate == 0 {
+		rate = 10000
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	runtime.SetBlockProfileRate(rate)
+	time.Sleep(time.Duration(sec) * time.Second)
+	runtime.SetBlockProfileRate(0)
+	p := rpprof.Lookup("block")
+	p.WriteTo(w, debug)
+}
+
+// mutexHandler writes out a mutex profile similar to the
+// standard library handler,
+// except it allows to specify a mutex profiling rate.
+// On average 1/rate events are reported.  The default is 1000
+func mutexHandler(w http.ResponseWriter, r *http.Request) {
+	debug, _ := strconv.Atoi(r.FormValue("debug"))
+	sec, _ := strconv.ParseInt(r.FormValue("seconds"), 10, 64)
+	if sec == 0 {
+		sec = 30
+	}
+	rate, _ := strconv.Atoi(r.FormValue("rate"))
+	if rate == 0 {
+		rate = 1000
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	runtime.SetMutexProfileFraction(rate)
+	time.Sleep(time.Duration(sec) * time.Second)
+	runtime.SetMutexProfileFraction(0)
+	p := rpprof.Lookup("mutex")
+	p.WriteTo(w, debug)
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -27,6 +27,8 @@ func (s *Server) RegisterRoutes() {
 	r.Get("/", s.appStatus)
 	r.Get("/node", s.getNodeStatus)
 	r.Post("/node", bind(models.NodeStatus{}), s.setNodeStatus)
+	r.Get("/debug/pprof/block", blockHandler)
+	r.Get("/debug/pprof/mutex", mutexHandler)
 
 	r.Get("/cluster", s.getClusterStatus)
 	r.Post("/cluster", bind(models.ClusterMembers{}), s.postClusterMembers)


### PR DESCRIPTION
* allow specifying block rate, e.g. :
curl http://localhost:6060/debug/pprof/block\?seconds\=5\&rate\=1

* allow specifying mutex rate, e.g. :
curl http://localhost:6060/debug/pprof/mutex\?seconds\=30\&rate\=1