### PR TITLE
remove from adjustment for clustered requests

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -90,11 +90,6 @@ func (s *Server) postClusterMembers(ctx *middleware.Context, req models.ClusterM
 
 // IndexFind returns a sequence of msgp encoded idx.Node's
 func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
-	// metricDefs only get updated periodically (when using CassandraIdx), so we add a 1day (86400seconds) buffer when
-	// filtering by our From timestamp.  This should be moved to a configuration option
-	if req.From != 0 {
-		req.From -= 86400
-	}
 	resp := models.NewIndexFindResp()
 
 	for _, pattern := range req.Patterns {


### PR DESCRIPTION
this was already removed for local requests via
4fbf1b7db5b10aa32419da849a7ac4166123b487
but we also need to remove it for cluster requests
otherwise data returned is inconsistent upon subsequent
requests to different cluster nodes, which can result
in all kinds of problems