### PR TITLE
Tag api endpoints

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -131,8 +131,8 @@ func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTag
 		return
 	}
 	idStrings := make([]string, 0, len(ids))
-	for id := range ids {
-		idStrings = append(idStrings, id.String())
+	for _, id := range ids {
+		idStrings = append(idStrings, id)
 	}
 	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: idStrings}))
 }

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -132,11 +132,7 @@ func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTag
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return
 	}
-	metricNames := make([]string, 0, len(metrics))
-	for _, metric := range metrics {
-		metricNames = append(metricNames, metric)
-	}
-	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: metricNames}))
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: metrics}))
 }
 
 // IndexGet returns a msgp encoded schema.MetricDefinition

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -126,13 +126,13 @@ func (s *Server) indexTags(ctx *middleware.Context, req models.IndexTags) {
 	response.Write(ctx, response.NewMsgp(200, &models.IndexTagsResp{Tags: tags}))
 }
 
-func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {
+func (s *Server) indexFindByTag(ctx *middleware.Context, req models.IndexFindByTag) {
 	metrics, err := s.MetricIndex.FindByTag(req.OrgId, req.Expr, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return
 	}
-	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Metrics: metrics}))
+	response.Write(ctx, response.NewMsgp(200, &models.IndexFindByTagResp{Metrics: metrics}))
 }
 
 // IndexGet returns a msgp encoded schema.MetricDefinition

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -125,7 +125,7 @@ func (s *Server) indexTags(ctx *middleware.Context, req models.IndexTags) {
 }
 
 func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {
-	ids, err := s.MetricIndex.FindByTag(req.OrgId, req.Expressions, 0)
+	ids, err := s.MetricIndex.FindByTag(req.OrgId, req.Expressions, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -108,7 +108,6 @@ func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 
 func (s *Server) indexTag(ctx *middleware.Context, req models.IndexTag) {
 	values := s.MetricIndex.Tag(req.OrgId, req.Tag, 0)
-	fmt.Println(fmt.Sprintf("returning values: %+v", values))
 	response.Write(ctx, response.NewMsgp(200, &models.IndexTagResp{Values: values}))
 }
 
@@ -118,7 +117,7 @@ func (s *Server) indexTagList(ctx *middleware.Context, req models.IndexTagList) 
 }
 
 func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {
-	ids, err := s.MetricIndex.FindByTag(ctx.OrgId, req.Expressions, 0)
+	ids, err := s.MetricIndex.FindByTag(req.OrgId, req.Expressions, 0)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 
 	"github.com/grafana/metrictank/api/middleware"
 	"github.com/grafana/metrictank/api/models"
@@ -183,4 +185,70 @@ func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
 		DeletedDefs: len(defs),
 	}
 	response.Write(ctx, response.NewMsgp(200, &resp))
+}
+
+// clusterQuery takes a request and the path to request it on, then fans it out
+// across the cluster, except to the local peer.
+// ctx:          request context
+// data:         request to be submitted
+// name:         name to be used in logging & tracing
+// path:         path to request on
+// respTemplate: the response object into which the responses shall
+//               be deserialized. each sub-request will get a copy of this
+//               template and the response will be unarshalled into that copy.
+//               (generic without generics)
+func (s *Server) clusterQuery(ctx context.Context, data cluster.Traceable, name, path string, respTemplate msgp.Unmarshaler) ([]msgp.Unmarshaler, error) {
+	peers, err := cluster.MembersForQuery()
+	if err != nil {
+		log.Error(3, "HTTP clusterQuery unable to get peers, %s", err)
+		return nil, err
+	}
+	log.Debug("HTTP %s across %d instances", name, len(peers)-1)
+
+	result := make([]msgp.Unmarshaler, 0, len(peers)-1)
+
+	var errors []error
+	var errLock sync.Mutex
+	var resLock sync.Mutex
+	var wg sync.WaitGroup
+	for _, peer := range peers {
+		if peer.IsLocal() {
+			continue
+		}
+		wg.Add(1)
+		go func(peer cluster.Node) {
+			defer wg.Done()
+			log.Debug("HTTP Render querying %s%s", peer.Name, path)
+			buf, err := peer.Post(ctx, name, path, data)
+
+			if err != nil {
+				log.Error(4, "HTTP Render error querying %s%s: %q", peer.Name, path, err)
+				errLock.Lock()
+				errors = append(errors, err)
+				errLock.Unlock()
+				return
+			}
+
+			resp := respTemplate
+			_, err = resp.UnmarshalMsg(buf)
+			if err != nil {
+				log.Error(4, "HTTP error unmarshaling body from %s%s: %q", peer.Name, path, err)
+				errLock.Lock()
+				errors = append(errors, err)
+				errLock.Unlock()
+				return
+			}
+
+			resLock.Lock()
+			result = append(result, resp)
+			resLock.Unlock()
+		}(peer)
+	}
+	wg.Wait()
+
+	if len(errors) > 0 {
+		return nil, errors[0]
+	}
+
+	return result, nil
 }

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -106,6 +106,25 @@ func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 	response.Write(ctx, response.NewMsgp(200, resp))
 }
 
+func (s *Server) indexTag(ctx *middleware.Context, req models.IndexTag) {
+	values := s.MetricIndex.Tag(req.OrgId, req.Tag)
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagResp{Values: values}))
+}
+
+func (s *Server) indexTagList(ctx *middleware.Context, req models.IndexTagList) {
+	tags := s.MetricIndex.TagList(req.OrgId, req.From)
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagListResp{Tags: tags}))
+}
+
+func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {
+	ids, err := s.MetricIndex.IdsByTagExpressions(ctx.OrgId, req.Expressions)
+	if err != nil {
+		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
+		return
+	}
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: ids}))
+}
+
 // IndexGet returns a msgp encoded schema.MetricDefinition
 func (s *Server) indexGet(ctx *middleware.Context, req models.IndexGet) {
 	def, ok := s.MetricIndex.Get(req.Id)

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -106,18 +106,22 @@ func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 	response.Write(ctx, response.NewMsgp(200, resp))
 }
 
-func (s *Server) indexTag(ctx *middleware.Context, req models.IndexTag) {
-	values := s.MetricIndex.Tag(req.OrgId, req.Tag, 0)
-	response.Write(ctx, response.NewMsgp(200, &models.IndexTagResp{Values: values}))
-}
-
-func (s *Server) indexTagList(ctx *middleware.Context, req models.IndexTagList) {
-	tags, err := s.MetricIndex.TagList(req.OrgId, req.Filter, req.From)
+func (s *Server) indexTagDetails(ctx *middleware.Context, req models.IndexTagDetails) {
+	values, err := s.MetricIndex.TagDetails(req.OrgId, req.Tag, req.Filter, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return
 	}
-	response.Write(ctx, response.NewMsgp(200, &models.IndexTagListResp{Tags: tags}))
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagDetailsResp{Values: values}))
+}
+
+func (s *Server) indexTags(ctx *middleware.Context, req models.IndexTags) {
+	tags, err := s.MetricIndex.Tags(req.OrgId, req.Filter, req.From)
+	if err != nil {
+		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
+		return
+	}
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagsResp{Tags: tags}))
 }
 
 func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -112,7 +112,11 @@ func (s *Server) indexTag(ctx *middleware.Context, req models.IndexTag) {
 }
 
 func (s *Server) indexTagList(ctx *middleware.Context, req models.IndexTagList) {
-	tags := s.MetricIndex.TagList(req.OrgId)
+	tags, err := s.MetricIndex.TagList(req.OrgId, req.Filter, req.From)
+	if err != nil {
+		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
+		return
+	}
 	response.Write(ctx, response.NewMsgp(200, &models.IndexTagListResp{Tags: tags}))
 }
 

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -127,7 +127,7 @@ func (s *Server) indexTags(ctx *middleware.Context, req models.IndexTags) {
 }
 
 func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {
-	metrics, err := s.MetricIndex.FindByTag(req.OrgId, req.Expressions, req.From)
+	metrics, err := s.MetricIndex.FindByTag(req.OrgId, req.Expr, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -125,16 +125,16 @@ func (s *Server) indexTags(ctx *middleware.Context, req models.IndexTags) {
 }
 
 func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {
-	ids, err := s.MetricIndex.FindByTag(req.OrgId, req.Expressions, req.From)
+	metrics, err := s.MetricIndex.FindByTag(req.OrgId, req.Expressions, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return
 	}
-	idStrings := make([]string, 0, len(ids))
-	for _, id := range ids {
-		idStrings = append(idStrings, id)
+	metricNames := make([]string, 0, len(metrics))
+	for _, metric := range metrics {
+		metricNames = append(metricNames, metric)
 	}
-	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: idStrings}))
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: metricNames}))
 }
 
 // IndexGet returns a msgp encoded schema.MetricDefinition

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -107,22 +107,27 @@ func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 }
 
 func (s *Server) indexTag(ctx *middleware.Context, req models.IndexTag) {
-	values := s.MetricIndex.Tag(req.OrgId, req.Tag)
+	values := s.MetricIndex.Tag(req.OrgId, req.Tag, 0)
+	fmt.Println(fmt.Sprintf("returning values: %+v", values))
 	response.Write(ctx, response.NewMsgp(200, &models.IndexTagResp{Values: values}))
 }
 
 func (s *Server) indexTagList(ctx *middleware.Context, req models.IndexTagList) {
-	tags := s.MetricIndex.TagList(req.OrgId, req.From)
+	tags := s.MetricIndex.TagList(req.OrgId)
 	response.Write(ctx, response.NewMsgp(200, &models.IndexTagListResp{Tags: tags}))
 }
 
 func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTagFindSeries) {
-	ids, err := s.MetricIndex.IdsByTagExpressions(ctx.OrgId, req.Expressions)
+	ids, err := s.MetricIndex.FindByTag(ctx.OrgId, req.Expressions, 0)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return
 	}
-	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: ids}))
+	idStrings := make([]string, 0, len(ids))
+	for id := range ids {
+		idStrings = append(idStrings, id.String())
+	}
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: idStrings}))
 }
 
 // IndexGet returns a msgp encoded schema.MetricDefinition

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -187,7 +187,7 @@ func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
 	response.Write(ctx, response.NewMsgp(200, &resp))
 }
 
-// clusterQuery takes a request and the path to request it on, then fans it out
+// peerQuery takes a request and the path to request it on, then fans it out
 // across the cluster, except to the local peer.
 // ctx:          request context
 // data:         request to be submitted
@@ -197,10 +197,10 @@ func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
 //               be deserialized. each sub-request will get a copy of this
 //               template and the response will be unarshalled into that copy.
 //               (generic without generics)
-func (s *Server) clusterQuery(ctx context.Context, data cluster.Traceable, name, path string, respTemplate msgp.Unmarshaler) ([]msgp.Unmarshaler, error) {
+func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, path string, respTemplate msgp.Unmarshaler) ([]msgp.Unmarshaler, error) {
 	peers, err := cluster.MembersForQuery()
 	if err != nil {
-		log.Error(3, "HTTP clusterQuery unable to get peers, %s", err)
+		log.Error(3, "HTTP peerQuery unable to get peers, %s", err)
 		return nil, err
 	}
 	log.Debug("HTTP %s across %d instances", name, len(peers)-1)

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -132,7 +132,7 @@ func (s *Server) indexTagFindSeries(ctx *middleware.Context, req models.IndexTag
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
 		return
 	}
-	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Series: metrics}))
+	response.Write(ctx, response.NewMsgp(200, &models.IndexTagFindSeriesResp{Metrics: metrics}))
 }
 
 // IndexGet returns a msgp encoded schema.MetricDefinition

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -712,14 +712,17 @@ func (s *Server) clusterTagDetails(ctx context.Context, orgId int, tag, filter s
 	}
 
 	data := models.IndexTagDetails{OrgId: orgId, Tag: tag, Filter: filter, From: from}
-	resp := &models.IndexTagDetailsResp{}
-	responses, err := s.peerQuery(ctx, data, "clusterTagDetails", "/index/tag_details", resp)
+	bufs, err := s.peerQuery(ctx, data, "clusterTagDetails", "/index/tag_details")
 	if err != nil {
 		return nil, err
 	}
