### PR TITLE
WIP: disable serializing of new ready state format

### DIFF
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -55,6 +55,8 @@ func (n *NodeState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+/*
+To be enabled once all clusters are upgraded to code that can decode the new state
 func (n NodeState) MarshalJSON() ([]byte, error) {
 	switch n {
 	case NodeNotReady:
@@ -66,6 +68,7 @@ func (n NodeState) MarshalJSON() ([]byte, error) {
 	}
 	return nil, fmt.Errorf("impossible nodestate %v", n)
 }
+*/
 
 type Error struct {
 	code int


### PR DESCRIPTION
I think we may currently suffer from this failure mode.
I need to diagnose this further, but here's my current thoughts.

1) clusters running old code (pre 5ae365f453ba8ecfbcd397747757d88d4295adb2)
2) introduce newer code that uses the new serialisation format
3) old nodes will encounter `Failed to decode node meta` when parsing
   messages of new nodes announcing themselves, this is OK, as
   they won't add the nodes as ready, so won't include them in the
   request path
4) the new nodes however, who perform a list.Join against all other cluster peers,
   are not able to add them into their own peer list, as they are not
   accepted by them. They only cluster with the new peers
5) the new nodes start serving traffic but may not be able to serve all
   data completely if the needed shards are not represented by new-code
   peers. i.e. if the only ready peers for that shard run the older code

=> partial, or no data is returned.