### PR TITLE
return full metric names with tags

### DIFF
--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -391,6 +391,65 @@ func TestTagKeysWithFromAndFilter(t *testing.T) {
 	queryAndCompareTagKeys(t, "di", 1000000, nil)
 }
 
+func TestTagSorting(t *testing.T) {
+	index := New()
+	index.Init()
+
+	md1 := &schema.MetricData{
+		Name:     "name1",
+		Metric:   "name1",
+		Tags:     []string{},
+		Interval: 10,
+		OrgId:    1,
+		Time:     int64(123),
+	}
+	md1.SetId()
+
+	// set out of order tags after SetId (because that would sort it)
+	md1.Tags = []string{"d=a", "b=a", "c=a", "a=a", "e=a"}
+	index.AddOrUpdate(md1, 1)
+
+	res, err := index.FindByTag(1, []string{"b=a"}, 0)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("Expected exactly 1 result, got %d: %+v", len(res), res)
+	}
+	expected := "name1;a=a;b=a;c=a;d=a;e=a"
+	if res[0] != expected {
+		t.Fatalf("Wrong metric name returned.\nExpected: %s\nGot: %s\n", expected, res[0])
+	}
+
+	md2 := []schema.MetricDefinition{
+		{
+			Name:       "name2",
+			Metric:     "name2",
+			Tags:       []string{},
+			Interval:   10,
+			OrgId:      1,
+			LastUpdate: int64(123),
+		},
+	}
+	md2[0].SetId()
+
+	// set out of order tags after SetId (because that would sort it)
+	md2[0].Tags = []string{"5=a", "1=a", "2=a", "4=a", "3=a"}
+	index.Load(md2)
+
+	res, err = index.FindByTag(1, []string{"3=a"}, 0)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("Expected exactly 1 result, got %d: %+v", len(res), res)
+	}
+	expected = "name2;1=a;2=a;3=a;4=a;5=a"
+	if res[0] != expected {
+		t.Fatalf("Wrong metric name returned.\nExpected: %s\nGot: %s\n", expected, res[0])
+	}
+}
+
 func BenchmarkTagDetailsWithoutFromNorFilter(b *testing.B) {
 	InitLargeIndex()
 

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -217,37 +217,47 @@ func TestGetByTag(t *testing.T) {
 		expectation []string
 	}
 
+	fullName := func(md schema.MetricData) string {
+		name := md.Metric
+		sort.Strings(md.Tags)
+		for _, tag := range md.Tags {
+			name += ";"
+			name += tag
+		}
+		return name
+	}
+
 	testCases := []testCase{
 		{
 			expressions: []string{"key1=value1"},
-			expectation: []string{mds[1].Metric, mds[11].Metric, mds[3].Metric},
+			expectation: []string{fullName(mds[1]), fullName(mds[11]), fullName(mds[3])},
 		}, {
 			expressions: []string{"key1=value2"},
-			expectation: []string{mds[18].Metric},
+			expectation: []string{fullName(mds[18])},
 		}, {
 			expressions: []string{"key1=~value[0-9]"},
-			expectation: []string{mds[1].Metric, mds[11].Metric, mds[18].Metric, mds[3].Metric},
+			expectation: []string{fullName(mds[1]), fullName(mds[11]), fullName(mds[18]), fullName(mds[3])},
 		}, {
 			expressions: []string{"key1=~value[23]"},
-			expectation: []string{mds[18].Metric},
+			expectation: []string{fullName(mds[18])},
 		}, {
 			expressions: []string{"key1=value1", "key2=value1"},
 			expectation: []string{},
 		}, {
 			expressions: []string{"key1=value1", "key2=value2"},
-			expectation: []string{mds[1].Metric},
+			expectation: []string{fullName(mds[1])},
 		}, {
 			expressions: []string{"key1=~value[12]", "key2=value2"},
-			expectation: []string{mds[1].Metric, mds[18].Metric},
+			expectation: []string{fullName(mds[1]), fullName(mds[18])},
 		}, {
 			expressions: []string{"key1=~value1", "key1=value2"},
 			expectation: []string{},
 		}, {
 			expressions: []string{"key1=~value[0-9]", "key2=~", "key3!=value3"},
-			expectation: []string{mds[11].Metric},
+			expectation: []string{fullName(mds[11])},
 		}, {
 			expressions: []string{"key2=", "key1=value1"},
-			expectation: []string{mds[11].Metric, mds[3].Metric},
+			expectation: []string{fullName(mds[11]), fullName(mds[3])},
 		},
 	}
 


### PR DESCRIPTION
When calling `/metrics/tags/findSeries` the returned results should be the full metric names including tags. 

```
mst@mst-nb1:~$ curl -s 'http://localhost:6060/metrics/tags/findSeries' -H 'X-Org-Id: 1'  -X POST -H 'Content-Type: application/json' -d '{"expr":["name=~.+metric.[0-9]$"]}' | jq '.'
[
  "some.id.of.a.metric.4;metric=some.id.of.a.metric;name=some.id.of.a.metric.4;some=tag",
  "some.id.of.a.metric.5;metric=some.id.of.a.metric;name=some.id.of.a.metric.5;some=tag",
  "some.id.of.a.metric.3;metric=some.id.of.a.metric;name=some.id.of.a.metric.3;some=tag",
  "some.id.of.a.metric.9;metric=some.id.of.a.metric;name=some.id.of.a.metric.9;some=tag",
  "some.id.of.a.metric.8;metric=some.id.of.a.metric;name=some.id.of.a.metric.8;some=tag",
  "some.id.of.a.metric.1;metric=some.id.of.a.metric;name=some.id.of.a.metric.1;some=tag",
  "some.id.of.a.metric.7;metric=some.id.of.a.metric;name=some.id.of.a.metric.7;some=tag",
  "some.id.of.a.metric.6;metric=some.id.of.a.metric;name=some.id.of.a.metric.6;some=tag",
  "some.id.of.a.metric.2;metric=some.id.of.a.metric;name=some.id.of.a.metric.2;some=tag"
]
```