-
-	for _, resp := range responses {
-		for k, v := range resp.(*models.IndexTagDetailsResp).Values {
+	resp := models.IndexTagDetailsResp{}
+	for _, buf := range bufs {
+		_, err = resp.UnmarshalMsg(buf)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range resp.Values {
 			result[k] = result[k] + v
 		}
 	}
@@ -750,14 +753,18 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 	}
 
 	data := models.IndexTagFindSeries{OrgId: orgId, Expressions: expressions, From: from}
-	resp := &models.IndexTagFindSeriesResp{}
-	responses, err := s.peerQuery(ctx, data, "clusterTagFindSeries", "/index/find_by_tag", resp)
+	bufs, err := s.peerQuery(ctx, data, "clusterTagFindSeries", "/index/find_by_tag")
 	if err != nil {
 		return nil, err
 	}
 
-	for _, resp := range responses {
-		for _, series := range resp.(*models.IndexTagFindSeriesResp).Series {
+	resp := models.IndexTagFindSeriesResp{}
+	for _, buf := range bufs {
+		_, err = resp.UnmarshalMsg(buf)
+		if err != nil {
+			return nil, err
+		}
+		for _, series := range resp.Series {
 			seriesSet[series] = struct{}{}
 		}
 	}
@@ -796,14 +803,18 @@ func (s *Server) clusterTags(ctx context.Context, orgId int, filter string, from
 	}
 
 	data := models.IndexTags{OrgId: orgId, Filter: filter, From: from}
-	resp := &models.IndexTagsResp{}
-	responses, err := s.peerQuery(ctx, data, "clusterTags", "/index/tags", resp)
+	bufs, err := s.peerQuery(ctx, data, "clusterTags", "/index/tags")
 	if err != nil {
 		return nil, err
 	}
 
-	for _, resp := range responses {
-		for _, tag := range resp.(*models.IndexTagsResp).Tags {
+	resp := models.IndexTagsResp{}
+	for _, buf := range bufs {
+		_, err = resp.UnmarshalMsg(buf)
+		if err != nil {
+			return nil, err
+		}
+		for _, tag := range resp.Tags {
 			tagSet[tag] = struct{}{}
 		}
 	}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -707,11 +707,13 @@ func (s *Server) clusterTagDetails(ctx context.Context, orgId int, tag, filter s
 	if err != nil {
 		return nil, err
 	}
+	if result == nil {
+		result = make(map[string]uint64)
+	}
 
-	path := "/index/tags/" + tag
 	data := models.IndexTagDetails{OrgId: orgId, Tag: tag, Filter: filter, From: from}
 	resp := &models.IndexTagDetailsResp{}
-	responses, err := s.peerQuery(ctx, data, "clusterTagDetails", path, resp)
+	responses, err := s.peerQuery(ctx, data, "clusterTagDetails", "/index/tag_details", resp)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +751,7 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 
 	data := models.IndexTagFindSeries{OrgId: orgId, Expressions: expressions, From: from}
 	resp := &models.IndexTagFindSeriesResp{}
-	responses, err := s.peerQuery(ctx, data, "clusterTagFindSeries", "/index/tags/findSeries", resp)
+	responses, err := s.peerQuery(ctx, data, "clusterTagFindSeries", "/index/find_by_tag", resp)
 	if err != nil {
 		return nil, err
 	}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -752,7 +752,7 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 		seriesSet[series] = struct{}{}
 	}
 
-	data := models.IndexTagFindSeries{OrgId: orgId, Expressions: expressions, From: from}
+	data := models.IndexTagFindSeries{OrgId: orgId, Expr: expressions, From: from}
 	bufs, err := s.peerQuery(ctx, data, "clusterTagFindSeries", "/index/find_by_tag")
 	if err != nil {
 		return nil, err

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -764,7 +764,7 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 		if err != nil {
 			return nil, err
 		}
-		for _, series := range resp.Series {
+		for _, series := range resp.Metrics {
 			seriesSet[series] = struct{}{}
 		}
 	}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -711,7 +711,7 @@ func (s *Server) clusterTagDetails(ctx context.Context, orgId int, tag, filter s
 	path := "/index/tags/" + tag
 	data := models.IndexTagDetails{OrgId: orgId, Tag: tag, Filter: filter, From: from}
 	resp := &models.IndexTagDetailsResp{}
-	responses, err := s.clusterQuery(ctx, data, "clusterTagDetails", path, resp)
+	responses, err := s.peerQuery(ctx, data, "clusterTagDetails", path, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +749,7 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 
 	data := models.IndexTagFindSeries{OrgId: orgId, Expressions: expressions, From: from}
 	resp := &models.IndexTagFindSeriesResp{}
-	responses, err := s.clusterQuery(ctx, data, "clusterTagFindSeries", "/index/tags/findSeries", resp)
+	responses, err := s.peerQuery(ctx, data, "clusterTagFindSeries", "/index/tags/findSeries", resp)
 	if err != nil {
 		return nil, err
 	}
@@ -795,7 +795,7 @@ func (s *Server) clusterTags(ctx context.Context, orgId int, filter string, from
 
 	data := models.IndexTags{OrgId: orgId, Filter: filter, From: from}
 	resp := &models.IndexTagsResp{}
-	responses, err := s.clusterQuery(ctx, data, "clusterTags", "/index/tags", resp)
+	responses, err := s.peerQuery(ctx, data, "clusterTags", "/index/tags", resp)
 	if err != nil {
 		return nil, err
 	}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -757,8 +757,8 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 			errors = append(errors, err)
 			return
 		}
-		for series := range result {
-			seriesSet[series.String()] = struct{}{}
+		for _, series := range result {
+			seriesSet[series] = struct{}{}
 		}
 	}()
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -754,8 +754,8 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 
 	wg.Add(1)
 	go func() {
-		result, err := s.MetricIndex.FindByTag(orgId, expressions, 0)
 		defer wg.Done()
+		result, err := s.MetricIndex.FindByTag(orgId, expressions, 0)
 		if err != nil {
 			log.Error(4, "HTTP Render error querying /index/tags/findSeries: %q", err)
 			errors = append(errors, err)
@@ -772,7 +772,7 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 
 	data := models.IndexTagFindSeries{OrgId: orgId, Expressions: expressions}
 	resp := &models.IndexTagFindSeriesResp{}
-	responses, err := s.clusterQuery(ctx, data, "clusterTagFindSeries", "/index/tags/FindSeries", resp)
+	responses, err := s.clusterQuery(ctx, data, "clusterTagFindSeries", "/index/tags/findSeries", resp)
 	if err != nil {
 		return nil, err
 	}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -731,7 +731,7 @@ func (s *Server) clusterTagDetails(ctx context.Context, orgId int, tag, filter s
 }
 
 func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.GraphiteTagFindSeries) {
-	series, err := s.clusterTagFindSeries(ctx.Req.Context(), ctx.OrgId, request.Expr, request.From)
+	series, err := s.clusterFindByTag(ctx.Req.Context(), ctx.OrgId, request.Expr, request.From)
 	if err != nil {
 		response.Write(ctx, response.WrapError(err))
 		return
@@ -740,7 +740,7 @@ func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.G
 	response.Write(ctx, response.NewJson(200, series, ""))
 }
 
-func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expressions []string, from int64) ([]string, error) {
+func (s *Server) clusterFindByTag(ctx context.Context, orgId int, expressions []string, from int64) ([]string, error) {
 	seriesSet := make(map[string]struct{})
 
 	result, err := s.MetricIndex.FindByTag(orgId, expressions, from)
@@ -752,13 +752,13 @@ func (s *Server) clusterTagFindSeries(ctx context.Context, orgId int, expression
 		seriesSet[series] = struct{}{}
 	}
 
-	data := models.IndexTagFindSeries{OrgId: orgId, Expr: expressions, From: from}
-	bufs, err := s.peerQuery(ctx, data, "clusterTagFindSeries", "/index/find_by_tag")
+	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions, From: from}
+	bufs, err := s.peerQuery(ctx, data, "clusterFindByTag", "/index/find_by_tag")
 	if err != nil {
 		return nil, err
 	}
 
-	resp := models.IndexTagFindSeriesResp{}
+	resp := models.IndexFindByTagResp{}
 	for _, buf := range bufs {
 		_, err = resp.UnmarshalMsg(buf)
 		if err != nil {

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -37,5 +37,5 @@ type IndexTagDetailsResp struct {
 
 //go:generate msgp
 type IndexTagFindSeriesResp struct {
-	Series []string `json:"series"`
+	Metrics []string `json:"metrics"`
 }

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -26,13 +26,13 @@ type MetricsDeleteResp struct {
 }
 
 //go:generate msgp
-type IndexTagListResp struct {
+type IndexTagsResp struct {
 	Tags []string `json:"tags"`
 }
 
 //go:generate msgp
-type IndexTagResp struct {
-	Values map[string]uint32 `json:"values"`
+type IndexTagDetailsResp struct {
+	Values map[string]uint64 `json:"values"`
 }
 
 //go:generate msgp

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -36,6 +36,6 @@ type IndexTagDetailsResp struct {
 }
 
 //go:generate msgp
-type IndexTagFindSeriesResp struct {
+type IndexFindByTagResp struct {
 	Metrics []string `json:"metrics"`
 }

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -24,3 +24,18 @@ type GetDataResp struct {
 type MetricsDeleteResp struct {
 	DeletedDefs int `json:"deletedDefs"`
 }
+
+//go:generate msgp
+type IndexTagListResp struct {
+	Tags []string `json:"tags"`
+}
+
+//go:generate msgp
+type IndexTagResp struct {
+	Values map[string]uint32 `json:"values"`
+}
+
+//go:generate msgp
+type IndexTagFindSeriesResp struct {
+	Series []string `json:"series"`
+}

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -13,31 +13,31 @@ import (
 func (z *GetDataResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var xsz uint32
-			xsz, err = dc.ReadArrayHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(xsz) {
-				z.Series = z.Series[:xsz]
+			if cap(z.Series) >= int(zb0002) {
+				z.Series = (z.Series)[:zb0002]
 			} else {
-				z.Series = make([]Series, xsz)
+				z.Series = make([]Series, zb0002)
 			}
-			for xvk := range z.Series {
-				err = z.Series[xvk].DecodeMsg(dc)
+			for za0001 := range z.Series {
+				err = z.Series[za0001].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -64,8 +64,8 @@ func (z *GetDataResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for xvk := range z.Series {
-		err = z.Series[xvk].EncodeMsg(en)
+	for za0001 := range z.Series {
+		err = z.Series[za0001].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -80,8 +80,8 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Series"
 	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
-	for xvk := range z.Series {
-		o, err = z.Series[xvk].MarshalMsg(o)
+	for za0001 := range z.Series {
+		o, err = z.Series[za0001].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -93,31 +93,31 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var xsz uint32
-			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(xsz) {
-				z.Series = z.Series[:xsz]
+			if cap(z.Series) >= int(zb0002) {
+				z.Series = (z.Series)[:zb0002]
 			} else {
-				z.Series = make([]Series, xsz)
+				z.Series = make([]Series, zb0002)
 			}
-			for xvk := range z.Series {
-				bts, err = z.Series[xvk].UnmarshalMsg(bts)
+			for za0001 := range z.Series {
+				bts, err = z.Series[za0001].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -133,10 +133,141 @@ func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *GetDataResp) Msgsize() (s int) {
 	s = 1 + 7 + msgp.ArrayHeaderSize
-	for xvk := range z.Series {
-		s += z.Series[xvk].Msgsize()
+	for za0001 := range z.Series {
+		s += z.Series[za0001].Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *IndexFindByTagResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Metrics":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Metrics) >= int(zb0002) {
+				z.Metrics = (z.Metrics)[:zb0002]
+			} else {
+				z.Metrics = make([]string, zb0002)
+			}
+			for za0001 := range z.Metrics {
+				z.Metrics[za0001], err = dc.ReadString()
+				if err != nil {
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IndexFindByTagResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Metrics"
+	err = en.Append(0x81, 0xa7, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Metrics)))
+	if err != nil {
+		return
+	}
+	for za0001 := range z.Metrics {
+		err = en.WriteString(z.Metrics[za0001])
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IndexFindByTagResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Metrics"
+	o = append(o, 0x81, 0xa7, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Metrics)))
+	for za0001 := range z.Metrics {
+		o = msgp.AppendString(o, z.Metrics[za0001])
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexFindByTagResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Metrics":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Metrics) >= int(zb0002) {
+				z.Metrics = (z.Metrics)[:zb0002]
+			} else {
+				z.Metrics = make([]string, zb0002)
+			}
+			for za0001 := range z.Metrics {
+				z.Metrics[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *IndexFindByTagResp) Msgsize() (s int) {
+	s = 1 + 8 + msgp.ArrayHeaderSize
+	for za0001 := range z.Metrics {
+		s += msgp.StringPrefixSize + len(z.Metrics[za0001])
 	}
 	return
 }
@@ -145,56 +276,56 @@ func (z *GetDataResp) Msgsize() (s int) {
 func (z *IndexFindResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var msz uint32
-			msz, err = dc.ReadMapHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && msz > 0 {
-				z.Nodes = make(map[string][]idx.Node, msz)
+			if z.Nodes == nil && zb0002 > 0 {
+				z.Nodes = make(map[string][]idx.Node, zb0002)
 			} else if len(z.Nodes) > 0 {
 				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for msz > 0 {
-				msz--
-				var bzg string
-				var bai []idx.Node
-				bzg, err = dc.ReadString()
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				var za0002 []idx.Node
+				za0001, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				var xsz uint32
-				xsz, err = dc.ReadArrayHeader()
+				var zb0003 uint32
+				zb0003, err = dc.ReadArrayHeader()
 				if err != nil {
 					return
 				}
-				if cap(bai) >= int(xsz) {
-					bai = bai[:xsz]
+				if cap(za0002) >= int(zb0003) {
+					za0002 = (za0002)[:zb0003]
 				} else {
-					bai = make([]idx.Node, xsz)
+					za0002 = make([]idx.Node, zb0003)
 				}
-				for cmr := range bai {
-					err = bai[cmr].DecodeMsg(dc)
+				for za0003 := range za0002 {
+					err = za0002[za0003].DecodeMsg(dc)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[bzg] = bai
+				z.Nodes[za0001] = za0002
 			}
 		default:
 			err = dc.Skip()
@@ -218,17 +349,17 @@ func (z *IndexFindResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for bzg, bai := range z.Nodes {
-		err = en.WriteString(bzg)
+	for za0001, za0002 := range z.Nodes {
+		err = en.WriteString(za0001)
 		if err != nil {
 			return
 		}
-		err = en.WriteArrayHeader(uint32(len(bai)))
+		err = en.WriteArrayHeader(uint32(len(za0002)))
 		if err != nil {
 			return
 		}
-		for cmr := range bai {
-			err = bai[cmr].EncodeMsg(en)
+		for za0003 := range za0002 {
+			err = za0002[za0003].EncodeMsg(en)
 			if err != nil {
 				return
 			}
@@ -244,11 +375,11 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Nodes"
 	o = append(o, 0x81, 0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Nodes)))
-	for bzg, bai := range z.Nodes {
-		o = msgp.AppendString(o, bzg)
-		o = msgp.AppendArrayHeader(o, uint32(len(bai)))
-		for cmr := range bai {
-			o, err = bai[cmr].MarshalMsg(o)
+	for za0001, za0002 := range z.Nodes {
+		o = msgp.AppendString(o, za0001)
+		o = msgp.AppendArrayHeader(o, uint32(len(za0002)))
+		for za0003 := range za0002 {
+			o, err = za0002[za0003].MarshalMsg(o)
 			if err != nil {
 				return
 			}
@@ -261,56 +392,56 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var msz uint32
-			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && msz > 0 {
-				z.Nodes = make(map[string][]idx.Node, msz)
+			if z.Nodes == nil && zb0002 > 0 {
+				z.Nodes = make(map[string][]idx.Node, zb0002)
 			} else if len(z.Nodes) > 0 {
 				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for msz > 0 {
-				var bzg string
-				var bai []idx.Node
-				msz--
-				bzg, bts, err = msgp.ReadStringBytes(bts)
+			for zb0002 > 0 {
+				var za0001 string
+				var za0002 []idx.Node
+				zb0002--
+				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				var xsz uint32
-				xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zb0003 uint32
+				zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				if cap(bai) >= int(xsz) {
-					bai = bai[:xsz]
+				if cap(za0002) >= int(zb0003) {
+					za0002 = (za0002)[:zb0003]
 				} else {
-					bai = make([]idx.Node, xsz)
+					za0002 = make([]idx.Node, zb0003)
 				}
-				for cmr := range bai {
-					bts, err = bai[cmr].UnmarshalMsg(bts)
+				for za0003 := range za0002 {
+					bts, err = za0002[za0003].UnmarshalMsg(bts)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[bzg] = bai
+				z.Nodes[za0001] = za0002
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -323,14 +454,15 @@ func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *IndexFindResp) Msgsize() (s int) {
 	s = 1 + 6 + msgp.MapHeaderSize
 	if z.Nodes != nil {
-		for bzg, bai := range z.Nodes {
-			_ = bai
-			s += msgp.StringPrefixSize + len(bzg) + msgp.ArrayHeaderSize
-			for cmr := range bai {
-				s += bai[cmr].Msgsize()
+		for za0001, za0002 := range z.Nodes {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + msgp.ArrayHeaderSize
+			for za0003 := range za0002 {
+				s += za0002[za0003].Msgsize()
 			}
 		}
 	}
@@ -341,44 +473,44 @@ func (z *IndexFindResp) Msgsize() (s int) {
 func (z *IndexTagDetailsResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Values":
-			var msz uint32
-			msz, err = dc.ReadMapHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				return
 			}
-			if z.Values == nil && msz > 0 {
-				z.Values = make(map[string]uint64, msz)
+			if z.Values == nil && zb0002 > 0 {
+				z.Values = make(map[string]uint64, zb0002)
 			} else if len(z.Values) > 0 {
 				for key, _ := range z.Values {
 					delete(z.Values, key)
 				}
 			}
-			for msz > 0 {
-				msz--
-				var ajw string
-				var wht uint64
-				ajw, err = dc.ReadString()
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				var za0002 uint64
+				za0001, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				wht, err = dc.ReadUint64()
+				za0002, err = dc.ReadUint64()
 				if err != nil {
 					return
 				}
-				z.Values[ajw] = wht
+				z.Values[za0001] = za0002
 			}
 		default:
 			err = dc.Skip()
@@ -402,12 +534,12 @@ func (z *IndexTagDetailsResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for ajw, wht := range z.Values {
-		err = en.WriteString(ajw)
+	for za0001, za0002 := range z.Values {
+		err = en.WriteString(za0001)
 		if err != nil {
 			return
 		}
-		err = en.WriteUint64(wht)
+		err = en.WriteUint64(za0002)
 		if err != nil {
 			return
 		}
@@ -422,9 +554,9 @@ func (z *IndexTagDetailsResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Values"
 	o = append(o, 0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Values)))
-	for ajw, wht := range z.Values {
-		o = msgp.AppendString(o, ajw)
-		o = msgp.AppendUint64(o, wht)
+	for za0001, za0002 := range z.Values {
+		o = msgp.AppendString(o, za0001)
+		o = msgp.AppendUint64(o, za0002)
 	}
 	return
 }
@@ -433,44 +565,44 @@ func (z *IndexTagDetailsResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexTagDetailsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Values":
-			var msz uint32
-			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if z.Values == nil && msz > 0 {
-				z.Values = make(map[string]uint64, msz)
+			if z.Values == nil && zb0002 > 0 {
+				z.Values = make(map[string]uint64, zb0002)
 			} else if len(z.Values) > 0 {
 				for key, _ := range z.Values {
 					delete(z.Values, key)
 				}
 			}
-			for msz > 0 {
-				var ajw string
-				var wht uint64
-				msz--
-				ajw, bts, err = msgp.ReadStringBytes(bts)
+			for zb0002 > 0 {
+				var za0001 string
+				var za0002 uint64
+				zb0002--
+				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				wht, bts, err = msgp.ReadUint64Bytes(bts)
+				za0002, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					return
 				}
-				z.Values[ajw] = wht
+				z.Values[za0001] = za0002
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -483,142 +615,14 @@ func (z *IndexTagDetailsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *IndexTagDetailsResp) Msgsize() (s int) {
 	s = 1 + 7 + msgp.MapHeaderSize
 	if z.Values != nil {
-		for ajw, wht := range z.Values {
-			_ = wht
-			s += msgp.StringPrefixSize + len(ajw) + msgp.Uint64Size
+		for za0001, za0002 := range z.Values {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + msgp.Uint64Size
 		}
-	}
-	return
-}
-
-// DecodeMsg implements msgp.Decodable
-func (z *IndexTagFindSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
-	var field []byte
-	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
-	if err != nil {
-		return
-	}
-	for isz > 0 {
-		isz--
-		field, err = dc.ReadMapKeyPtr()
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "Metrics":
-			var xsz uint32
-			xsz, err = dc.ReadArrayHeader()
-			if err != nil {
-				return
-			}
-			if cap(z.Metrics) >= int(xsz) {
-				z.Metrics = z.Metrics[:xsz]
-			} else {
-				z.Metrics = make([]string, xsz)
-			}
-			for hct := range z.Metrics {
-				z.Metrics[hct], err = dc.ReadString()
-				if err != nil {
-					return
-				}
-			}
-		default:
-			err = dc.Skip()
-			if err != nil {
-				return
-			}
-		}
-	}
-	return
-}
-
-// EncodeMsg implements msgp.Encodable
-func (z *IndexTagFindSeriesResp) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 1
-	// write "Metrics"
-	err = en.Append(0x81, 0xa7, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
-	if err != nil {
-		return err
-	}
-	err = en.WriteArrayHeader(uint32(len(z.Metrics)))
-	if err != nil {
-		return
-	}
-	for hct := range z.Metrics {
-		err = en.WriteString(z.Metrics[hct])
-		if err != nil {
-			return
-		}
-	}
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z *IndexTagFindSeriesResp) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	// map header, size 1
-	// string "Metrics"
-	o = append(o, 0x81, 0xa7, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
-	o = msgp.AppendArrayHeader(o, uint32(len(z.Metrics)))
-	for hct := range z.Metrics {
-		o = msgp.AppendString(o, z.Metrics[hct])
-	}
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *IndexTagFindSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var field []byte
-	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
-	if err != nil {
-		return
-	}
-	for isz > 0 {
-		isz--
-		field, bts, err = msgp.ReadMapKeyZC(bts)
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "Metrics":
-			var xsz uint32
-			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
-			if err != nil {
-				return
-			}
-			if cap(z.Metrics) >= int(xsz) {
-				z.Metrics = z.Metrics[:xsz]
-			} else {
-				z.Metrics = make([]string, xsz)
-			}
-			for hct := range z.Metrics {
-				z.Metrics[hct], bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					return
-				}
-			}
-		default:
-			bts, err = msgp.Skip(bts)
-			if err != nil {
-				return
-			}
-		}
-	}
-	o = bts
-	return
-}
-
-func (z *IndexTagFindSeriesResp) Msgsize() (s int) {
-	s = 1 + 8 + msgp.ArrayHeaderSize
-	for hct := range z.Metrics {
-		s += msgp.StringPrefixSize + len(z.Metrics[hct])
 	}
 	return
 }
@@ -627,31 +631,31 @@ func (z *IndexTagFindSeriesResp) Msgsize() (s int) {
 func (z *IndexTagsResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Tags":
-			var xsz uint32
-			xsz, err = dc.ReadArrayHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(xsz) {
-				z.Tags = z.Tags[:xsz]
+			if cap(z.Tags) >= int(zb0002) {
+				z.Tags = (z.Tags)[:zb0002]
 			} else {
-				z.Tags = make([]string, xsz)
+				z.Tags = make([]string, zb0002)
 			}
-			for cua := range z.Tags {
-				z.Tags[cua], err = dc.ReadString()
+			for za0001 := range z.Tags {
+				z.Tags[za0001], err = dc.ReadString()
 				if err != nil {
 					return
 				}
@@ -678,8 +682,8 @@ func (z *IndexTagsResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for cua := range z.Tags {
-		err = en.WriteString(z.Tags[cua])
+	for za0001 := range z.Tags {
+		err = en.WriteString(z.Tags[za0001])
 		if err != nil {
 			return
 		}
@@ -694,8 +698,8 @@ func (z *IndexTagsResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Tags"
 	o = append(o, 0x81, 0xa4, 0x54, 0x61, 0x67, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Tags)))
-	for cua := range z.Tags {
-		o = msgp.AppendString(o, z.Tags[cua])
+	for za0001 := range z.Tags {
+		o = msgp.AppendString(o, z.Tags[za0001])
 	}
 	return
 }
@@ -704,31 +708,31 @@ func (z *IndexTagsResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexTagsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Tags":
-			var xsz uint32
-			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(xsz) {
-				z.Tags = z.Tags[:xsz]
+			if cap(z.Tags) >= int(zb0002) {
+				z.Tags = (z.Tags)[:zb0002]
 			} else {
-				z.Tags = make([]string, xsz)
+				z.Tags = make([]string, zb0002)
 			}
-			for cua := range z.Tags {
-				z.Tags[cua], bts, err = msgp.ReadStringBytes(bts)
+			for za0001 := range z.Tags {
+				z.Tags[za0001], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
@@ -744,10 +748,11 @@ func (z *IndexTagsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *IndexTagsResp) Msgsize() (s int) {
 	s = 1 + 5 + msgp.ArrayHeaderSize
-	for cua := range z.Tags {
-		s += msgp.StringPrefixSize + len(z.Tags[cua])
+	for za0001 := range z.Tags {
+		s += msgp.StringPrefixSize + len(z.Tags[za0001])
 	}
 	return
 }
@@ -756,13 +761,13 @@ func (z *IndexTagsResp) Msgsize() (s int) {
 func (z *MetricsDeleteResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -812,13 +817,13 @@ func (z MetricsDeleteResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *MetricsDeleteResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for isz > 0 {
-		isz--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -840,6 +845,7 @@ func (z *MetricsDeleteResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z MetricsDeleteResp) Msgsize() (s int) {
 	s = 1 + 12 + msgp.IntSize
 	return

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -13,31 +13,31 @@ import (
 func (z *GetDataResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zbzg uint32
-	zbzg, err = dc.ReadMapHeader()
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zbzg > 0 {
-		zbzg--
+	for isz > 0 {
+		isz--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var zbai uint32
-			zbai, err = dc.ReadArrayHeader()
+			var xsz uint32
+			xsz, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(zbai) {
-				z.Series = (z.Series)[:zbai]
+			if cap(z.Series) >= int(xsz) {
+				z.Series = z.Series[:xsz]
 			} else {
-				z.Series = make([]Series, zbai)
+				z.Series = make([]Series, xsz)
 			}
-			for zxvk := range z.Series {
-				err = z.Series[zxvk].DecodeMsg(dc)
+			for xvk := range z.Series {
+				err = z.Series[xvk].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -64,8 +64,8 @@ func (z *GetDataResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zxvk := range z.Series {
-		err = z.Series[zxvk].EncodeMsg(en)
+	for xvk := range z.Series {
+		err = z.Series[xvk].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -80,8 +80,8 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Series"
 	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
-	for zxvk := range z.Series {
-		o, err = z.Series[zxvk].MarshalMsg(o)
+	for xvk := range z.Series {
+		o, err = z.Series[xvk].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -93,31 +93,31 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var zajw uint32
-			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var xsz uint32
+			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(zajw) {
-				z.Series = (z.Series)[:zajw]
+			if cap(z.Series) >= int(xsz) {
+				z.Series = z.Series[:xsz]
 			} else {
-				z.Series = make([]Series, zajw)
+				z.Series = make([]Series, xsz)
 			}
-			for zxvk := range z.Series {
-				bts, err = z.Series[zxvk].UnmarshalMsg(bts)
+			for xvk := range z.Series {
+				bts, err = z.Series[xvk].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -133,11 +133,10 @@ func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *GetDataResp) Msgsize() (s int) {
 	s = 1 + 7 + msgp.ArrayHeaderSize
-	for zxvk := range z.Series {
-		s += z.Series[zxvk].Msgsize()
+	for xvk := range z.Series {
+		s += z.Series[xvk].Msgsize()
 	}
 	return
 }
@@ -146,56 +145,56 @@ func (z *GetDataResp) Msgsize() (s int) {
 func (z *IndexFindResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zxhx uint32
-	zxhx, err = dc.ReadMapHeader()
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zxhx > 0 {
-		zxhx--
+	for isz > 0 {
+		isz--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var zlqf uint32
-			zlqf, err = dc.ReadMapHeader()
+			var msz uint32
+			msz, err = dc.ReadMapHeader()
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && zlqf > 0 {
-				z.Nodes = make(map[string][]idx.Node, zlqf)
+			if z.Nodes == nil && msz > 0 {
+				z.Nodes = make(map[string][]idx.Node, msz)
 			} else if len(z.Nodes) > 0 {
 				for key := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for zlqf > 0 {
-				zlqf--
-				var zwht string
-				var zhct []idx.Node
-				zwht, err = dc.ReadString()
+			for msz > 0 {
+				msz--
+				var bzg string
+				var bai []idx.Node
+				bzg, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				var zdaf uint32
-				zdaf, err = dc.ReadArrayHeader()
+				var xsz uint32
+				xsz, err = dc.ReadArrayHeader()
 				if err != nil {
 					return
 				}
-				if cap(zhct) >= int(zdaf) {
-					zhct = (zhct)[:zdaf]
+				if cap(bai) >= int(xsz) {
+					bai = bai[:xsz]
 				} else {
-					zhct = make([]idx.Node, zdaf)
+					bai = make([]idx.Node, xsz)
 				}
-				for zcua := range zhct {
-					err = zhct[zcua].DecodeMsg(dc)
+				for cmr := range bai {
+					err = bai[cmr].DecodeMsg(dc)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[zwht] = zhct
+				z.Nodes[bzg] = bai
 			}
 		default:
 			err = dc.Skip()
@@ -219,17 +218,17 @@ func (z *IndexFindResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zwht, zhct := range z.Nodes {
-		err = en.WriteString(zwht)
+	for bzg, bai := range z.Nodes {
+		err = en.WriteString(bzg)
 		if err != nil {
 			return
 		}
-		err = en.WriteArrayHeader(uint32(len(zhct)))
+		err = en.WriteArrayHeader(uint32(len(bai)))
 		if err != nil {
 			return
 		}
-		for zcua := range zhct {
-			err = zhct[zcua].EncodeMsg(en)
+		for cmr := range bai {
+			err = bai[cmr].EncodeMsg(en)
 			if err != nil {
 				return
 			}
@@ -245,11 +244,11 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Nodes"
 	o = append(o, 0x81, 0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Nodes)))
-	for zwht, zhct := range z.Nodes {
-		o = msgp.AppendString(o, zwht)
-		o = msgp.AppendArrayHeader(o, uint32(len(zhct)))
-		for zcua := range zhct {
-			o, err = zhct[zcua].MarshalMsg(o)
+	for bzg, bai := range z.Nodes {
+		o = msgp.AppendString(o, bzg)
+		o = msgp.AppendArrayHeader(o, uint32(len(bai)))
+		for cmr := range bai {
+			o, err = bai[cmr].MarshalMsg(o)
 			if err != nil {
 				return
 			}
@@ -262,56 +261,56 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zpks uint32
-	zpks, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zpks > 0 {
-		zpks--
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var zjfb uint32
-			zjfb, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var msz uint32
+			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && zjfb > 0 {
-				z.Nodes = make(map[string][]idx.Node, zjfb)
+			if z.Nodes == nil && msz > 0 {
+				z.Nodes = make(map[string][]idx.Node, msz)
 			} else if len(z.Nodes) > 0 {
 				for key := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for zjfb > 0 {
-				var zwht string
-				var zhct []idx.Node
-				zjfb--
-				zwht, bts, err = msgp.ReadStringBytes(bts)
+			for msz > 0 {
+				var bzg string
+				var bai []idx.Node
+				msz--
+				bzg, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				var zcxo uint32
-				zcxo, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var xsz uint32
+				xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				if cap(zhct) >= int(zcxo) {
-					zhct = (zhct)[:zcxo]
+				if cap(bai) >= int(xsz) {
+					bai = bai[:xsz]
 				} else {
-					zhct = make([]idx.Node, zcxo)
+					bai = make([]idx.Node, xsz)
 				}
-				for zcua := range zhct {
-					bts, err = zhct[zcua].UnmarshalMsg(bts)
+				for cmr := range bai {
+					bts, err = bai[cmr].UnmarshalMsg(bts)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[zwht] = zhct
+				z.Nodes[bzg] = bai
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -324,16 +323,430 @@ func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *IndexFindResp) Msgsize() (s int) {
 	s = 1 + 6 + msgp.MapHeaderSize
 	if z.Nodes != nil {
-		for zwht, zhct := range z.Nodes {
-			_ = zhct
-			s += msgp.StringPrefixSize + len(zwht) + msgp.ArrayHeaderSize
-			for zcua := range zhct {
-				s += zhct[zcua].Msgsize()
+		for bzg, bai := range z.Nodes {
+			_ = bai
+			s += msgp.StringPrefixSize + len(bzg) + msgp.ArrayHeaderSize
+			for cmr := range bai {
+				s += bai[cmr].Msgsize()
 			}
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *IndexTagFindSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Series":
+			var xsz uint32
+			xsz, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Series) >= int(xsz) {
+				z.Series = z.Series[:xsz]
+			} else {
+				z.Series = make([]string, xsz)
+			}
+			for ajw := range z.Series {
+				z.Series[ajw], err = dc.ReadString()
+				if err != nil {
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IndexTagFindSeriesResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Series"
+	err = en.Append(0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Series)))
+	if err != nil {
+		return
+	}
+	for ajw := range z.Series {
+		err = en.WriteString(z.Series[ajw])
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IndexTagFindSeriesResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Series"
+	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
+	for ajw := range z.Series {
+		o = msgp.AppendString(o, z.Series[ajw])
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexTagFindSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Series":
+			var xsz uint32
+			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Series) >= int(xsz) {
+				z.Series = z.Series[:xsz]
+			} else {
+				z.Series = make([]string, xsz)
+			}
+			for ajw := range z.Series {
+				z.Series[ajw], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *IndexTagFindSeriesResp) Msgsize() (s int) {
+	s = 1 + 7 + msgp.ArrayHeaderSize
+	for ajw := range z.Series {
+		s += msgp.StringPrefixSize + len(z.Series[ajw])
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *IndexTagListResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Tags":
+			var xsz uint32
+			xsz, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Tags) >= int(xsz) {
+				z.Tags = z.Tags[:xsz]
+			} else {
+				z.Tags = make([]string, xsz)
+			}
+			for wht := range z.Tags {
+				z.Tags[wht], err = dc.ReadString()
+				if err != nil {
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IndexTagListResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Tags"
+	err = en.Append(0x81, 0xa4, 0x54, 0x61, 0x67, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Tags)))
+	if err != nil {
+		return
+	}
+	for wht := range z.Tags {
+		err = en.WriteString(z.Tags[wht])
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IndexTagListResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Tags"
+	o = append(o, 0x81, 0xa4, 0x54, 0x61, 0x67, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Tags)))
+	for wht := range z.Tags {
+		o = msgp.AppendString(o, z.Tags[wht])
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexTagListResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Tags":
+			var xsz uint32
+			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Tags) >= int(xsz) {
+				z.Tags = z.Tags[:xsz]
+			} else {
+				z.Tags = make([]string, xsz)
+			}
+			for wht := range z.Tags {
+				z.Tags[wht], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *IndexTagListResp) Msgsize() (s int) {
+	s = 1 + 5 + msgp.ArrayHeaderSize
+	for wht := range z.Tags {
+		s += msgp.StringPrefixSize + len(z.Tags[wht])
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *IndexTagResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Values":
+			var msz uint32
+			msz, err = dc.ReadMapHeader()
+			if err != nil {
+				return
+			}
+			if z.Values == nil && msz > 0 {
+				z.Values = make(map[string]uint32, msz)
+			} else if len(z.Values) > 0 {
+				for key, _ := range z.Values {
+					delete(z.Values, key)
+				}
+			}
+			for msz > 0 {
+				msz--
+				var hct string
+				var cua uint32
+				hct, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				cua, err = dc.ReadUint32()
+				if err != nil {
+					return
+				}
+				z.Values[hct] = cua
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IndexTagResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Values"
+	err = en.Append(0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteMapHeader(uint32(len(z.Values)))
+	if err != nil {
+		return
+	}
+	for hct, cua := range z.Values {
+		err = en.WriteString(hct)
+		if err != nil {
+			return
+		}
+		err = en.WriteUint32(cua)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IndexTagResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Values"
+	o = append(o, 0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Values)))
+	for hct, cua := range z.Values {
+		o = msgp.AppendString(o, hct)
+		o = msgp.AppendUint32(o, cua)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexTagResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Values":
+			var msz uint32
+			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if z.Values == nil && msz > 0 {
+				z.Values = make(map[string]uint32, msz)
+			} else if len(z.Values) > 0 {
+				for key, _ := range z.Values {
+					delete(z.Values, key)
+				}
+			}
+			for msz > 0 {
+				var hct string
+				var cua uint32
+				msz--
+				hct, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				cua, bts, err = msgp.ReadUint32Bytes(bts)
+				if err != nil {
+					return
+				}
+				z.Values[hct] = cua
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *IndexTagResp) Msgsize() (s int) {
+	s = 1 + 7 + msgp.MapHeaderSize
+	if z.Values != nil {
+		for hct, cua := range z.Values {
+			_ = cua
+			s += msgp.StringPrefixSize + len(hct) + msgp.Uint32Size
 		}
 	}
 	return
@@ -343,13 +756,13 @@ func (z *IndexFindResp) Msgsize() (s int) {
 func (z *MetricsDeleteResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zeff uint32
-	zeff, err = dc.ReadMapHeader()
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zeff > 0 {
-		zeff--
+	for isz > 0 {
+		isz--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -399,13 +812,13 @@ func (z MetricsDeleteResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *MetricsDeleteResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zrsw uint32
-	zrsw, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zrsw > 0 {
-		zrsw--
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -427,7 +840,6 @@ func (z *MetricsDeleteResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z MetricsDeleteResp) Msgsize() (s int) {
 	s = 1 + 12 + msgp.IntSize
 	return

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -510,19 +510,19 @@ func (z *IndexTagFindSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "Series":
+		case "Metrics":
 			var xsz uint32
 			xsz, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(xsz) {
-				z.Series = z.Series[:xsz]
+			if cap(z.Metrics) >= int(xsz) {
+				z.Metrics = z.Metrics[:xsz]
 			} else {
-				z.Series = make([]string, xsz)
+				z.Metrics = make([]string, xsz)
 			}
-			for hct := range z.Series {
-				z.Series[hct], err = dc.ReadString()
+			for hct := range z.Metrics {
+				z.Metrics[hct], err = dc.ReadString()
 				if err != nil {
 					return
 				}
@@ -540,17 +540,17 @@ func (z *IndexTagFindSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *IndexTagFindSeriesResp) EncodeMsg(en *msgp.Writer) (err error) {
 	// map header, size 1
-	// write "Series"
-	err = en.Append(0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
+	// write "Metrics"
+	err = en.Append(0x81, 0xa7, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
 	if err != nil {
 		return err
 	}
-	err = en.WriteArrayHeader(uint32(len(z.Series)))
+	err = en.WriteArrayHeader(uint32(len(z.Metrics)))
 	if err != nil {
 		return
 	}
-	for hct := range z.Series {
-		err = en.WriteString(z.Series[hct])
+	for hct := range z.Metrics {
+		err = en.WriteString(z.Metrics[hct])
 		if err != nil {
 			return
 		}
@@ -562,11 +562,11 @@ func (z *IndexTagFindSeriesResp) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *IndexTagFindSeriesResp) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 1
-	// string "Series"
-	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
-	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
-	for hct := range z.Series {
-		o = msgp.AppendString(o, z.Series[hct])
+	// string "Metrics"
+	o = append(o, 0x81, 0xa7, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Metrics)))
+	for hct := range z.Metrics {
+		o = msgp.AppendString(o, z.Metrics[hct])
 	}
 	return
 }
@@ -587,19 +587,19 @@ func (z *IndexTagFindSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) 
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "Series":
+		case "Metrics":
 			var xsz uint32
 			xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(xsz) {
-				z.Series = z.Series[:xsz]
+			if cap(z.Metrics) >= int(xsz) {
+				z.Metrics = z.Metrics[:xsz]
 			} else {
-				z.Series = make([]string, xsz)
+				z.Metrics = make([]string, xsz)
 			}
-			for hct := range z.Series {
-				z.Series[hct], bts, err = msgp.ReadStringBytes(bts)
+			for hct := range z.Metrics {
+				z.Metrics[hct], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
@@ -616,9 +616,9 @@ func (z *IndexTagFindSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) 
 }
 
 func (z *IndexTagFindSeriesResp) Msgsize() (s int) {
-	s = 1 + 7 + msgp.ArrayHeaderSize
-	for hct := range z.Series {
-		s += msgp.StringPrefixSize + len(z.Series[hct])
+	s = 1 + 8 + msgp.ArrayHeaderSize
+	for hct := range z.Metrics {
+		s += msgp.StringPrefixSize + len(z.Metrics[hct])
 	}
 	return
 }

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -166,7 +166,7 @@ func (z *IndexFindResp) DecodeMsg(dc *msgp.Reader) (err error) {
 			if z.Nodes == nil && msz > 0 {
 				z.Nodes = make(map[string][]idx.Node, msz)
 			} else if len(z.Nodes) > 0 {
-				for key := range z.Nodes {
+				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
@@ -282,7 +282,7 @@ func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			if z.Nodes == nil && msz > 0 {
 				z.Nodes = make(map[string][]idx.Node, msz)
 			} else if len(z.Nodes) > 0 {
-				for key := range z.Nodes {
+				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
@@ -338,6 +338,163 @@ func (z *IndexFindResp) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *IndexTagDetailsResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Values":
+			var msz uint32
+			msz, err = dc.ReadMapHeader()
+			if err != nil {
+				return
+			}
+			if z.Values == nil && msz > 0 {
+				z.Values = make(map[string]uint64, msz)
+			} else if len(z.Values) > 0 {
+				for key, _ := range z.Values {
+					delete(z.Values, key)
+				}
+			}
+			for msz > 0 {
+				msz--
+				var ajw string
+				var wht uint64
+				ajw, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				wht, err = dc.ReadUint64()
+				if err != nil {
+					return
+				}
+				z.Values[ajw] = wht
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IndexTagDetailsResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Values"
+	err = en.Append(0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteMapHeader(uint32(len(z.Values)))
+	if err != nil {
+		return
+	}
+	for ajw, wht := range z.Values {
+		err = en.WriteString(ajw)
+		if err != nil {
+			return
+		}
+		err = en.WriteUint64(wht)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IndexTagDetailsResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Values"
+	o = append(o, 0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Values)))
+	for ajw, wht := range z.Values {
+		o = msgp.AppendString(o, ajw)
+		o = msgp.AppendUint64(o, wht)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexTagDetailsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Values":
+			var msz uint32
+			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if z.Values == nil && msz > 0 {
+				z.Values = make(map[string]uint64, msz)
+			} else if len(z.Values) > 0 {
+				for key, _ := range z.Values {
+					delete(z.Values, key)
+				}
+			}
+			for msz > 0 {
+				var ajw string
+				var wht uint64
+				msz--
+				ajw, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				wht, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					return
+				}
+				z.Values[ajw] = wht
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *IndexTagDetailsResp) Msgsize() (s int) {
+	s = 1 + 7 + msgp.MapHeaderSize
+	if z.Values != nil {
+		for ajw, wht := range z.Values {
+			_ = wht
+			s += msgp.StringPrefixSize + len(ajw) + msgp.Uint64Size
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *IndexTagFindSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -364,8 +521,8 @@ func (z *IndexTagFindSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
 			} else {
 				z.Series = make([]string, xsz)
 			}
-			for ajw := range z.Series {
-				z.Series[ajw], err = dc.ReadString()
+			for hct := range z.Series {
+				z.Series[hct], err = dc.ReadString()
 				if err != nil {
 					return
 				}
@@ -392,8 +549,8 @@ func (z *IndexTagFindSeriesResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for ajw := range z.Series {
-		err = en.WriteString(z.Series[ajw])
+	for hct := range z.Series {
+		err = en.WriteString(z.Series[hct])
 		if err != nil {
 			return
 		}
@@ -408,8 +565,8 @@ func (z *IndexTagFindSeriesResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Series"
 	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
-	for ajw := range z.Series {
-		o = msgp.AppendString(o, z.Series[ajw])
+	for hct := range z.Series {
+		o = msgp.AppendString(o, z.Series[hct])
 	}
 	return
 }
@@ -441,8 +598,8 @@ func (z *IndexTagFindSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) 
 			} else {
 				z.Series = make([]string, xsz)
 			}
-			for ajw := range z.Series {
-				z.Series[ajw], bts, err = msgp.ReadStringBytes(bts)
+			for hct := range z.Series {
+				z.Series[hct], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
@@ -460,14 +617,14 @@ func (z *IndexTagFindSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) 
 
 func (z *IndexTagFindSeriesResp) Msgsize() (s int) {
 	s = 1 + 7 + msgp.ArrayHeaderSize
-	for ajw := range z.Series {
-		s += msgp.StringPrefixSize + len(z.Series[ajw])
+	for hct := range z.Series {
+		s += msgp.StringPrefixSize + len(z.Series[hct])
 	}
 	return
 }
 
 // DecodeMsg implements msgp.Decodable
-func (z *IndexTagListResp) DecodeMsg(dc *msgp.Reader) (err error) {
+func (z *IndexTagsResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
 	var isz uint32
@@ -493,8 +650,8 @@ func (z *IndexTagListResp) DecodeMsg(dc *msgp.Reader) (err error) {
 			} else {
 				z.Tags = make([]string, xsz)
 			}
-			for wht := range z.Tags {
-				z.Tags[wht], err = dc.ReadString()
+			for cua := range z.Tags {
+				z.Tags[cua], err = dc.ReadString()
 				if err != nil {
 					return
 				}
@@ -510,7 +667,7 @@ func (z *IndexTagListResp) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z *IndexTagListResp) EncodeMsg(en *msgp.Writer) (err error) {
+func (z *IndexTagsResp) EncodeMsg(en *msgp.Writer) (err error) {
 	// map header, size 1
 	// write "Tags"
 	err = en.Append(0x81, 0xa4, 0x54, 0x61, 0x67, 0x73)
@@ -521,8 +678,8 @@ func (z *IndexTagListResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for wht := range z.Tags {
-		err = en.WriteString(z.Tags[wht])
+	for cua := range z.Tags {
+		err = en.WriteString(z.Tags[cua])
 		if err != nil {
 			return
 		}
@@ -531,20 +688,20 @@ func (z *IndexTagListResp) EncodeMsg(en *msgp.Writer) (err error) {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *IndexTagListResp) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *IndexTagsResp) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 1
 	// string "Tags"
 	o = append(o, 0x81, 0xa4, 0x54, 0x61, 0x67, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Tags)))
-	for wht := range z.Tags {
-		o = msgp.AppendString(o, z.Tags[wht])
+	for cua := range z.Tags {
+		o = msgp.AppendString(o, z.Tags[cua])
 	}
 	return
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *IndexTagListResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+func (z *IndexTagsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
 	var isz uint32
@@ -570,8 +727,8 @@ func (z *IndexTagListResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			} else {
 				z.Tags = make([]string, xsz)
 			}
-			for wht := range z.Tags {
-				z.Tags[wht], bts, err = msgp.ReadStringBytes(bts)
+			for cua := range z.Tags {
+				z.Tags[cua], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
@@ -587,167 +744,10 @@ func (z *IndexTagListResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	return
 }
 
-func (z *IndexTagListResp) Msgsize() (s int) {
+func (z *IndexTagsResp) Msgsize() (s int) {
 	s = 1 + 5 + msgp.ArrayHeaderSize
-	for wht := range z.Tags {
-		s += msgp.StringPrefixSize + len(z.Tags[wht])
-	}
-	return
-}
-
-// DecodeMsg implements msgp.Decodable
-func (z *IndexTagResp) DecodeMsg(dc *msgp.Reader) (err error) {
-	var field []byte
-	_ = field
-	var isz uint32
-	isz, err = dc.ReadMapHeader()
-	if err != nil {
-		return
-	}
-	for isz > 0 {
-		isz--
-		field, err = dc.ReadMapKeyPtr()
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "Values":
-			var msz uint32
-			msz, err = dc.ReadMapHeader()
-			if err != nil {
-				return
-			}
-			if z.Values == nil && msz > 0 {
-				z.Values = make(map[string]uint32, msz)
-			} else if len(z.Values) > 0 {
-				for key, _ := range z.Values {
-					delete(z.Values, key)
-				}
-			}
-			for msz > 0 {
-				msz--
-				var hct string
-				var cua uint32
-				hct, err = dc.ReadString()
-				if err != nil {
-					return
-				}
-				cua, err = dc.ReadUint32()
-				if err != nil {
-					return
-				}
-				z.Values[hct] = cua
-			}
-		default:
-			err = dc.Skip()
-			if err != nil {
-				return
-			}
-		}
-	}
-	return
-}
-
-// EncodeMsg implements msgp.Encodable
-func (z *IndexTagResp) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 1
-	// write "Values"
-	err = en.Append(0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
-	if err != nil {
-		return err
-	}
-	err = en.WriteMapHeader(uint32(len(z.Values)))
-	if err != nil {
-		return
-	}
-	for hct, cua := range z.Values {
-		err = en.WriteString(hct)
-		if err != nil {
-			return
-		}
-		err = en.WriteUint32(cua)
-		if err != nil {
-			return
-		}
-	}
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z *IndexTagResp) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	// map header, size 1
-	// string "Values"
-	o = append(o, 0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
-	o = msgp.AppendMapHeader(o, uint32(len(z.Values)))
-	for hct, cua := range z.Values {
-		o = msgp.AppendString(o, hct)
-		o = msgp.AppendUint32(o, cua)
-	}
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *IndexTagResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var field []byte
-	_ = field
-	var isz uint32
-	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
-	if err != nil {
-		return
-	}
-	for isz > 0 {
-		isz--
-		field, bts, err = msgp.ReadMapKeyZC(bts)
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "Values":
-			var msz uint32
-			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
-			if err != nil {
-				return
-			}
-			if z.Values == nil && msz > 0 {
-				z.Values = make(map[string]uint32, msz)
-			} else if len(z.Values) > 0 {
-				for key, _ := range z.Values {
-					delete(z.Values, key)
-				}
-			}
-			for msz > 0 {
-				var hct string
-				var cua uint32
-				msz--
-				hct, bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					return
-				}
-				cua, bts, err = msgp.ReadUint32Bytes(bts)
-				if err != nil {
-					return
-				}
-				z.Values[hct] = cua
-			}
-		default:
-			bts, err = msgp.Skip(bts)
-			if err != nil {
-				return
-			}
-		}
-	}
-	o = bts
-	return
-}
-
-func (z *IndexTagResp) Msgsize() (s int) {
-	s = 1 + 7 + msgp.MapHeaderSize
-	if z.Values != nil {
-		for hct, cua := range z.Values {
-			_ = cua
-			s += msgp.StringPrefixSize + len(hct) + msgp.Uint32Size
-		}
+	for cua := range z.Tags {
+		s += msgp.StringPrefixSize + len(z.Tags[cua])
 	}
 	return
 }

--- a/api/models/cluster_gen_test.go
+++ b/api/models/cluster_gen_test.go
@@ -237,6 +237,119 @@ func BenchmarkDecodeIndexFindResp(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalIndexTagDetailsResp(t *testing.T) {
+	v := IndexTagDetailsResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexTagDetailsResp(b *testing.B) {
+	v := IndexTagDetailsResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexTagDetailsResp(b *testing.B) {
+	v := IndexTagDetailsResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexTagDetailsResp(b *testing.B) {
+	v := IndexTagDetailsResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexTagDetailsResp(t *testing.T) {
+	v := IndexTagDetailsResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexTagDetailsResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexTagDetailsResp(b *testing.B) {
+	v := IndexTagDetailsResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexTagDetailsResp(b *testing.B) {
+	v := IndexTagDetailsResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalIndexTagFindSeriesResp(t *testing.T) {
 	v := IndexTagFindSeriesResp{}
 	bts, err := v.MarshalMsg(nil)
@@ -350,8 +463,8 @@ func BenchmarkDecodeIndexTagFindSeriesResp(b *testing.B) {
 	}
 }
 
-func TestMarshalUnmarshalIndexTagListResp(t *testing.T) {
-	v := IndexTagListResp{}
+func TestMarshalUnmarshalIndexTagsResp(t *testing.T) {
+	v := IndexTagsResp{}
 	bts, err := v.MarshalMsg(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -373,8 +486,8 @@ func TestMarshalUnmarshalIndexTagListResp(t *testing.T) {
 	}
 }
 
-func BenchmarkMarshalMsgIndexTagListResp(b *testing.B) {
-	v := IndexTagListResp{}
+func BenchmarkMarshalMsgIndexTagsResp(b *testing.B) {
+	v := IndexTagsResp{}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -382,8 +495,8 @@ func BenchmarkMarshalMsgIndexTagListResp(b *testing.B) {
 	}
 }
 
-func BenchmarkAppendMsgIndexTagListResp(b *testing.B) {
-	v := IndexTagListResp{}
+func BenchmarkAppendMsgIndexTagsResp(b *testing.B) {
+	v := IndexTagsResp{}
 	bts := make([]byte, 0, v.Msgsize())
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
@@ -394,8 +507,8 @@ func BenchmarkAppendMsgIndexTagListResp(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmarshalIndexTagListResp(b *testing.B) {
-	v := IndexTagListResp{}
+func BenchmarkUnmarshalIndexTagsResp(b *testing.B) {
+	v := IndexTagsResp{}
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
@@ -408,8 +521,8 @@ func BenchmarkUnmarshalIndexTagListResp(b *testing.B) {
 	}
 }
 
-func TestEncodeDecodeIndexTagListResp(t *testing.T) {
-	v := IndexTagListResp{}
+func TestEncodeDecodeIndexTagsResp(t *testing.T) {
+	v := IndexTagsResp{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 
@@ -418,7 +531,7 @@ func TestEncodeDecodeIndexTagListResp(t *testing.T) {
 		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
 	}
 
-	vn := IndexTagListResp{}
+	vn := IndexTagsResp{}
 	err := msgp.Decode(&buf, &vn)
 	if err != nil {
 		t.Error(err)
@@ -432,8 +545,8 @@ func TestEncodeDecodeIndexTagListResp(t *testing.T) {
 	}
 }
 
-func BenchmarkEncodeIndexTagListResp(b *testing.B) {
-	v := IndexTagListResp{}
+func BenchmarkEncodeIndexTagsResp(b *testing.B) {
+	v := IndexTagsResp{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))
@@ -446,121 +559,8 @@ func BenchmarkEncodeIndexTagListResp(b *testing.B) {
 	en.Flush()
 }
 
-func BenchmarkDecodeIndexTagListResp(b *testing.B) {
-	v := IndexTagListResp{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	rd := msgp.NewEndlessReader(buf.Bytes(), b)
-	dc := msgp.NewReader(rd)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err := v.DecodeMsg(dc)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestMarshalUnmarshalIndexTagResp(t *testing.T) {
-	v := IndexTagResp{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	left, err := v.UnmarshalMsg(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
-	}
-
-	left, err = msgp.Skip(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
-	}
-}
-
-func BenchmarkMarshalMsgIndexTagResp(b *testing.B) {
-	v := IndexTagResp{}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.MarshalMsg(nil)
-	}
-}
-
-func BenchmarkAppendMsgIndexTagResp(b *testing.B) {
-	v := IndexTagResp{}
-	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
-	b.SetBytes(int64(len(bts)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
-	}
-}
-
-func BenchmarkUnmarshalIndexTagResp(b *testing.B) {
-	v := IndexTagResp{}
-	bts, _ := v.MarshalMsg(nil)
-	b.ReportAllocs()
-	b.SetBytes(int64(len(bts)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := v.UnmarshalMsg(bts)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestEncodeDecodeIndexTagResp(t *testing.T) {
-	v := IndexTagResp{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-
-	m := v.Msgsize()
-	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
-	}
-
-	vn := IndexTagResp{}
-	err := msgp.Decode(&buf, &vn)
-	if err != nil {
-		t.Error(err)
-	}
-
-	buf.Reset()
-	msgp.Encode(&buf, &v)
-	err = msgp.NewReader(&buf).Skip()
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func BenchmarkEncodeIndexTagResp(b *testing.B) {
-	v := IndexTagResp{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	en := msgp.NewWriter(msgp.Nowhere)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.EncodeMsg(en)
-	}
-	en.Flush()
-}
-
-func BenchmarkDecodeIndexTagResp(b *testing.B) {
-	v := IndexTagResp{}
+func BenchmarkDecodeIndexTagsResp(b *testing.B) {
+	v := IndexTagsResp{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/api/models/cluster_gen_test.go
+++ b/api/models/cluster_gen_test.go
@@ -237,6 +237,345 @@ func BenchmarkDecodeIndexFindResp(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalIndexTagFindSeriesResp(t *testing.T) {
+	v := IndexTagFindSeriesResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexTagFindSeriesResp(b *testing.B) {
+	v := IndexTagFindSeriesResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexTagFindSeriesResp(b *testing.B) {
+	v := IndexTagFindSeriesResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexTagFindSeriesResp(b *testing.B) {
+	v := IndexTagFindSeriesResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexTagFindSeriesResp(t *testing.T) {
+	v := IndexTagFindSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexTagFindSeriesResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexTagFindSeriesResp(b *testing.B) {
+	v := IndexTagFindSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexTagFindSeriesResp(b *testing.B) {
+	v := IndexTagFindSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalIndexTagListResp(t *testing.T) {
+	v := IndexTagListResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexTagListResp(b *testing.B) {
+	v := IndexTagListResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexTagListResp(b *testing.B) {
+	v := IndexTagListResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexTagListResp(b *testing.B) {
+	v := IndexTagListResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexTagListResp(t *testing.T) {
+	v := IndexTagListResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexTagListResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexTagListResp(b *testing.B) {
+	v := IndexTagListResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexTagListResp(b *testing.B) {
+	v := IndexTagListResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalIndexTagResp(t *testing.T) {
+	v := IndexTagResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexTagResp(b *testing.B) {
+	v := IndexTagResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexTagResp(b *testing.B) {
+	v := IndexTagResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexTagResp(b *testing.B) {
+	v := IndexTagResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexTagResp(t *testing.T) {
+	v := IndexTagResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexTagResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexTagResp(b *testing.B) {
+	v := IndexTagResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexTagResp(b *testing.B) {
+	v := IndexTagResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalMetricsDeleteResp(t *testing.T) {
 	v := MetricsDeleteResp{}
 	bts, err := v.MarshalMsg(nil)

--- a/api/models/cluster_gen_test.go
+++ b/api/models/cluster_gen_test.go
@@ -124,6 +124,119 @@ func BenchmarkDecodeGetDataResp(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalIndexFindByTagResp(t *testing.T) {
+	v := IndexFindByTagResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexFindByTagResp(b *testing.B) {
+	v := IndexFindByTagResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexFindByTagResp(b *testing.B) {
+	v := IndexFindByTagResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexFindByTagResp(b *testing.B) {
+	v := IndexFindByTagResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexFindByTagResp(t *testing.T) {
+	v := IndexFindByTagResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexFindByTagResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexFindByTagResp(b *testing.B) {
+	v := IndexFindByTagResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexFindByTagResp(b *testing.B) {
+	v := IndexFindByTagResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalIndexFindResp(t *testing.T) {
 	v := IndexFindResp{}
 	bts, err := v.MarshalMsg(nil)
@@ -335,119 +448,6 @@ func BenchmarkEncodeIndexTagDetailsResp(b *testing.B) {
 
 func BenchmarkDecodeIndexTagDetailsResp(b *testing.B) {
 	v := IndexTagDetailsResp{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	rd := msgp.NewEndlessReader(buf.Bytes(), b)
-	dc := msgp.NewReader(rd)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err := v.DecodeMsg(dc)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestMarshalUnmarshalIndexTagFindSeriesResp(t *testing.T) {
-	v := IndexTagFindSeriesResp{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	left, err := v.UnmarshalMsg(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
-	}
-
-	left, err = msgp.Skip(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
-	}
-}
-
-func BenchmarkMarshalMsgIndexTagFindSeriesResp(b *testing.B) {
-	v := IndexTagFindSeriesResp{}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.MarshalMsg(nil)
-	}
-}
-
-func BenchmarkAppendMsgIndexTagFindSeriesResp(b *testing.B) {
-	v := IndexTagFindSeriesResp{}
-	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
-	b.SetBytes(int64(len(bts)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
-	}
-}
-
-func BenchmarkUnmarshalIndexTagFindSeriesResp(b *testing.B) {
-	v := IndexTagFindSeriesResp{}
-	bts, _ := v.MarshalMsg(nil)
-	b.ReportAllocs()
-	b.SetBytes(int64(len(bts)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := v.UnmarshalMsg(bts)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestEncodeDecodeIndexTagFindSeriesResp(t *testing.T) {
-	v := IndexTagFindSeriesResp{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-
-	m := v.Msgsize()
-	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
-	}
-
-	vn := IndexTagFindSeriesResp{}
-	err := msgp.Decode(&buf, &vn)
-	if err != nil {
-		t.Error(err)
-	}
-
-	buf.Reset()
-	msgp.Encode(&buf, &v)
-	err = msgp.NewReader(&buf).Skip()
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func BenchmarkEncodeIndexTagFindSeriesResp(b *testing.B) {
-	v := IndexTagFindSeriesResp{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	en := msgp.NewWriter(msgp.Nowhere)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.EncodeMsg(en)
-	}
-	en.Flush()
-}
-
-func BenchmarkDecodeIndexTagFindSeriesResp(b *testing.B) {
-	v := IndexTagFindSeriesResp{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -52,6 +52,36 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 	return errs
 }
 
+type GraphiteTagList struct {
+	From uint32 `json:"from" form:"from"`
+}
+
+type GraphiteTagListResp struct {
+	Tags []string `json:"tags"`
+}
+
+type GraphiteTag struct {
+	Tag string `json:"tag" form:"tag"`
+}
+
+type GraphiteTagValueResp struct {
+	Count uint32 `json:"count"`
+	Value string `json:"value"`
+}
+
+type GraphiteTagResp struct {
+	Tag    string                 `json:"tag" form:"tag"`
+	Values []GraphiteTagValueResp `json:"values"`
+}
+
+type GraphiteTagFindSeries struct {
+	Expr []string `json:"expr" form:"expr"`
+}
+
+type GraphiteTagFindSeriesResp struct {
+	Series []string `json:"series"`
+}
+
 type GraphiteFind struct {
 	FromTo
 	Query  string `json:"query" form:"query" binding:"Required"`

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -69,14 +69,14 @@ type GraphiteTagDetails struct {
 	From   int64  `json:"from"`
 }
 
-type GraphiteTagDetailsValueResp struct {
-	Count uint64 `json:"count"`
-	Value string `json:"value"`
-}
-
 type GraphiteTagDetailsResp struct {
 	Tag    string                        `json:"tag"`
 	Values []GraphiteTagDetailsValueResp `json:"values"`
+}
+
+type GraphiteTagDetailsValueResp struct {
+	Count uint64 `json:"count"`
+	Value string `json:"value"`
 }
 
 type GraphiteTagFindSeries struct {

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -52,25 +52,31 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 	return errs
 }
 
-type GraphiteTagList struct {
+type GraphiteTags struct {
 	Filter string `json:"filter"`
 	From   int64  `json:"from"`
 }
 
-type GraphiteTagListResp []GraphiteTag
+type GraphiteTagsResp []GraphiteTagResp
 
-type GraphiteTag struct {
+type GraphiteTagResp struct {
 	Tag string `json:"tag" form:"tag"`
 }
 
-type GraphiteTagValueResp struct {
-	Count uint32 `json:"count"`
+type GraphiteTagDetails struct {
+	Tag    string `json:"tag"`
+	Filter string `json:"filter"`
+	From   int64  `json:"from"`
+}
+
+type GraphiteTagDetailsValueResp struct {
+	Count uint64 `json:"count"`
 	Value string `json:"value"`
 }
 
-type GraphiteTagResp struct {
-	Tag    string                 `json:"tag" form:"tag"`
-	Values []GraphiteTagValueResp `json:"values"`
+type GraphiteTagDetailsResp struct {
+	Tag    string                        `json:"tag" form:"tag"`
+	Values []GraphiteTagDetailsValueResp `json:"values"`
 }
 
 type GraphiteTagFindSeries struct {

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -60,7 +60,7 @@ type GraphiteTags struct {
 type GraphiteTagsResp []GraphiteTagResp
 
 type GraphiteTagResp struct {
-	Tag string `json:"tag" form:"tag"`
+	Tag string `json:"tag"`
 }
 
 type GraphiteTagDetails struct {
@@ -75,12 +75,12 @@ type GraphiteTagDetailsValueResp struct {
 }
 
 type GraphiteTagDetailsResp struct {
-	Tag    string                        `json:"tag" form:"tag"`
+	Tag    string                        `json:"tag"`
 	Values []GraphiteTagDetailsValueResp `json:"values"`
 }
 
 type GraphiteTagFindSeries struct {
-	Expr []string `json:"expr" form:"expr"`
+	Expr []string `json:"expr"`
 	From int64    `json:"from"`
 }
 

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -81,6 +81,7 @@ type GraphiteTagDetailsResp struct {
 
 type GraphiteTagFindSeries struct {
 	Expr []string `json:"expr" form:"expr"`
+	From int64    `json:"from"`
 }
 
 type GraphiteTagFindSeriesResp struct {

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -53,12 +53,11 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 }
 
 type GraphiteTagList struct {
-	From uint32 `json:"from" form:"from"`
+	Filter string `json:"filter"`
+	From   int64  `json:"from"`
 }
 
-type GraphiteTagListResp struct {
-	Tags []string `json:"tags"`
-}
+type GraphiteTagListResp []GraphiteTag
 
 type GraphiteTag struct {
 	Tag string `json:"tag" form:"tag"`

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -38,6 +38,7 @@ func (i IndexList) TraceDebug(span opentracing.Span) {
 type IndexTagFindSeries struct {
 	OrgId       int      `json:"orgId" form:"orgId" binding:"Required"`
 	Expressions []string `json:"expressions"`
+	From        int64    `json:"from"`
 }
 
 func (t IndexTagFindSeries) Trace(span opentracing.Span) {

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -48,31 +48,36 @@ func (t IndexTagFindSeries) Trace(span opentracing.Span) {
 func (i IndexTagFindSeries) TraceDebug(span opentracing.Span) {
 }
 
-type IndexTag struct {
-	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
-	Tag   string `json:"tag"`
+type IndexTagDetails struct {
+	OrgId  int    `json:"orgId" form:"orgId" binding:"Required"`
+	Filter string `json:"filter"`
+	Tag    string `json:"tag"`
+	From   int64  `json:"from"`
 }
 
-func (t IndexTag) Trace(span opentracing.Span) {
+func (t IndexTagDetails) Trace(span opentracing.Span) {
 	span.SetTag("org", t.OrgId)
+	span.SetTag("filter", t.Filter)
 	span.SetTag("tag", t.Tag)
+	span.SetTag("from", t.From)
 }
 
-func (i IndexTag) TraceDebug(span opentracing.Span) {
+func (i IndexTagDetails) TraceDebug(span opentracing.Span) {
 }
 
-type IndexTagList struct {
-	OrgId  int    `json:"orgId" binding:"Required"`
+type IndexTags struct {
+	OrgId  int    `json:"orgId" form:"orgId" binding:"Required"`
 	Filter string `json:"filter"`
 	From   int64  `json:"from"`
 }
 
-func (t IndexTagList) Trace(span opentracing.Span) {
+func (t IndexTags) Trace(span opentracing.Span) {
 	span.SetTag("org", t.OrgId)
+	span.SetTag("filter", t.Filter)
 	span.SetTag("from", t.From)
 }
 
-func (i IndexTagList) TraceDebug(span opentracing.Span) {
+func (i IndexTags) TraceDebug(span opentracing.Span) {
 }
 
 type IndexGet struct {

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -62,8 +62,9 @@ func (i IndexTag) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTagList struct {
-	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
-	From  uint32 `json:"from" form:"from"`
+	OrgId  int    `json:"orgId" binding:"Required"`
+	Filter string `json:"filter"`
+	From   int64  `json:"from"`
 }
 
 func (t IndexTagList) Trace(span opentracing.Span) {

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -35,19 +35,19 @@ func (i IndexList) Trace(span opentracing.Span) {
 func (i IndexList) TraceDebug(span opentracing.Span) {
 }
 
-type IndexTagFindSeries struct {
+type IndexFindByTag struct {
 	OrgId int      `json:"orgId" binding:"Required"`
 	Expr  []string `json:"expressions"`
 	From  int64    `json:"from"`
 }
 
-func (t IndexTagFindSeries) Trace(span opentracing.Span) {
+func (t IndexFindByTag) Trace(span opentracing.Span) {
 	span.SetTag("org", t.OrgId)
 	span.SetTag("expressions", t.Expr)
 	span.SetTag("from", t.From)
 }
 
-func (i IndexTagFindSeries) TraceDebug(span opentracing.Span) {
+func (i IndexFindByTag) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTagDetails struct {

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -53,7 +53,7 @@ func (i IndexTagFindSeries) TraceDebug(span opentracing.Span) {
 type IndexTagDetails struct {
 	OrgId  int    `json:"orgId" binding:"Required"`
 	Filter string `json:"filter"`
-	Tag    string `json:"tag"`
+	Tag    string `json:"tag" binding:"Required"`
 	From   int64  `json:"from"`
 }
 

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -36,14 +36,14 @@ func (i IndexList) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTagFindSeries struct {
-	OrgId       int      `json:"orgId" binding:"Required"`
-	Expressions []string `json:"expressions"`
-	From        int64    `json:"from"`
+	OrgId int      `json:"orgId" binding:"Required"`
+	Expr  []string `json:"expressions"`
+	From  int64    `json:"from"`
 }
 
 func (t IndexTagFindSeries) Trace(span opentracing.Span) {
 	span.SetTag("org", t.OrgId)
-	span.SetTag("expressions", t.Expressions)
+	span.SetTag("expressions", t.Expr)
 	span.SetTag("from", t.From)
 }
 

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -36,7 +36,7 @@ func (i IndexList) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTagFindSeries struct {
-	OrgId       int      `json:"orgId" form:"orgId" binding:"Required"`
+	OrgId       int      `json:"orgId" binding:"Required"`
 	Expressions []string `json:"expressions"`
 	From        int64    `json:"from"`
 }
@@ -44,13 +44,14 @@ type IndexTagFindSeries struct {
 func (t IndexTagFindSeries) Trace(span opentracing.Span) {
 	span.SetTag("org", t.OrgId)
 	span.SetTag("expressions", t.Expressions)
+	span.SetTag("from", t.From)
 }
 
 func (i IndexTagFindSeries) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTagDetails struct {
-	OrgId  int    `json:"orgId" form:"orgId" binding:"Required"`
+	OrgId  int    `json:"orgId" binding:"Required"`
 	Filter string `json:"filter"`
 	Tag    string `json:"tag"`
 	From   int64  `json:"from"`
@@ -67,7 +68,7 @@ func (i IndexTagDetails) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTags struct {
-	OrgId  int    `json:"orgId" form:"orgId" binding:"Required"`
+	OrgId  int    `json:"orgId" binding:"Required"`
 	Filter string `json:"filter"`
 	From   int64  `json:"from"`
 }

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -35,6 +35,36 @@ func (i IndexList) Trace(span opentracing.Span) {
 func (i IndexList) TraceDebug(span opentracing.Span) {
 }
 
+type IndexTagFindSeries struct {
+	OrgId       int      `json:"orgId" form:"orgId" binding:"Required"`
+	Expressions []string `json:"expressions"`
+}
+
+func (t IndexTagFindSeries) Trace(span opentracing.Span) {
+	span.SetTag("org", t.OrgId)
+	span.SetTag("expressions", t.Expressions)
+}
+
+type IndexTag struct {
+	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
+	Tag   string `json:"tag"`
+}
+
+func (t IndexTag) Trace(span opentracing.Span) {
+	span.SetTag("org", t.OrgId)
+	span.SetTag("tag", t.Tag)
+}
+
+type IndexTagList struct {
+	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
+	From  uint32 `json:"from" form:"from"`
+}
+
+func (t IndexTagList) Trace(span opentracing.Span) {
+	span.SetTag("org", t.OrgId)
+	span.SetTag("from", t.From)
+}
+
 type IndexGet struct {
 	Id string `json:"id" form:"id" binding:"Required"`
 }

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -45,6 +45,9 @@ func (t IndexTagFindSeries) Trace(span opentracing.Span) {
 	span.SetTag("expressions", t.Expressions)
 }
 
+func (i IndexTagFindSeries) TraceDebug(span opentracing.Span) {
+}
+
 type IndexTag struct {
 	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
 	Tag   string `json:"tag"`
@@ -55,6 +58,9 @@ func (t IndexTag) Trace(span opentracing.Span) {
 	span.SetTag("tag", t.Tag)
 }
 
+func (i IndexTag) TraceDebug(span opentracing.Span) {
+}
+
 type IndexTagList struct {
 	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
 	From  uint32 `json:"from" form:"from"`
@@ -63,6 +69,9 @@ type IndexTagList struct {
 func (t IndexTagList) Trace(span opentracing.Span) {
 	span.SetTag("org", t.OrgId)
 	span.SetTag("from", t.From)
+}
+
+func (i IndexTagList) TraceDebug(span opentracing.Span) {
 }
 
 type IndexGet struct {

--- a/api/models/series_gen.go
+++ b/api/models/series_gen.go
@@ -13,13 +13,13 @@ import (
 func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zbzg uint32
-	zbzg, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zbzg > 0 {
-		zbzg--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -31,18 +31,18 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Datapoints":
-			var zbai uint32
-			zbai, err = dc.ReadArrayHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Datapoints) >= int(zbai) {
-				z.Datapoints = (z.Datapoints)[:zbai]
+			if cap(z.Datapoints) >= int(zb0002) {
+				z.Datapoints = (z.Datapoints)[:zb0002]
 			} else {
-				z.Datapoints = make([]schema.Point, zbai)
+				z.Datapoints = make([]schema.Point, zb0002)
 			}
-			for zxvk := range z.Datapoints {
-				err = z.Datapoints[zxvk].DecodeMsg(dc)
+			for za0001 := range z.Datapoints {
+				err = z.Datapoints[za0001].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -108,8 +108,8 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zxvk := range z.Datapoints {
-		err = z.Datapoints[zxvk].EncodeMsg(en)
+	for za0001 := range z.Datapoints {
+		err = z.Datapoints[za0001].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -181,8 +181,8 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Datapoints"
 	o = append(o, 0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Datapoints)))
-	for zxvk := range z.Datapoints {
-		o, err = z.Datapoints[zxvk].MarshalMsg(o)
+	for za0001 := range z.Datapoints {
+		o, err = z.Datapoints[za0001].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -218,13 +218,13 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -236,18 +236,18 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Datapoints":
-			var zajw uint32
-			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Datapoints) >= int(zajw) {
-				z.Datapoints = (z.Datapoints)[:zajw]
+			if cap(z.Datapoints) >= int(zb0002) {
+				z.Datapoints = (z.Datapoints)[:zb0002]
 			} else {
-				z.Datapoints = make([]schema.Point, zajw)
+				z.Datapoints = make([]schema.Point, zb0002)
 			}
-			for zxvk := range z.Datapoints {
-				bts, err = z.Datapoints[zxvk].UnmarshalMsg(bts)
+			for za0001 := range z.Datapoints {
+				bts, err = z.Datapoints[za0001].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -296,8 +296,8 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Series) Msgsize() (s int) {
 	s = 1 + 7 + msgp.StringPrefixSize + len(z.Target) + 11 + msgp.ArrayHeaderSize
-	for zxvk := range z.Datapoints {
-		s += z.Datapoints[zxvk].Msgsize()
+	for za0001 := range z.Datapoints {
+		s += z.Datapoints[za0001].Msgsize()
 	}
 	s += 9 + msgp.Uint32Size + 10 + msgp.StringPrefixSize + len(z.QueryPatt) + 10 + msgp.Uint32Size + 8 + msgp.Uint32Size + 10 + z.QueryCons.Msgsize() + 13 + z.Consolidator.Msgsize()
 	return
@@ -305,18 +305,18 @@ func (z *Series) Msgsize() (s int) {
 
 // DecodeMsg implements msgp.Decodable
 func (z *SeriesByTarget) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zcua uint32
-	zcua, err = dc.ReadArrayHeader()
+	var zb0002 uint32
+	zb0002, err = dc.ReadArrayHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zcua) {
-		(*z) = (*z)[:zcua]
+	if cap((*z)) >= int(zb0002) {
+		(*z) = (*z)[:zb0002]
 	} else {
-		(*z) = make(SeriesByTarget, zcua)
+		(*z) = make(SeriesByTarget, zb0002)
 	}
-	for zhct := range *z {
-		err = (*z)[zhct].DecodeMsg(dc)
+	for zb0001 := range *z {
+		err = (*z)[zb0001].DecodeMsg(dc)
 		if err != nil {
 			return
 		}
@@ -330,8 +330,8 @@ func (z SeriesByTarget) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zxhx := range z {
-		err = z[zxhx].EncodeMsg(en)
+	for zb0003 := range z {
+		err = z[zb0003].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -343,8 +343,8 @@ func (z SeriesByTarget) EncodeMsg(en *msgp.Writer) (err error) {
 func (z SeriesByTarget) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
-	for zxhx := range z {
-		o, err = z[zxhx].MarshalMsg(o)
+	for zb0003 := range z {
+		o, err = z[zb0003].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -354,18 +354,18 @@ func (z SeriesByTarget) MarshalMsg(b []byte) (o []byte, err error) {
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *SeriesByTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var zdaf uint32
-	zdaf, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	var zb0002 uint32
+	zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zdaf) {
-		(*z) = (*z)[:zdaf]
+	if cap((*z)) >= int(zb0002) {
+		(*z) = (*z)[:zb0002]
 	} else {
-		(*z) = make(SeriesByTarget, zdaf)
+		(*z) = make(SeriesByTarget, zb0002)
 	}
-	for zlqf := range *z {
-		bts, err = (*z)[zlqf].UnmarshalMsg(bts)
+	for zb0001 := range *z {
+		bts, err = (*z)[zb0001].UnmarshalMsg(bts)
 		if err != nil {
 			return
 		}
@@ -377,8 +377,8 @@ func (z *SeriesByTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z SeriesByTarget) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for zpks := range z {
-		s += z[zpks].Msgsize()
+	for zb0003 := range z {
+		s += z[zb0003].Msgsize()
 	}
 	return
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -52,7 +52,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/metrics/find", withOrg, ready, bind(models.GraphiteFind{})).Get(s.metricsFind).Post(s.metricsFind)
 	r.Get("/metrics/index.json", withOrg, ready, s.metricsIndex)
 	r.Post("/metrics/delete", withOrg, ready, bind(models.MetricsDelete{}), s.metricsDelete)
-	r.Combo("/tags", withOrg, ready, bind(models.GraphiteTags{})).Get(s.graphiteTags).Post(s.graphiteTags)
-	r.Combo("/tags/:tag([0-9a-zA-Z]+)", withOrg, ready, bind(models.GraphiteTagDetails{})).Get(s.graphiteTagDetails).Post(s.graphiteTagDetails)
-	r.Combo("/tags/findSeries", withOrg, ready, bind(models.GraphiteTagFindSeries{})).Get(s.graphiteTagFindSeries).Post(s.graphiteTagFindSeries)
+	r.Combo("/metrics/tags", withOrg, ready, bind(models.GraphiteTags{})).Get(s.graphiteTags).Post(s.graphiteTags)
+	r.Combo("/metrics/tags/:tag([0-9a-zA-Z]+)", withOrg, ready, bind(models.GraphiteTagDetails{})).Get(s.graphiteTagDetails).Post(s.graphiteTagDetails)
+	r.Combo("/metrics/tags/findSeries", withOrg, ready, bind(models.GraphiteTagFindSeries{})).Get(s.graphiteTagFindSeries).Post(s.graphiteTagFindSeries)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -40,8 +40,8 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/delete", ready, bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
 	r.Combo("/index/get", ready, bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
 	r.Combo("/index/tags", ready, bind(models.IndexTags{})).Get(s.indexTags).Post(s.indexTags)
-	r.Combo("/index/tags/findSeries", ready, bind(models.IndexTagFindSeries{})).Get(s.indexTagFindSeries).Post(s.indexTagFindSeries)
-	r.Combo("/index/tags/:tag([0-9a-zA-Z]+)", ready, bind(models.IndexTagDetails{})).Get(s.indexTagDetails).Post(s.indexTagDetails)
+	r.Combo("/index/find_by_tag", ready, bind(models.IndexTagFindSeries{})).Get(s.indexTagFindSeries).Post(s.indexTagFindSeries)
+	r.Combo("/index/tag_details", ready, bind(models.IndexTagDetails{})).Get(s.indexTagDetails).Post(s.indexTagDetails)
 
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)

--- a/api/routes.go
+++ b/api/routes.go
@@ -39,9 +39,9 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/list", ready, bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
 	r.Combo("/index/delete", ready, bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
 	r.Combo("/index/get", ready, bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
-	r.Combo("/index/tags", ready, bind(models.IndexTagList{})).Get(s.indexTagList).Post(s.indexTagList)
+	r.Combo("/index/tags", ready, bind(models.IndexTags{})).Get(s.indexTags).Post(s.indexTags)
 	r.Combo("/index/tags/findSeries", ready, bind(models.IndexTagFindSeries{})).Get(s.indexTagFindSeries).Post(s.indexTagFindSeries)
-	r.Combo("/index/tags/:tag([0-9a-zA-Z]+)", ready, bind(models.IndexTag{})).Get(s.indexTag).Post(s.indexTag)
+	r.Combo("/index/tags/:tag([0-9a-zA-Z]+)", ready, bind(models.IndexTagDetails{})).Get(s.indexTagDetails).Post(s.indexTagDetails)
 
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)
@@ -52,7 +52,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/metrics/find", withOrg, ready, bind(models.GraphiteFind{})).Get(s.metricsFind).Post(s.metricsFind)
 	r.Get("/metrics/index.json", withOrg, ready, s.metricsIndex)
 	r.Post("/metrics/delete", withOrg, ready, bind(models.MetricsDelete{}), s.metricsDelete)
-	r.Combo("/tags", withOrg, ready, bind(models.GraphiteTagList{})).Get(s.graphiteTagList).Post(s.graphiteTagList)
-	r.Combo("/tags/:tag([0-9a-zA-Z]+)", withOrg, ready, bind(models.GraphiteTag{})).Get(s.graphiteTag).Post(s.graphiteTag)
+	r.Combo("/tags", withOrg, ready, bind(models.GraphiteTags{})).Get(s.graphiteTags).Post(s.graphiteTags)
+	r.Combo("/tags/:tag([0-9a-zA-Z]+)", withOrg, ready, bind(models.GraphiteTagDetails{})).Get(s.graphiteTagDetails).Post(s.graphiteTagDetails)
 	r.Combo("/tags/findSeries", withOrg, ready, bind(models.GraphiteTagFindSeries{})).Get(s.graphiteTagFindSeries).Post(s.graphiteTagFindSeries)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -39,6 +39,9 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/list", ready, bind(models.IndexList{})).Get(s.indexList).Post(s.indexList)
 	r.Combo("/index/delete", ready, bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
 	r.Combo("/index/get", ready, bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
+	r.Combo("/index/tags", ready, bind(models.IndexTagList{})).Get(s.indexTagList).Post(s.indexTagList)
+	r.Combo("/index/tags/findSeries", ready, bind(models.IndexTagFindSeries{})).Get(s.indexTagFindSeries).Post(s.indexTagFindSeries)
+	r.Combo("/index/tags/:tag([0-9a-zA-Z]+)", ready, bind(models.IndexTag{})).Get(s.indexTag).Post(s.indexTag)
 
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)
@@ -49,5 +52,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/metrics/find", withOrg, ready, bind(models.GraphiteFind{})).Get(s.metricsFind).Post(s.metricsFind)
 	r.Get("/metrics/index.json", withOrg, ready, s.metricsIndex)
 	r.Post("/metrics/delete", withOrg, ready, bind(models.MetricsDelete{}), s.metricsDelete)
-
+	r.Combo("/tags", withOrg, ready, bind(models.GraphiteTagList{})).Get(s.graphiteTagList).Post(s.graphiteTagList)
+	r.Combo("/tags/:tag([0-9a-zA-Z]+)", withOrg, ready, bind(models.GraphiteTag{})).Get(s.graphiteTag).Post(s.graphiteTag)
+	r.Combo("/tags/findSeries", withOrg, ready, bind(models.GraphiteTagFindSeries{})).Get(s.graphiteTagFindSeries).Post(s.graphiteTagFindSeries)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -40,7 +40,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/delete", ready, bind(models.IndexDelete{})).Get(s.indexDelete).Post(s.indexDelete)
 	r.Combo("/index/get", ready, bind(models.IndexGet{})).Get(s.indexGet).Post(s.indexGet)
 	r.Combo("/index/tags", ready, bind(models.IndexTags{})).Get(s.indexTags).Post(s.indexTags)
-	r.Combo("/index/find_by_tag", ready, bind(models.IndexTagFindSeries{})).Get(s.indexTagFindSeries).Post(s.indexTagFindSeries)
+	r.Combo("/index/find_by_tag", ready, bind(models.IndexFindByTag{})).Get(s.indexFindByTag).Post(s.indexFindByTag)
 	r.Combo("/index/tag_details", ready, bind(models.IndexTagDetails{})).Get(s.indexTagDetails).Post(s.indexTagDetails)
 
 	r.Options("/*", func(ctx *macaron.Context) {

--- a/consolidation/consolidation_gen.go
+++ b/consolidation/consolidation_gen.go
@@ -11,12 +11,12 @@ import (
 // DecodeMsg implements msgp.Decodable
 func (z *Consolidator) DecodeMsg(dc *msgp.Reader) (err error) {
 	{
-		var zxvk int
-		zxvk, err = dc.ReadInt()
-		(*z) = Consolidator(zxvk)
-	}
-	if err != nil {
-		return
+		var zb0001 int
+		zb0001, err = dc.ReadInt()
+		if err != nil {
+			return
+		}
+		(*z) = Consolidator(zb0001)
 	}
 	return
 }
@@ -40,12 +40,12 @@ func (z Consolidator) MarshalMsg(b []byte) (o []byte, err error) {
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *Consolidator) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	{
-		var zbzg int
-		zbzg, bts, err = msgp.ReadIntBytes(bts)
-		(*z) = Consolidator(zbzg)
-	}
-	if err != nil {
-		return
+		var zb0001 int
+		zb0001, bts, err = msgp.ReadIntBytes(bts)
+		if err != nil {
+			return
+		}
+		(*z) = Consolidator(zb0001)
 	}
 	o = bts
 	return

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -293,8 +293,6 @@ FOR:
 		default:
 			break FOR
 		}
-
-		allowEqual = false
 	}
 
 	if i == len(s) {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -264,11 +264,16 @@ func parseConst(s string) (*expr, string, error) {
 func parseName(s string) (string, string) {
 
 	var i int
+	allowEqual := false
 
 FOR:
 	for braces := 0; i < len(s); i++ {
-
-		if isNameChar(s[i]) {
+		// if the current expression is a metric name with ";" (59) we should
+		// allow the "=" (61) character to be part of the metric name
+		if isNameChar(s[i]) || (allowEqual && s[i] == 61) {
+			if s[i] == 59 {
+				allowEqual = true
+			}
 			continue
 		}
 
@@ -289,6 +294,7 @@ FOR:
 			break FOR
 		}
 
+		allowEqual = false
 	}
 
 	if i == len(s) {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -177,6 +177,8 @@ func parseArgList(e string) (string, []*expr, map[string]*expr, string, error) {
 		}
 
 		// we now know we're parsing a key-value pair
+		// in the future we should probably add validation here that the key
+		// can't contain otherwise-valid-name chars like {, }, etc
 		if arg.etype == etName && e[0] == '=' {
 			e = e[1:]
 			argCont, eCont, errCont := Parse(e)
@@ -261,6 +263,15 @@ func parseConst(s string) (*expr, string, error) {
 	return &expr{int: v, str: s[:i], etype: etInt}, s[i:], err
 }
 
+// parseName parses a "name" which is either:
+// 1) a metric expression
+// 2) the key of a keyword argument
+// 3) a function name
+// It's up to the caller to determine which, based on context. E.g.:
+// * if leftover data starts with '(' then assume 3 and validate function name
+// * if leftover data starts with '=' assume 2
+// * fallback to assuming 1.
+// it returns the parsed name and any leftover data
 func parseName(s string) (string, string) {
 
 	var i int

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -305,6 +305,23 @@ func TestParse(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"func(metric1;tag1=val1, key2='value2', metric2;tag2=val2, key1='value1')",
+			&expr{
+				str:   "func",
+				etype: etFunc,
+				args: []*expr{
+					{str: "metric1;tag1=val1"},
+					{str: "metric2;tag2=val2"},
+				},
+				namedArgs: map[string]*expr{
+					"key2": {etype: etString, str: "value2"},
+					"key1": {etype: etString, str: "value1"},
+				},
+				argsStr: "metric1;tag1=val1, key2='value2', metric2;tag2=val2, key1='value1'",
+			},
+			nil,
+		},
 
 		{
 			`foo.{bar,baz}.qux`,

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -29,6 +29,24 @@ func TestParse(t *testing.T) {
 			nil,
 		},
 		{
+			"a.b.c;tagkey1=tagvalue1;tagkey2=tagvalue2",
+			&expr{str: "a.b.c;tagkey1=tagvalue1;tagkey2=tagvalue2"},
+			nil,
+		},
+		{
+			"func(metric;tag1=value1, key='value')",
+			&expr{
+				str:     "func",
+				etype:   etFunc,
+				args:    []*expr{{str: "metric;tag1=value1"}},
+				argsStr: "metric;tag1=value1, key='value'",
+				namedArgs: map[string]*expr{
+					"key": {etype: etString, str: "value"},
+				},
+			},
+			nil,
+		},
+		{
 			"func(metric)",
 			&expr{
 				str:     "func",

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -306,19 +306,22 @@ func TestParse(t *testing.T) {
 			nil,
 		},
 		{
-			"func(metric1;tag1=val1, key2='value2', metric2;tag2=val2, key1='value1')",
+			"func(metric1;tag1=val1, key1='value1', metric2;tag2=val2, key2=true, metric3;tag3=val3, key3=None, metric4;tag4=val4)",
 			&expr{
 				str:   "func",
 				etype: etFunc,
 				args: []*expr{
 					{str: "metric1;tag1=val1"},
 					{str: "metric2;tag2=val2"},
+					{str: "metric3;tag3=val3"},
+					{str: "metric4;tag4=val4"},
 				},
 				namedArgs: map[string]*expr{
-					"key2": {etype: etString, str: "value2"},
 					"key1": {etype: etString, str: "value1"},
+					"key2": {etype: etBool, str: "true", bool: true},
+					"key3": {etype: etName, str: "None"},
 				},
-				argsStr: "metric1;tag1=val1, key2='value2', metric2;tag2=val2, key1='value1'",
+				argsStr: "metric1;tag1=val1, key1='value1', metric2;tag2=val2, key2=true, metric3;tag3=val3, key3=None, metric4;tag4=val4",
 			},
 			nil,
 		},

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -80,106 +80,77 @@ func NewArchiveBare(name string) Archive {
 	}
 }
 
-/*
-Currently the index is solely used for supporting Graphite style queries.
-So, the index only needs to be able to search by a pattern that matches the
-MetricDefinition.Name field. In future we plan to extend the searching
-capabilities to include the other fields in the definition.
-
-Note:
-
-* metrictank is a multi-tenant system where different orgs cannot see each
-  other's data
-
-* any given metric may appear multiple times, under different organisations
-
-* Each metric path can be mapped to multiple metricDefinitions in the case that
-  fields other then the Name vary.  The most common occurrence of this is when
-  the Interval at which the metric is being collected has changed.
-
-Interface
-
-* Init()
-  This is the initialization step performed at startup. This method should
-  block until the index is ready to handle searches.
-
-* Stop():
- This will be called when metrictank is shutting down.
-
-* AddOrUpdate(*schema.MetricData, int32) Archive:
-  Every metric received will result in a call to this method to ensure the
-  metric has been added to the index. The method is passed the metricData
-  payload and the partition id of the metric
-
-* Get(string) (Archive, bool):
-  This method should return the MetricDefintion with the passed Id.
-
-* GetPath(string) (Archive, bool) []Archive:
-  This method should return the archives under the given path
-
-* List(int) []Archive:
-  This method should return all MetricDefinitions for the passed OrgId.  If the
-  passed OrgId is "-1", then all metricDefinitions across all organisations
-  should be returned.
-
-* Find(int, string, int64) ([]Node, error):
-  This method provides searches.  The method is passed an OrgId, a query
-  pattern and a unix timestamp. Searches should return all nodes that match for
-  the given OrgId and OrgId -1.  The pattern should be handled in the same way
-  Graphite would. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
-  And the unix stimestamp is used to ignore series that have been stale since
-  the timestamp.
-
-* Delete(int, string) ([]Archive, error):
-  This method is used for deleting items from the index. The method is passed
-  an OrgId and a query pattern.  If the pattern matches a branch node, then
-  all leaf nodes on that branch should also be deleted. So if the pattern is
-  "*", all items in the index should be deleted.  A copy of all of the
-  metricDefinitions deleted are returned.
-
-* Prune(int, time.Time) ([]Archive, error):
-  This method should delete all metrics from the index for the passed org where
-  the last time the metric was seen is older then the passed timestamp. If the org
-  passed is -1, then the all orgs should be examined for stale metrics to be deleted.
-  The method returns a list of the metricDefinitions deleted from the index and any
-  error encountered.
-
-* Tags(int, string, int64) ([]string, error):
-  This method returns a list of all tag keys associated with the metrics of a given
-  organization. The return values are filtered by the regex in the second parameter.
-  If the third parameter is >0 then only metrics will be accounted of which the
-  LastUpdate time is >= the given value.
-
-* TagDetails(int, string, string, int64) map[string]uint64:
-  This method returns a list of all values associated with a given tag key in the
-  given org. The occurences of each value is counted and the count is referred to by
-  the metric names in the returned map.
-  If the third parameter is not "" it will be used as a regular expression to filter
-  the values before accouting for them.
-  If the fourth parameter is > 0 then the metrics will be filtered and only those
-  of which the LastUpdate time is >= the from timestamp will be considered while
-  the others are being ignored.
-
-* FindByTag(int, []string, int64) ([]string, error):
-  This method takes a list of expressions in the format key<operator>value.
-  The allowed operators are: =, !=, =~, !=~.
-  It returns a slice of metric names that match the given conditions, the
-  conditions are logically AND-ed.
-  If the third argument is > 0 then the results will be filtered and only those
-  where the LastUpdate time is >= from will be returned as results.
-*/
-
+// The MetricIndex interface supports Graphite style queries.
+// Note:
+// * metrictank is a multi-tenant system where different orgs cannot see each
+//   other's data, and any given metric name may appear multiple times,
+//   under different organisations
+//
+// * Each metric path can be mapped to multiple metricDefinitions in the case that
+//   fields other then the Name vary.  The most common occurrence of this is when
+//   the Interval at which the metric is being collected has changed.
 type MetricIndex interface {
+	// Init initializes the index at startup and
+	// blocks until the index is ready for use.
 	Init() error
+
+	// Stop shuts down the index.
 	Stop()
+
+	// AddOrUpdate makes sure a metric is known in the index,
+	// and should be called for every received metric.
 	AddOrUpdate(*schema.MetricData, int32) Archive
+
+	// Get returns the archive for the requested id.
 	Get(string) (Archive, bool)
+
+	// GetPath returns the archives under the given path.
 	GetPath(int, string) []Archive
+
+	// Delete deletes items from the index for the given org and query.
+	// If the pattern matches a branch node, then
+	// all leaf nodes on that branch are deleted. So if the pattern is
+	// "*", all items in the index are deleted.
+	// It returns a copy of all of the Archives deleted.
 	Delete(int, string) ([]Archive, error)
+
+	// Find searches the index.  The method is passed an OrgId, a query
+	// pattern and a unix timestamp. Searches should return all nodes that match for
+	// the given OrgId and OrgId -1.  The pattern should be handled in the same way
+	// Graphite would. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
+	// And the unix stimestamp is used to ignore series that have been stale since
+	// the timestamp.
 	Find(int, string, int64) ([]Node, error)
+
+	// List returns all Archives for the passed OrgId, or for all organisations if -1 is provided.
 	List(int) []Archive
+
+	// Prune deletes all metrics from the index for the passed org where
+	// the last time the metric was seen is older then the passed timestamp. If the org
+	// passed is -1, then the all orgs should be examined for stale metrics to be deleted.
+	// It returns all Archives deleted and any error encountered.
 	Prune(int, time.Time) ([]Archive, error)
+
+	// FindByTag takes a list of expressions in the format key<operator>value.
+	// The allowed operators are: =, !=, =~, !=~.
+	// It returns a slice of metric names that match the given conditions, the
+	// conditions are logically AND-ed.
+	// If the third argument is > 0 then the results will be filtered and only those
+	// where the LastUpdate time is >= from will be returned as results.
 	FindByTag(int, []string, int64) ([]string, error)
+
+	// Tags returns a list of all tag keys associated with the metrics of a given
+	// organization. The return values are filtered by the regex in the second parameter.
+	// If the third parameter is >0 then only metrics will be accounted of which the
+	// LastUpdate time is >= the given value.
 	Tags(int, string, int64) ([]string, error)
+
+	// TagDetails returns a list of all values associated with a given tag key in the
+	// given org. The occurences of each value is counted and the count is referred to by
+	// the metric names in the returned map.
+	// If the third parameter is not "" it will be used as a regular expression to filter
+	// the values before accounting for them.
+	// If the fourth parameter is > 0 then only those metrics of which the LastUpdate
+	// time is >= the from timestamp will be included.
 	TagDetails(int, string, string, int64) (map[string]uint64, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -144,9 +144,9 @@ Interface
   The method returns a list of the metricDefinitions deleted from the index and any
   error encountered.
 
-* TagList(int) []string:
+* TagList(int, string, int64) ([]string, error):
   This method returns a list of all tag keys associated with the metrics of a given
-  organization.
+  organization. The return values are filtered by the regex in the second parameter.
 
 * Tag(int, string, int64) map[string]uint32:
   This method returns a list of all values associated with a given tag key in the
@@ -173,7 +173,7 @@ type MetricIndex interface {
 	Find(int, string, int64) ([]Node, error)
 	List(int) []Archive
 	Prune(int, time.Time) ([]Archive, error)
-	TagList(int) []string
+	TagList(int, string, int64) ([]string, error)
 	Tag(int, string, int64) map[string]uint32
 	FindByTag(int, []string, int64) (map[MetricID]struct{}, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -40,11 +40,6 @@ type MetricID struct {
 	key [16]byte
 }
 
-type TagValueDetail struct {
-	Value string
-	Count uint64
-}
-
 func NewMetricIDFromString(s string) (MetricID, error) {
 	id := MetricID{}
 	err := id.FromString(s)
@@ -152,11 +147,16 @@ Interface
 * TagList(int, string, int64) ([]string, error):
   This method returns a list of all tag keys associated with the metrics of a given
   organization. The return values are filtered by the regex in the second parameter.
+  If the third parameter is >0 then only metrics will be account of which the
+  LastUpdate time is >= the given value.
 
-* Tag(int, string, int64) map[string]uint32:
+* TagDetails(int, string, string, int64) map[string]uint32:
   This method returns a list of all values associated with a given tag key in the
   given org. The occurences of each value is counted and the count is referred to by
-  the series ids in the returned map. If the third parameter is > 0 then the metrics
+  the series ids in the returned map.
+  If the third parameter is not "" it will be used as a regular expression to filter
+  the values before accouting for them.
+  If the fourth parameter is > 0 then the metrics
   will be filtered and only those of which the LastUpdate time is >= the from
   timestamp will be considered while the others are being ignored.
 
@@ -178,9 +178,7 @@ type MetricIndex interface {
 	Find(int, string, int64) ([]Node, error)
 	List(int) []Archive
 	Prune(int, time.Time) ([]Archive, error)
-	TagList(int, string, int64) ([]string, error)
-	Tag(int, string, int64) map[string]uint32
 	FindByTag(int, []string, int64) (map[MetricID]struct{}, error)
-	TagKeys(int, string, int64) ([]string, error)
-	TagValues(int, string, string, int64) ([]TagValueDetail, error)
+	Tags(int, string, int64) ([]string, error)
+	TagDetails(int, string, string, int64) (map[string]uint64, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -137,6 +137,8 @@ type MetricIndex interface {
 	// conditions are logically AND-ed.
 	// If the third argument is > 0 then the results will be filtered and only those
 	// where the LastUpdate time is >= from will be returned as results.
+	// The returned results are not deduplicated and in certain cases it is possible
+	// that duplicate entries will be returned.
 	FindByTag(int, []string, int64) ([]string, error)
 
 	// Tags returns a list of all tag keys associated with the metrics of a given

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -176,4 +176,5 @@ type MetricIndex interface {
 	TagList(int, string, int64) ([]string, error)
 	Tag(int, string, int64) map[string]uint32
 	FindByTag(int, []string, int64) (map[MetricID]struct{}, error)
+	TagKeys(int, string, int64) ([]string, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -163,9 +163,10 @@ Interface
 * FindByTag(int, []string, int64) ([]string, error):
   This method takes a list of expressions in the format key<operator>value.
   The allowed operators are: =, !=, =~, !=~.
-  It returns a slice of IDs that match the given conditions, the conditions are
-  logically AND-ed. If the third argument is > 0 then the results will be filtered
-  and only those where the LastUpdate time is >= from will be returned as results.
+  It returns a slice of Metric names that match the given conditions, the
+  conditions are logically AND-ed.
+  If the third argument is > 0 then the results will be filtered and only those
+  where the LastUpdate time is >= from will be returned as results.
 */
 
 type MetricIndex interface {

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -178,7 +178,7 @@ type MetricIndex interface {
 	Find(int, string, int64) ([]Node, error)
 	List(int) []Archive
 	Prune(int, time.Time) ([]Archive, error)
-	FindByTag(int, []string, int64) (map[MetricID]struct{}, error)
+	FindByTag(int, []string, int64) ([]string, error)
 	Tags(int, string, int64) ([]string, error)
 	TagDetails(int, string, string, int64) (map[string]uint64, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -144,26 +144,26 @@ Interface
   The method returns a list of the metricDefinitions deleted from the index and any
   error encountered.
 
-* TagList(int, string, int64) ([]string, error):
+* Tags(int, string, int64) ([]string, error):
   This method returns a list of all tag keys associated with the metrics of a given
   organization. The return values are filtered by the regex in the second parameter.
-  If the third parameter is >0 then only metrics will be account of which the
+  If the third parameter is >0 then only metrics will be accounted of which the
   LastUpdate time is >= the given value.
 
-* TagDetails(int, string, string, int64) map[string]uint32:
+* TagDetails(int, string, string, int64) map[string]uint64:
   This method returns a list of all values associated with a given tag key in the
   given org. The occurences of each value is counted and the count is referred to by
-  the series ids in the returned map.
+  the metric names in the returned map.
   If the third parameter is not "" it will be used as a regular expression to filter
   the values before accouting for them.
-  If the fourth parameter is > 0 then the metrics
-  will be filtered and only those of which the LastUpdate time is >= the from
-  timestamp will be considered while the others are being ignored.
+  If the fourth parameter is > 0 then the metrics will be filtered and only those
+  of which the LastUpdate time is >= the from timestamp will be considered while
+  the others are being ignored.
 
 * FindByTag(int, []string, int64) ([]string, error):
   This method takes a list of expressions in the format key<operator>value.
   The allowed operators are: =, !=, =~, !=~.
-  It returns a slice of Metric names that match the given conditions, the
+  It returns a slice of metric names that match the given conditions, the
   conditions are logically AND-ed.
   If the third argument is > 0 then the results will be filtered and only those
   where the LastUpdate time is >= from will be returned as results.

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -40,6 +40,11 @@ type MetricID struct {
 	key [16]byte
 }
 
+type TagValueDetail struct {
+	Value string
+	Count uint64
+}
+
 func NewMetricIDFromString(s string) (MetricID, error) {
 	id := MetricID{}
 	err := id.FromString(s)
@@ -177,4 +182,5 @@ type MetricIndex interface {
 	Tag(int, string, int64) map[string]uint32
 	FindByTag(int, []string, int64) (map[MetricID]struct{}, error)
 	TagKeys(int, string, int64) ([]string, error)
+	TagValues(int, string, string, int64) ([]TagValueDetail, error)
 }

--- a/idx/idx_gen.go
+++ b/idx/idx_gen.go
@@ -4,19 +4,21 @@ package idx
 // MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
 // DO NOT EDIT
 
-import "github.com/tinylib/msgp/msgp"
+import (
+	"github.com/tinylib/msgp/msgp"
+)
 
 // DecodeMsg implements msgp.Decodable
 func (z *Archive) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zxvk uint32
-	zxvk, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zxvk > 0 {
-		zxvk--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -120,13 +122,13 @@ func (z *Archive) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *Archive) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zbzg uint32
-	zbzg, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zbzg > 0 {
-		zbzg--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -170,16 +172,93 @@ func (z *Archive) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
-func (z *Node) DecodeMsg(dc *msgp.Reader) (err error) {
+func (z *MetricID) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z MetricID) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 0
+	err = en.Append(0x80)
+	if err != nil {
+		return err
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z MetricID) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 0
+	o = append(o, 0x80)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MetricID) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z MetricID) Msgsize() (s int) {
+	s = 1
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *Node) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -196,18 +275,18 @@ func (z *Node) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Defs":
-			var zajw uint32
-			zajw, err = dc.ReadArrayHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Defs) >= int(zajw) {
-				z.Defs = (z.Defs)[:zajw]
+			if cap(z.Defs) >= int(zb0002) {
+				z.Defs = (z.Defs)[:zb0002]
 			} else {
-				z.Defs = make([]Archive, zajw)
+				z.Defs = make([]Archive, zb0002)
 			}
-			for zbai := range z.Defs {
-				err = z.Defs[zbai].DecodeMsg(dc)
+			for za0001 := range z.Defs {
+				err = z.Defs[za0001].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -257,8 +336,8 @@ func (z *Node) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zbai := range z.Defs {
-		err = z.Defs[zbai].EncodeMsg(en)
+	for za0001 := range z.Defs {
+		err = z.Defs[za0001].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -288,8 +367,8 @@ func (z *Node) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Defs"
 	o = append(o, 0xa4, 0x44, 0x65, 0x66, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Defs)))
-	for zbai := range z.Defs {
-		o, err = z.Defs[zbai].MarshalMsg(o)
+	for za0001 := range z.Defs {
+		o, err = z.Defs[za0001].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -304,13 +383,13 @@ func (z *Node) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *Node) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zwht uint32
-	zwht, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zwht > 0 {
-		zwht--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -327,18 +406,18 @@ func (z *Node) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Defs":
-			var zhct uint32
-			zhct, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Defs) >= int(zhct) {
-				z.Defs = (z.Defs)[:zhct]
+			if cap(z.Defs) >= int(zb0002) {
+				z.Defs = (z.Defs)[:zb0002]
 			} else {
-				z.Defs = make([]Archive, zhct)
+				z.Defs = make([]Archive, zb0002)
 			}
-			for zbai := range z.Defs {
-				bts, err = z.Defs[zbai].UnmarshalMsg(bts)
+			for za0001 := range z.Defs {
+				bts, err = z.Defs[za0001].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -362,8 +441,8 @@ func (z *Node) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Node) Msgsize() (s int) {
 	s = 1 + 5 + msgp.StringPrefixSize + len(z.Path) + 5 + msgp.BoolSize + 5 + msgp.ArrayHeaderSize
-	for zbai := range z.Defs {
-		s += z.Defs[zbai].Msgsize()
+	for za0001 := range z.Defs {
+		s += z.Defs[za0001].Msgsize()
 	}
 	s += 12 + msgp.BoolSize
 	return

--- a/idx/idx_gen_test.go
+++ b/idx/idx_gen_test.go
@@ -124,6 +124,119 @@ func BenchmarkDecodeArchive(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalMetricID(t *testing.T) {
+	v := MetricID{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgMetricID(b *testing.B) {
+	v := MetricID{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgMetricID(b *testing.B) {
+	v := MetricID{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalMetricID(b *testing.B) {
+	v := MetricID{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeMetricID(t *testing.T) {
+	v := MetricID{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := MetricID{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeMetricID(b *testing.B) {
+	v := MetricID{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeMetricID(b *testing.B) {
+	v := MetricID{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalNode(t *testing.T) {
 	v := Node{}
 	bts, err := v.MarshalMsg(nil)

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -522,6 +522,8 @@ func (m *MemoryIdx) resolveIDs(ids TagIDs) []string {
 	for id := range ids {
 		def, ok := m.DefById[id.String()]
 		if !ok {
+			corruptIndex.Inc()
+			log.Error(3, "memory-idx: corrupt. ID %q has been given, but it is not in the byId lookup table", id.String())
 			continue
 		}
 		res[i] = def.Name

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -537,7 +537,7 @@ func (m *MemoryIdx) resolveIDs(ids TagIDs) []string {
 	return res
 }
 
-func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) (map[idx.MetricID]struct{}, error) {
+func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) ([]string, error) {
 	if !tagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil, nil
@@ -548,7 +548,7 @@ func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) (map[
 		return nil, err
 	}
 
-	return m.idsByTagQuery(orgId, query), nil
+	return m.resolveIDs(m.idsByTagQuery(orgId, query)), nil
 }
 
 func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) TagIDs {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -548,10 +548,10 @@ func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) ([]st
 		return nil, err
 	}
 
-	return m.resolveIDs(m.idsByTagQuery(orgId, query)), nil
+	return m.idsByTagQuery(orgId, query), nil
 }
 
-func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) TagIDs {
+func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) []string {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -560,7 +560,7 @@ func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) TagIDs {
 		return nil
 	}
 
-	return query.Run(tree, m.DefById)
+	return m.resolveIDs(query.Run(tree, m.DefById))
 }
 
 func (m *MemoryIdx) Find(orgId int, pattern string, from int64) ([]idx.Node, error) {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -514,8 +514,8 @@ KEYS:
 	return res, nil
 }
 
-// resolves a list of ids (TagIDs) into a list of metric names
-// assumes that at least a read lock is already held by the caller
+// resolveIDs resolves a list of ids (TagIDs) into a list of metric names
+// it assumes that at least a read lock is already held by the caller
 func (m *MemoryIdx) resolveIDs(ids TagIDs) []string {
 	res := make([]string, len(ids))
 	i := uint32(0)

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -397,12 +397,12 @@ func (m *MemoryIdx) TagDetails(orgId int, key, filter string, from int64) (map[s
 	m.RLock()
 	defer m.RUnlock()
 
-	tree, ok := m.tags[orgId]
+	tags, ok := m.tags[orgId]
 	if !ok {
 		return nil, nil
 	}
 
-	values, ok := tree[key]
+	values, ok := tags[key]
 	if !ok {
 		return nil, nil
 	}
@@ -462,7 +462,7 @@ func (m *MemoryIdx) Tags(orgId int, filter string, from int64) ([]string, error)
 	m.RLock()
 	defer m.RUnlock()
 
-	tree, ok := m.tags[orgId]
+	tags, ok := m.tags[orgId]
 	if !ok {
 		return nil, nil
 	}
@@ -472,11 +472,11 @@ func (m *MemoryIdx) Tags(orgId int, filter string, from int64) ([]string, error)
 	// if there is no filter/from given we know how much space we'll need
 	// and can preallocate it
 	if re == nil && from == 0 {
-		res = make([]string, 0, len(tree))
+		res = make([]string, 0, len(tags))
 	}
 
 KEYS:
-	for key := range tree {
+	for key := range tags {
 		// filter by pattern if one was given
 		if re != nil && !re.MatchString(key) {
 			continue
@@ -485,7 +485,7 @@ KEYS:
 		// if from is > 0 we need to find at least one metric definition where
 		// LastUpdate >= from before we add the key to the result set
 		if from > 0 {
-			for _, ids := range tree[key] {
+			for _, ids := range tags[key] {
 				for id := range ids {
 					def, ok := m.DefById[id.String()]
 					if !ok {
@@ -548,12 +548,12 @@ func (m *MemoryIdx) idsByTagQuery(orgId int, query TagQuery) []string {
 	m.RLock()
 	defer m.RUnlock()
 
-	tree, ok := m.tags[orgId]
+	tags, ok := m.tags[orgId]
 	if !ok {
 		return nil
 	}
 
-	return m.resolveIDs(query.Run(tree, m.DefById))
+	return m.resolveIDs(query.Run(tags, m.DefById))
 }
 
 func (m *MemoryIdx) Find(orgId int, pattern string, from int64) ([]idx.Node, error) {

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -210,8 +210,8 @@ func Init() {
 	}
 }
 
-func queryAndCompareTagValues(t *testing.T, key, filter string, from int64, expected []idx.TagValueDetail) {
-	values, err := ix.TagValues(1, key, filter, from)
+func queryAndCompareTagValues(t *testing.T, key, filter string, from int64, expected map[string]uint64) {
+	values, err := ix.TagDetails(1, key, filter, from)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err.Error())
 	}
@@ -219,18 +219,18 @@ func queryAndCompareTagValues(t *testing.T, key, filter string, from int64, expe
 		t.Fatalf("Expected %d values, but got %d", len(expected), len(values))
 	}
 
-	for _, e := range expected {
+	for ev, ec := range expected {
 		found := false
-		for _, v := range values {
-			if e.Value == v.Value {
+		for v, c := range values {
+			if ev == v {
 				found = true
-				if e.Count != v.Count {
-					t.Fatalf("Expected count %d for %s, but got %d", e.Count, e.Value, v.Count)
+				if ec != c {
+					t.Fatalf("Expected count %d for %s, but got %d", ec, ev, c)
 				}
 			}
 		}
 		if !found {
-			t.Fatalf("Expected value %s, but did not find it", e.Value)
+			t.Fatalf("Expected value %s, but did not find it", ev)
 		}
 	}
 }
@@ -240,24 +240,12 @@ func TestTagValuesWithoutFilters(t *testing.T) {
 		Init()
 	}
 
-	expected := []idx.TagValueDetail{
-		{
-			Value: "dc0",
-			Count: 336000,
-		}, {
-			Value: "dc1",
-			Count: 336000,
-		}, {
-			Value: "dc2",
-			Count: 336000,
-		}, {
-			Value: "dc3",
-			Count: 336000,
-		}, {
-			Value: "dc4",
-			Count: 336000,
-		},
-	}
+	expected := make(map[string]uint64)
+	expected["dc0"] = 336000
+	expected["dc1"] = 336000
+	expected["dc2"] = 336000
+	expected["dc3"] = 336000
+	expected["dc4"] = 336000
 	queryAndCompareTagValues(t, "dc", "", 0, expected)
 }
 
@@ -266,15 +254,9 @@ func TestTagValuesWithFrom(t *testing.T) {
 		Init()
 	}
 
-	expected := []idx.TagValueDetail{
-		{
-			Value: "dc3",
-			Count: 24100,
-		}, {
-			Value: "dc4",
-			Count: 256000,
-		},
-	}
+	expected := make(map[string]uint64)
+	expected["dc3"] = 24100
+	expected["dc4"] = 256000
 
 	queryAndCompareTagValues(t, "dc", "", 1000000, expected)
 }
@@ -284,15 +266,9 @@ func TestTagValuesWithFilter(t *testing.T) {
 		Init()
 	}
 
-	expected := []idx.TagValueDetail{
-		{
-			Value: "dc3",
-			Count: 336000,
-		}, {
-			Value: "dc4",
-			Count: 336000,
-		},
-	}
+	expected := make(map[string]uint64)
+	expected["dc3"] = 336000
+	expected["dc4"] = 336000
 
 	queryAndCompareTagValues(t, "dc", ".+[3-9]{1}$", 0, expected)
 }
@@ -302,18 +278,14 @@ func TestTagValuesWithFilterAndFrom(t *testing.T) {
 		Init()
 	}
 
-	expected := []idx.TagValueDetail{
-		{
-			Value: "dc4",
-			Count: 256000,
-		},
-	}
+	expected := make(map[string]uint64)
+	expected["dc4"] = 256000
 
 	queryAndCompareTagValues(t, "dc", ".+[4-9]{1}$", 1000000, expected)
 }
 
 func queryAndCompareTagKeys(t *testing.T, filter string, from int64, expected []string) {
-	values, err := ix.TagKeys(1, filter, from)
+	values, err := ix.Tags(1, filter, from)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err.Error())
 	}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -505,9 +505,9 @@ func ixFindByTag(b *testing.B, org, q int) {
 		panic(err)
 	}
 	if len(series) != tagQueries[q].ExpectedResults {
-		for s := range series {
+		for _, s := range series {
 			memoryIdx := ix.(*MemoryIdx)
-			b.Log(memoryIdx.DefById[s.String()].Tags)
+			b.Log(memoryIdx.DefById[s].Tags)
 		}
 		b.Fatalf("%+v expected %d got %d results instead", tagQueries[q].Expressions, tagQueries[q].ExpectedResults, len(series))
 	}

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -162,7 +162,7 @@ func NewTagQuery(expressions []string, from int64) (TagQuery, error) {
 		} else {
 			// always anchor all regular expressions at the beginning
 			if (e.operator == MATCH || e.operator == NOT_MATCH) && e.value[0] != byte('^') {
-				e.value = "^(" + e.value + ")"
+				e.value = "^(?:" + e.value + ")"
 			}
 
 			switch e.operator {

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -293,7 +293,7 @@ func TestDeleteTaggedSeries(t *testing.T) {
 	}
 
 	if len(ix.tags[orgId]) != 2 {
-		t.Fatalf("Expected tag index to contain 2 keys, but it does not: %+v", ix.Tags)
+		t.Fatalf("Expected tag index to contain 2 keys, but it does not: %+v", ix.tags)
 	}
 
 	deleted, err := ix.Delete(orgId, mds[10].Metric)
@@ -312,7 +312,7 @@ func TestDeleteTaggedSeries(t *testing.T) {
 	}
 
 	if len(ix.tags[orgId]) > 0 {
-		t.Fatalf("Expected tag index to be empty, but it is not: %+v", ix.Tags)
+		t.Fatalf("Expected tag index to be empty, but it is not: %+v", ix.tags)
 	}
 }
 

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -213,40 +214,40 @@ func TestGetByTag(t *testing.T) {
 
 	type testCase struct {
 		expressions []string
-		expectation []idx.MetricID
+		expectation []string
 	}
 
 	testCases := []testCase{
 		{
 			expressions: []string{"key1=value1"},
-			expectation: []idx.MetricID{ids[1], ids[11], ids[3]},
+			expectation: []string{mds[1].Metric, mds[11].Metric, mds[3].Metric},
 		}, {
 			expressions: []string{"key1=value2"},
-			expectation: []idx.MetricID{ids[18]},
+			expectation: []string{mds[18].Metric},
 		}, {
 			expressions: []string{"key1=~value[0-9]"},
-			expectation: []idx.MetricID{ids[1], ids[11], ids[18], ids[3]},
+			expectation: []string{mds[1].Metric, mds[11].Metric, mds[18].Metric, mds[3].Metric},
 		}, {
 			expressions: []string{"key1=~value[23]"},
-			expectation: []idx.MetricID{ids[18]},
+			expectation: []string{mds[18].Metric},
 		}, {
 			expressions: []string{"key1=value1", "key2=value1"},
-			expectation: []idx.MetricID{},
+			expectation: []string{},
 		}, {
 			expressions: []string{"key1=value1", "key2=value2"},
-			expectation: []idx.MetricID{ids[1]},
+			expectation: []string{mds[1].Metric},
 		}, {
 			expressions: []string{"key1=~value[12]", "key2=value2"},
-			expectation: []idx.MetricID{ids[1], ids[18]},
+			expectation: []string{mds[1].Metric, mds[18].Metric},
 		}, {
 			expressions: []string{"key1=~value1", "key1=value2"},
-			expectation: []idx.MetricID{},
+			expectation: []string{},
 		}, {
 			expressions: []string{"key1=~value[0-9]", "key2=~", "key3!=value3"},
-			expectation: []idx.MetricID{ids[11]},
+			expectation: []string{mds[11].Metric},
 		}, {
 			expressions: []string{"key2=", "key1=value1"},
-			expectation: []idx.MetricID{ids[11], ids[3]},
+			expectation: []string{mds[11].Metric, mds[3].Metric},
 		},
 	}
 
@@ -259,11 +260,9 @@ func TestGetByTag(t *testing.T) {
 		if len(res) != len(tc.expectation) {
 			t.Fatalf("Result does not match expectation for expressions %+v\nGot:\n%+v\nExpected:\n%+v\n", tc.expressions, res, tc.expectation)
 		}
-		expectationMap := make(TagIDs)
-		for _, v := range tc.expectation {
-			expectationMap[v] = struct{}{}
-		}
-		if !reflect.DeepEqual(res, expectationMap) {
+		sort.Strings(tc.expectation)
+		sort.Strings(res)
+		if !reflect.DeepEqual(res, tc.expectation) {
 			t.Fatalf("Result does not match expectation\nGot:\n%+v\nExpected:\n%+v\n", res, tc.expectation)
 		}
 	}

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -258,7 +258,7 @@ func TestGetByTag(t *testing.T) {
 		}
 		res := ix.idsByTagQuery(1, tagQuery)
 		if len(tc.expectation) != len(res) {
-			t.Fatalf("Result does not match expectation for expressions %+v\nGot:\n%+v\nExpected:\n%+v\n", tc.expressions, res, tc.expectation)
+			t.Fatalf("Result does not match expectation for expressions %+v\nExpected:\n%+v\nGot:\n%+v\n", tc.expressions, tc.expectation, res)
 		}
 		sort.Strings(tc.expectation)
 		sort.Strings(res)

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -257,7 +257,7 @@ func TestGetByTag(t *testing.T) {
 			t.Fatalf("Got an unexpected error with query %s: %s", tc.expressions, err)
 		}
 		res := ix.idsByTagQuery(1, tagQuery)
-		if len(res) != len(tc.expectation) {
+		if len(tc.expectation) != len(res) {
 			t.Fatalf("Result does not match expectation for expressions %+v\nGot:\n%+v\nExpected:\n%+v\n", tc.expressions, res, tc.expectation)
 		}
 		sort.Strings(tc.expectation)

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -182,33 +182,6 @@ func TestTagExpressionQueryByTagWithFrom(t *testing.T) {
 	}
 }
 
-func TestSingleTagQueryByTagWithFrom(t *testing.T) {
-	tagIdx, byId := getTestIndex(t)
-	memIdx := New()
-	memIdx.Tags[1] = tagIdx
-	memIdx.DefById = byId
-
-	res := memIdx.Tag(1, "key1", 0)
-	if res["value1"] != 4 {
-		t.Fatalf("Expected %d results, but got %d", 4, len(res))
-	}
-
-	res = memIdx.Tag(1, "key1", 2)
-	if res["value1"] != 3 {
-		t.Fatalf("Expected %d results, but got %d", 4, len(res))
-	}
-
-	res = memIdx.Tag(1, "key1", 3)
-	if res["value1"] != 2 {
-		t.Fatalf("Expected %d results, but got %d", 4, len(res))
-	}
-
-	res = memIdx.Tag(1, "key1", 4)
-	if res["value1"] != 1 {
-		t.Fatalf("Expected %d results, but got %d", 4, len(res))
-	}
-}
-
 func TestGetByTag(t *testing.T) {
 	_tagSupport := tagSupport
 	defer func() { tagSupport = _tagSupport }()
@@ -320,7 +293,7 @@ func TestDeleteTaggedSeries(t *testing.T) {
 		t.Fatalf("Expected to get 1 result, but got %d", len(res))
 	}
 
-	if len(ix.Tags[orgId]) != 2 {
+	if len(ix.tags[orgId]) != 2 {
 		t.Fatalf("Expected tag index to contain 2 keys, but it does not: %+v", ix.Tags)
 	}
 
@@ -339,7 +312,7 @@ func TestDeleteTaggedSeries(t *testing.T) {
 		t.Fatalf("Expected to get 0 results, but got %d", len(res))
 	}
 
-	if len(ix.Tags[orgId]) > 0 {
+	if len(ix.tags[orgId]) > 0 {
 		t.Fatalf("Expected tag index to be empty, but it is not: %+v", ix.Tags)
 	}
 }

--- a/mdata/chunk/archive/archive_gen.go
+++ b/mdata/chunk/archive/archive_gen.go
@@ -13,13 +13,13 @@ import (
 func (z *Archive) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zbzg uint32
-	zbzg, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zbzg > 0 {
-		zbzg--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -41,18 +41,18 @@ func (z *Archive) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Chunks":
-			var zbai uint32
-			zbai, err = dc.ReadArrayHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Chunks) >= int(zbai) {
-				z.Chunks = (z.Chunks)[:zbai]
+			if cap(z.Chunks) >= int(zb0002) {
+				z.Chunks = (z.Chunks)[:zb0002]
 			} else {
-				z.Chunks = make([]chunk.IterGen, zbai)
+				z.Chunks = make([]chunk.IterGen, zb0002)
 			}
-			for zxvk := range z.Chunks {
-				err = z.Chunks[zxvk].DecodeMsg(dc)
+			for za0001 := range z.Chunks {
+				err = z.Chunks[za0001].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -106,8 +106,8 @@ func (z *Archive) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zxvk := range z.Chunks {
-		err = z.Chunks[zxvk].EncodeMsg(en)
+	for za0001 := range z.Chunks {
+		err = z.Chunks[za0001].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -131,8 +131,8 @@ func (z *Archive) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Chunks"
 	o = append(o, 0xa6, 0x43, 0x68, 0x75, 0x6e, 0x6b, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Chunks)))
-	for zxvk := range z.Chunks {
-		o, err = z.Chunks[zxvk].MarshalMsg(o)
+	for za0001 := range z.Chunks {
+		o, err = z.Chunks[za0001].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -144,13 +144,13 @@ func (z *Archive) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *Archive) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -172,18 +172,18 @@ func (z *Archive) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Chunks":
-			var zajw uint32
-			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Chunks) >= int(zajw) {
-				z.Chunks = (z.Chunks)[:zajw]
+			if cap(z.Chunks) >= int(zb0002) {
+				z.Chunks = (z.Chunks)[:zb0002]
 			} else {
-				z.Chunks = make([]chunk.IterGen, zajw)
+				z.Chunks = make([]chunk.IterGen, zb0002)
 			}
-			for zxvk := range z.Chunks {
-				bts, err = z.Chunks[zxvk].UnmarshalMsg(bts)
+			for za0001 := range z.Chunks {
+				bts, err = z.Chunks[za0001].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -202,8 +202,8 @@ func (z *Archive) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Archive) Msgsize() (s int) {
 	s = 1 + 7 + msgp.StringPrefixSize + len(z.RowKey) + 16 + msgp.Uint32Size + 7 + msgp.Uint32Size + 7 + msgp.ArrayHeaderSize
-	for zxvk := range z.Chunks {
-		s += z.Chunks[zxvk].Msgsize()
+	for za0001 := range z.Chunks {
+		s += z.Chunks[za0001].Msgsize()
 	}
 	return
 }
@@ -212,13 +212,13 @@ func (z *Archive) Msgsize() (s int) {
 func (z *Metric) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zhct uint32
-	zhct, err = dc.ReadMapHeader()
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zhct > 0 {
-		zhct--
+	for zb0001 > 0 {
+		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -235,18 +235,18 @@ func (z *Metric) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Archives":
-			var zcua uint32
-			zcua, err = dc.ReadArrayHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Archives) >= int(zcua) {
-				z.Archives = (z.Archives)[:zcua]
+			if cap(z.Archives) >= int(zb0002) {
+				z.Archives = (z.Archives)[:zb0002]
 			} else {
-				z.Archives = make([]Archive, zcua)
+				z.Archives = make([]Archive, zb0002)
 			}
-			for zwht := range z.Archives {
-				err = z.Archives[zwht].DecodeMsg(dc)
+			for za0001 := range z.Archives {
+				err = z.Archives[za0001].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -291,8 +291,8 @@ func (z *Metric) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zwht := range z.Archives {
-		err = z.Archives[zwht].EncodeMsg(en)
+	for za0001 := range z.Archives {
+		err = z.Archives[za0001].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -316,8 +316,8 @@ func (z *Metric) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Archives"
 	o = append(o, 0xa8, 0x41, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Archives)))
-	for zwht := range z.Archives {
-		o, err = z.Archives[zwht].MarshalMsg(o)
+	for za0001 := range z.Archives {
+		o, err = z.Archives[za0001].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -329,13 +329,13 @@ func (z *Metric) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *Metric) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zxhx uint32
-	zxhx, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zxhx > 0 {
-		zxhx--
+	for zb0001 > 0 {
+		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -352,18 +352,18 @@ func (z *Metric) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Archives":
-			var zlqf uint32
-			zlqf, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Archives) >= int(zlqf) {
-				z.Archives = (z.Archives)[:zlqf]
+			if cap(z.Archives) >= int(zb0002) {
+				z.Archives = (z.Archives)[:zb0002]
 			} else {
-				z.Archives = make([]Archive, zlqf)
+				z.Archives = make([]Archive, zb0002)
 			}
-			for zwht := range z.Archives {
-				bts, err = z.Archives[zwht].UnmarshalMsg(bts)
+			for za0001 := range z.Archives {
+				bts, err = z.Archives[za0001].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -382,8 +382,8 @@ func (z *Metric) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Metric) Msgsize() (s int) {
 	s = 1 + 11 + z.MetricData.Msgsize() + 18 + msgp.Uint32Size + 9 + msgp.ArrayHeaderSize
-	for zwht := range z.Archives {
-		s += z.Archives[zwht].Msgsize()
+	for za0001 := range z.Archives {
+		s += z.Archives[za0001].Msgsize()
 	}
 	return
 }


### PR DESCRIPTION
Add the API endpoints for:

`/tags` (with optional `filter`)
`/tags/<tag>` (with optional `filter`)
`/tags/findSeries` (with list of `expr`)

The goal is that the API is exactly the same like documented in the graphite docs: http://graphite.readthedocs.io/en/latest/tags.html#querying
The `pretty` parameter has been ignored for now.

I think that once we change the main index to use the numeric `idx.MetricID` type instead of `string`s then the performance fo calls like `/tags/<tag>` might improve, because they rely heavily on ID lookups in the main index.