### PR TITLE
remove directory prefix when writing metric names

### DIFF
--- a/cmd/mt-whisper-importer-reader/main.go
+++ b/cmd/mt-whisper-importer-reader/main.go
@@ -201,11 +201,12 @@ func processFromChan(files chan string, wg *sync.WaitGroup) {
 // generate the metric name based on the file name and given prefix
 func getMetricName(file string) string {
 	// remove all leading '/' from file name
+	file = strings.TrimPrefix(file, *whisperDirectory)
 	for file[0] == '/' {
 		file = file[1:]
 	}
 
-	return *namePrefix + strings.Replace(strings.TrimSuffix(strings.TrimPrefix(file, *whisperDirectory), ".wsp"), "/", ".", -1)
+	return *namePrefix + strings.Replace(strings.TrimSuffix(file, ".wsp"), "/", ".", -1)
 }
 
 // pointSorter sorts points by timestamp

--- a/cmd/mt-whisper-importer-reader/main.go
+++ b/cmd/mt-whisper-importer-reader/main.go
@@ -205,7 +205,7 @@ func getMetricName(file string) string {
 		file = file[1:]
 	}
 
-	return *namePrefix + strings.Replace(strings.TrimSuffix(file, ".wsp"), "/", ".", -1)
+	return *namePrefix + strings.Replace(strings.TrimSuffix(strings.TrimPrefix(file, *whisperDirectory), ".wsp"), "/", ".", -1)
 }
 
 // pointSorter sorts points by timestamp


### PR DESCRIPTION
This is a fix to the importer-reader tool that removes the whisper directory flag from the metric name.