### PR TITLE
remove unused clusterName variable

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -46,7 +46,7 @@ func Init(name, version string, started time.Time, apiScheme string, apiPort int
 		local:         true,
 	}
 	if Mode == ModeMulti {
-		Manager = NewMemberlistManager(thisNode, ClusterName, clusterHost, clusterPort)
+		Manager = NewMemberlistManager(thisNode, clusterHost, clusterPort)
 	} else {
 		Manager = NewSingleNodeManager(thisNode)
 	}

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -73,7 +73,7 @@ type MemberlistManager struct {
 	cfg      *memberlist.Config
 }
 
-func NewMemberlistManager(thisNode Node, clusterName string, clusterHost net.IP, clusterPort int) *MemberlistManager {
+func NewMemberlistManager(thisNode Node, clusterHost net.IP, clusterPort int) *MemberlistManager {
 	mgr := &MemberlistManager{
 		members: map[string]Node{
 			thisNode.Name: thisNode,


### PR DESCRIPTION
the function uses the global ClusterName, not the passed-in clusterName