### PR TITLE
fix mt-store-cat nilpointer

### DIFF
--- a/cmd/mt-store-cat/full.go
+++ b/cmd/mt-store-cat/full.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -9,7 +10,7 @@ import (
 	"github.com/grafana/metrictank/mdata"
 )
 
-func chunkSummary(store *mdata.CassandraStore, tables []string, metrics []Metric, keyspace, groupTTL string) error {
+func chunkSummary(ctx context.Context, store *mdata.CassandraStore, tables []string, metrics []Metric, keyspace, groupTTL string) error {
 	now := uint32(time.Now().Unix())
 	end_month := now - (now % mdata.Month_sec)
 

--- a/cmd/mt-store-cat/main.go
+++ b/cmd/mt-store-cat/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/grafana/metrictank/conf"
+	opentracing "github.com/opentracing/opentracing-go"
 
 	"github.com/grafana/metrictank/mdata"
 	"github.com/raintank/dur"
@@ -161,6 +164,12 @@ func main() {
 	if err != nil {
 		log.Fatal(4, "failed to initialize cassandra. %s", err)
 	}
+	tracer, traceCloser, err := conf.GetTracer(false, "")
+	if err != nil {
+		log.Fatal(4, "Could not initialize jaeger tracer: %s", err.Error())
+	}
+	defer traceCloser.Close()
+	store.SetTracer(tracer)
 
 	if tableSelector == "tables" {
 		tables, err := getTables(store, *cassandraKeyspace, "")
@@ -247,12 +256,15 @@ func main() {
 
 	fmt.Printf("# Keyspace %q:\n", *cassandraKeyspace)
 
+	span := tracer.StartSpan("mt-store-cat " + format)
+	ctx := opentracing.ContextWithSpan(context.Background(), span)
+
 	switch format {
 	case "points":
-		points(store, tables, metrics, fromUnix, toUnix, uint32(*fix))
+		points(ctx, store, tables, metrics, fromUnix, toUnix, uint32(*fix))
 	case "point-summary":
-		pointSummary(store, tables, metrics, fromUnix, toUnix, uint32(*fix))
+		pointSummary(ctx, store, tables, metrics, fromUnix, toUnix, uint32(*fix))
 	case "chunk-summary":
-		chunkSummary(store, tables, metrics, *cassandraKeyspace, *groupTTL)
+		chunkSummary(ctx, store, tables, metrics, *cassandraKeyspace, *groupTTL)
 	}
 }

--- a/cmd/mt-store-cat/series.go
+++ b/cmd/mt-store-cat/series.go
@@ -13,16 +13,16 @@ import (
 	"gopkg.in/raintank/schema.v1"
 )
 
-func points(store *mdata.CassandraStore, tables []string, metrics []Metric, fromUnix, toUnix, fix uint32) {
+func points(ctx context.Context, store *mdata.CassandraStore, tables []string, metrics []Metric, fromUnix, toUnix, fix uint32) {
 	for _, metric := range metrics {
 		fmt.Println("## Metric", metric)
 		for _, table := range tables {
 			fmt.Println("### Table", table)
 			if fix != 0 {
-				points := getSeries(store, table, metric.id, fromUnix, toUnix, fix)
+				points := getSeries(ctx, store, table, metric.id, fromUnix, toUnix, fix)
 				printPointsNormal(points, fromUnix, toUnix)
 			} else {
-				igens, err := store.SearchTable(context.Background(), metric.id, table, fromUnix, toUnix)
+				igens, err := store.SearchTable(ctx, metric.id, table, fromUnix, toUnix)
 				if err != nil {
 					panic(err)
 				}
@@ -32,16 +32,16 @@ func points(store *mdata.CassandraStore, tables []string, metrics []Metric, from
 	}
 }
 
-func pointSummary(store *mdata.CassandraStore, tables []string, metrics []Metric, fromUnix, toUnix, fix uint32) {
+func pointSummary(ctx context.Context, store *mdata.CassandraStore, tables []string, metrics []Metric, fromUnix, toUnix, fix uint32) {
 	for _, metric := range metrics {
 		fmt.Println("## Metric", metric)
 		for _, table := range tables {
 			fmt.Println("### Table", table)
 			if fix != 0 {
-				points := getSeries(store, table, metric.id, fromUnix, toUnix, fix)
+				points := getSeries(ctx, store, table, metric.id, fromUnix, toUnix, fix)
 				printPointsSummary(points, fromUnix, toUnix)
 			} else {
-				igens, err := store.SearchTable(context.Background(), metric.id, table, fromUnix, toUnix)
+				igens, err := store.SearchTable(ctx, metric.id, table, fromUnix, toUnix)
 				if err != nil {
 					panic(err)
 				}
@@ -51,9 +51,9 @@ func pointSummary(store *mdata.CassandraStore, tables []string, metrics []Metric
 	}
 }
 
-func getSeries(store *mdata.CassandraStore, table, id string, fromUnix, toUnix, interval uint32) []schema.Point {
+func getSeries(ctx context.Context, store *mdata.CassandraStore, table, id string, fromUnix, toUnix, interval uint32) []schema.Point {
 	var points []schema.Point
-	itgens, err := store.SearchTable(context.Background(), id, table, fromUnix, toUnix)
+	itgens, err := store.SearchTable(ctx, id, table, fromUnix, toUnix)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
the provided context must contain a span

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x7d3c2d]

goroutine 1 [running]:
github.com/raintank/metrictank/tracing.NewSpan(0xc94ec0, 0xc4200d6008, 0xc94680, 0xce80f0, 0xa0e4c5, 0x1a, 0x4bd0d3, 0x989da0, 0xc420fa2220, 0x99)
	/home/ubuntu/.go_workspace/src/github.com/raintank/metrictank/tracing/tracing.go:19 +0x6d
github.com/raintank/metrictank/mdata.(*CassandraStore).SearchTable(0xc42046e1e0, 0xc94ec0, 0xc4200d6008, 0xc420a0fb90, 0x26, 0xc4205b82a0, 0x9, 0x5a0349e65a01f866, 0x0, 0x0, ...)
	/home/ubuntu/.go_workspace/src/github.com/raintank/metrictank/mdata/store_cassandra.go:416 +0xce
main.points(0xc42046e1e0, 0xc4201e4380, 0x5, 0x8, 0xc4209a9780, 0x1, 0x1, 0x5a0349e65a01f866, 0x0)
	/home/ubuntu/.go_workspace/src/github.com/raintank/metrictank/cmd/mt-store-cat/series.go:25 +0x3c6
main.main()
	/home/ubuntu/.go_workspace/src/github.com/raintank/metrictank/cmd/mt-store-cat/main.go:251 +0x15b7