### PR TITLE
remove wait-for-endpoint logs that were only useful during development

### DIFF
--- a/scripts/wait_for_endpoint.sh
+++ b/scripts/wait_for_endpoint.sh
@@ -12,10 +12,8 @@ CONN_HOLD=${CONN_HOLD:-3}
 timeout_exec=$(basename "$(readlink $(which timeout))")
 if [ "$timeout_exec" = "busybox" ]
 then
-  log "using busybox"
   _using_busybox=1
 else
-  log "not using busybox"
   _using_busybox=0
 fi
 
@@ -43,7 +41,7 @@ do
     # connection stays up for $CONN_HOLD seconds.
     if [ $_using_busybox -eq 1 ]
     then
-      timeout -t $CONN_HOLD busybox nc $host $port -e busybox sleep $(( $CONN_HOLD + 1 ))
+      timeout -t $CONN_HOLD busybox nc $host $port -e busybox sleep $(( $CONN_HOLD + 1 )) 2>/dev/null
       retval=$?
 
       # busybox-timeout on alpine returns 0 on timeout
@@ -60,8 +58,6 @@ do
     then
       log "$endpoint is up. maintained connection for $CONN_HOLD seconds!"
       break
-    else
-      log "returned value $retval, expecting $expected"
     fi
 
     sleep 1


### PR DESCRIPTION
this cleans up the output quite a bit.

BEFORE:

2017/11/04 00:41:21 using busybox
2017/11/04 00:41:21 waiting for cassandra:9042 to become up...
2017/11/04 00:41:21 returned value 1, expecting 143
2017/11/04 00:41:22 waiting for cassandra:9042 to become up...
2017/11/04 00:41:22 returned value 1, expecting 143
2017/11/04 00:41:23 waiting for cassandra:9042 to become up...
2017/11/04 00:41:23 returned value 1, expecting 143
2017/11/04 00:41:24 waiting for cassandra:9042 to become up...
2017/11/04 00:41:24 returned value 1, expecting 143
2017/11/04 00:41:25 waiting for cassandra:9042 to become up...
2017/11/04 00:41:25 returned value 1, expecting 143
2017/11/04 00:41:26 waiting for cassandra:9042 to become up...
2017/11/04 00:41:26 returned value 1, expecting 143
2017/11/04 00:41:27 waiting for cassandra:9042 to become up...
2017/11/04 00:41:27 returned value 1, expecting 143
2017/11/04 00:41:28 waiting for cassandra:9042 to become up...
2017/11/04 00:41:28 returned value 1, expecting 143
2017/11/04 00:41:29 waiting for cassandra:9042 to become up...
2017/11/04 00:41:29 returned value 1, expecting 143
2017/11/04 00:41:30 waiting for cassandra:9042 to become up...
2017/11/04 00:41:30 returned value 1, expecting 143
2017/11/04 00:41:31 waiting for cassandra:9042 to become up...
2017/11/04 00:41:31 returned value 1, expecting 143
2017/11/04 00:41:32 waiting for cassandra:9042 to become up...
2017/11/04 00:41:32 returned value 1, expecting 143
2017/11/04 00:41:33 waiting for cassandra:9042 to become up...
2017/11/04 00:41:33 returned value 1, expecting 143
2017/11/04 00:41:34 waiting for cassandra:9042 to become up...
Terminated
2017/11/04 00:41:37 cassandra:9042 is up. maintained connection for 3 seconds!
2017/11/04 00:41:37 [I] Metrictank starting. Built from 0.7.4-292-g4512748b - Go version go1.9.2

AFTER:

2017/11/04 00:42:45 waiting for cassandra:9042 to become up...
2017/11/04 00:42:46 waiting for cassandra:9042 to become up...
2017/11/04 00:42:47 waiting for cassandra:9042 to become up...
2017/11/04 00:42:48 waiting for cassandra:9042 to become up...
2017/11/04 00:42:49 waiting for cassandra:9042 to become up...
2017/11/04 00:42:50 waiting for cassandra:9042 to become up...
2017/11/04 00:42:51 waiting for cassandra:9042 to become up...
2017/11/04 00:42:52 waiting for cassandra:9042 to become up...
2017/11/04 00:42:53 waiting for cassandra:9042 to become up...
2017/11/04 00:42:54 waiting for cassandra:9042 to become up...
2017/11/04 00:42:55 waiting for cassandra:9042 to become up...
2017/11/04 00:42:56 waiting for cassandra:9042 to become up...
2017/11/04 00:42:57 waiting for cassandra:9042 to become up...
2017/11/04 00:42:58 waiting for cassandra:9042 to become up...
2017/11/04 00:43:01 cassandra:9042 is up. maintained connection for 3 seconds!
2017/11/04 00:43:01 [I] Metrictank starting. Built from 0.7.4-293-g7307e71d - Go version go1.9.2