### PR TITLE
add support for seriesByTag

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -228,3 +228,59 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 
 	return result, nil
 }
+
+type PeerResponse struct {
+	peer cluster.Node
+	buf  []byte
+}
+
+// peerQuery takes a request and the path to request it on, then fans it out
+// across the cluster, except to the local peer.
+// ctx:          request context
+// data:         request to be submitted
+// name:         name to be used in logging & tracing
+// path:         path to request on
+func (s *Server) peerQueryWithPeer(ctx context.Context, data cluster.Traceable, name, path string) ([]PeerResponse, error) {
+	peers, err := cluster.MembersForQuery()
+	if err != nil {
+		log.Error(3, "HTTP peerQuery unable to get peers, %s", err)
+		return nil, err
+	}
+	log.Debug("HTTP %s across %d instances", name, len(peers)-1)
+
+	result := make([]PeerResponse, 0, len(peers)-1)
+
+	var errors []error
+	var errLock sync.Mutex
+	var resLock sync.Mutex
+	var wg sync.WaitGroup
+	for _, peer := range peers {
+		if peer.IsLocal() {
+			continue
+		}
+		wg.Add(1)
+		go func(peer cluster.Node) {
+			defer wg.Done()
+			log.Debug("HTTP Render querying %s%s", peer.Name, path)
+			buf, err := peer.Post(ctx, name, path, data)
+			if err != nil {
+				log.Error(4, "HTTP Render error querying %s%s: %q", peer.Name, path, err)
+				errLock.Lock()
+				errors = append(errors, err)
+				errLock.Unlock()
+				return
+			}
+
+			resLock.Lock()
+			result = append(result, PeerResponse{peer, buf})
+			resLock.Unlock()
+		}(peer)
+	}
+	wg.Wait()
+
+	if len(errors) > 0 {
+		return nil, errors[0]
+	}
+
+	return result, nil
+}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -568,7 +568,21 @@ func (s *Server) executePlan(ctx context.Context, orgId int, plan expr.Plan) ([]
 	// e.g. target=movingAvg(foo.*, "1h")&target=foo.*
 	// note that in this case we fetch foo.* twice. can be optimized later
 	for _, r := range plan.Reqs {
-		series, err := s.findSeries(ctx, orgId, []string{r.Query}, int64(r.From))
+		var err error
+		var series []Series
+		const SeriesByTagIdent = "seriesByTag("
+		if strings.HasPrefix(r.Query, SeriesByTagIdent) {
+			startPos := len(SeriesByTagIdent)
+			endPos := strings.LastIndex(r.Query, ")")
+			exprs := strings.Split(r.Query[startPos:endPos], ",")
+			// Trim quotes
+			for i, e := range exprs {
+				exprs[i] = e[1 : len(e)-1]
+			}
+			series, err = s.clusterFindByTag(ctx, orgId, exprs, int64(r.From))
+		} else {
+			series, err = s.findSeries(ctx, orgId, []string{r.Query}, int64(r.From))
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -741,11 +755,15 @@ func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.G
 		return
 	}
 
-	response.Write(ctx, response.NewJson(200, series, ""))
+	seriesNames := make([]string, 0, len(series))
+	for _, serie := range series {
+		seriesNames = append(seriesNames, serie.Pattern)
+	}
+	response.Write(ctx, response.NewJson(200, seriesNames, ""))
 }
 
-func (s *Server) clusterFindByTag(ctx context.Context, orgId int, expressions []string, from int64) ([]string, error) {
-	seriesSet := make(map[string]struct{})
+func (s *Server) clusterFindByTag(ctx context.Context, orgId int, expressions []string, from int64) ([]Series, error) {
+	seriesSet := make(map[string]Series)
 
 	result, err := s.MetricIndex.FindByTag(orgId, expressions, from)
 	if err != nil {
@@ -753,28 +771,36 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId int, expressions []
 	}
 
 	for _, series := range result {
-		seriesSet[series] = struct{}{}
+		seriesSet[series.Path] = Series{
+			Pattern: series.Path,
+			Node:    cluster.Manager.ThisNode(),
+			Series:  []idx.Node{series},
+		}
 	}
 
 	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions, From: from}
-	bufs, err := s.peerQuery(ctx, data, "clusterFindByTag", "/index/find_by_tag")
+	resps, err := s.peerQueryWithPeer(ctx, data, "clusterFindByTag", "/index/find_by_tag")
 	if err != nil {
 		return nil, err
 	}
 
-	resp := models.IndexFindByTagResp{}
-	for _, buf := range bufs {
-		_, err = resp.UnmarshalMsg(buf)
+	for _, r := range resps {
+		resp := models.IndexFindByTagResp{}
+		_, err = resp.UnmarshalMsg(r.buf)
 		if err != nil {
 			return nil, err
 		}
 		for _, series := range resp.Metrics {
-			seriesSet[series] = struct{}{}
+			seriesSet[series.Path] = Series{
+				Pattern: series.Path,
+				Node:    r.peer,
+				Series:  []idx.Node{series},
+			}
 		}
 	}
 
-	series := make([]string, 0, len(seriesSet))
-	for s := range seriesSet {
+	series := make([]Series, 0, len(seriesSet))
+	for _, s := range seriesSet {
 		series = append(series, s)
 	}
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -730,13 +730,13 @@ func (s *Server) clusterTagDetails(ctx context.Context, orgId int, tag, filter s
 	}
 
 	data := models.IndexTagDetails{OrgId: orgId, Tag: tag, Filter: filter, From: from}
-	bufs, err := s.peerQuery(ctx, data, "clusterTagDetails", "/index/tag_details")
+	resps, err := s.peerQuery(ctx, data, "clusterTagDetails", "/index/tag_details")
 	if err != nil {
 		return nil, err
 	}
 	resp := models.IndexTagDetailsResp{}
-	for _, buf := range bufs {
-		_, err = resp.UnmarshalMsg(buf)
+	for _, r := range resps {
+		_, err = resp.UnmarshalMsg(r.buf)
 		if err != nil {
 			return nil, err
 		}
@@ -779,7 +779,7 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId int, expressions []
 	}
 
 	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions, From: from}
-	resps, err := s.peerQueryWithPeer(ctx, data, "clusterFindByTag", "/index/find_by_tag")
+	resps, err := s.peerQuery(ctx, data, "clusterFindByTag", "/index/find_by_tag")
 	if err != nil {
 		return nil, err
 	}
@@ -833,14 +833,14 @@ func (s *Server) clusterTags(ctx context.Context, orgId int, filter string, from
 	}
 
 	data := models.IndexTags{OrgId: orgId, Filter: filter, From: from}
-	bufs, err := s.peerQuery(ctx, data, "clusterTags", "/index/tags")
+	resps, err := s.peerQuery(ctx, data, "clusterTags", "/index/tags")
 	if err != nil {
 		return nil, err
 	}
 
 	resp := models.IndexTagsResp{}
-	for _, buf := range bufs {
-		_, err = resp.UnmarshalMsg(buf)
+	for _, r := range resps {
+		_, err = resp.UnmarshalMsg(r.buf)
 		if err != nil {
 			return nil, err
 		}

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -37,5 +37,5 @@ type IndexTagDetailsResp struct {
 
 //go:generate msgp
 type IndexFindByTagResp struct {
-	Metrics []string `json:"metrics"`
+	Metrics []idx.Node `json:"metrics"`
 }

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -13,31 +13,31 @@ import (
 func (z *GetDataResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
+	var zbzg uint32
+	zbzg, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zbzg > 0 {
+		zbzg--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var zb0002 uint32
-			zb0002, err = dc.ReadArrayHeader()
+			var zbai uint32
+			zbai, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(zb0002) {
-				z.Series = (z.Series)[:zb0002]
+			if cap(z.Series) >= int(zbai) {
+				z.Series = (z.Series)[:zbai]
 			} else {
-				z.Series = make([]Series, zb0002)
+				z.Series = make([]Series, zbai)
 			}
-			for za0001 := range z.Series {
-				err = z.Series[za0001].DecodeMsg(dc)
+			for zxvk := range z.Series {
+				err = z.Series[zxvk].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -64,8 +64,8 @@ func (z *GetDataResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for za0001 := range z.Series {
-		err = z.Series[za0001].EncodeMsg(en)
+	for zxvk := range z.Series {
+		err = z.Series[zxvk].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -80,8 +80,8 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Series"
 	o = append(o, 0x81, 0xa6, 0x53, 0x65, 0x72, 0x69, 0x65, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Series)))
-	for za0001 := range z.Series {
-		o, err = z.Series[za0001].MarshalMsg(o)
+	for zxvk := range z.Series {
+		o, err = z.Series[zxvk].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -93,31 +93,31 @@ func (z *GetDataResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zcmr uint32
+	zcmr, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zcmr > 0 {
+		zcmr--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Series":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zajw uint32
+			zajw, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Series) >= int(zb0002) {
-				z.Series = (z.Series)[:zb0002]
+			if cap(z.Series) >= int(zajw) {
+				z.Series = (z.Series)[:zajw]
 			} else {
-				z.Series = make([]Series, zb0002)
+				z.Series = make([]Series, zajw)
 			}
-			for za0001 := range z.Series {
-				bts, err = z.Series[za0001].UnmarshalMsg(bts)
+			for zxvk := range z.Series {
+				bts, err = z.Series[zxvk].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -136,8 +136,8 @@ func (z *GetDataResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *GetDataResp) Msgsize() (s int) {
 	s = 1 + 7 + msgp.ArrayHeaderSize
-	for za0001 := range z.Series {
-		s += z.Series[za0001].Msgsize()
+	for zxvk := range z.Series {
+		s += z.Series[zxvk].Msgsize()
 	}
 	return
 }
@@ -146,31 +146,31 @@ func (z *GetDataResp) Msgsize() (s int) {
 func (z *IndexFindByTagResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
+	var zhct uint32
+	zhct, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zhct > 0 {
+		zhct--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Metrics":
-			var zb0002 uint32
-			zb0002, err = dc.ReadArrayHeader()
+			var zcua uint32
+			zcua, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Metrics) >= int(zb0002) {
-				z.Metrics = (z.Metrics)[:zb0002]
+			if cap(z.Metrics) >= int(zcua) {
+				z.Metrics = (z.Metrics)[:zcua]
 			} else {
-				z.Metrics = make([]string, zb0002)
+				z.Metrics = make([]idx.Node, zcua)
 			}
-			for za0001 := range z.Metrics {
-				z.Metrics[za0001], err = dc.ReadString()
+			for zwht := range z.Metrics {
+				err = z.Metrics[zwht].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
@@ -197,8 +197,8 @@ func (z *IndexFindByTagResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for za0001 := range z.Metrics {
-		err = en.WriteString(z.Metrics[za0001])
+	for zwht := range z.Metrics {
+		err = z.Metrics[zwht].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -213,8 +213,11 @@ func (z *IndexFindByTagResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Metrics"
 	o = append(o, 0x81, 0xa7, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Metrics)))
-	for za0001 := range z.Metrics {
-		o = msgp.AppendString(o, z.Metrics[za0001])
+	for zwht := range z.Metrics {
+		o, err = z.Metrics[zwht].MarshalMsg(o)
+		if err != nil {
+			return
+		}
 	}
 	return
 }
@@ -223,31 +226,31 @@ func (z *IndexFindByTagResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexFindByTagResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zxhx uint32
+	zxhx, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zxhx > 0 {
+		zxhx--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Metrics":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zlqf uint32
+			zlqf, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Metrics) >= int(zb0002) {
-				z.Metrics = (z.Metrics)[:zb0002]
+			if cap(z.Metrics) >= int(zlqf) {
+				z.Metrics = (z.Metrics)[:zlqf]
 			} else {
-				z.Metrics = make([]string, zb0002)
+				z.Metrics = make([]idx.Node, zlqf)
 			}
-			for za0001 := range z.Metrics {
-				z.Metrics[za0001], bts, err = msgp.ReadStringBytes(bts)
+			for zwht := range z.Metrics {
+				bts, err = z.Metrics[zwht].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
@@ -266,8 +269,8 @@ func (z *IndexFindByTagResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *IndexFindByTagResp) Msgsize() (s int) {
 	s = 1 + 8 + msgp.ArrayHeaderSize
-	for za0001 := range z.Metrics {
-		s += msgp.StringPrefixSize + len(z.Metrics[za0001])
+	for zwht := range z.Metrics {
+		s += z.Metrics[zwht].Msgsize()
 	}
 	return
 }
@@ -276,56 +279,56 @@ func (z *IndexFindByTagResp) Msgsize() (s int) {
 func (z *IndexFindResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
+	var zcxo uint32
+	zcxo, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zcxo > 0 {
+		zcxo--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zeff uint32
+			zeff, err = dc.ReadMapHeader()
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && zb0002 > 0 {
-				z.Nodes = make(map[string][]idx.Node, zb0002)
+			if z.Nodes == nil && zeff > 0 {
+				z.Nodes = make(map[string][]idx.Node, zeff)
 			} else if len(z.Nodes) > 0 {
 				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
-				var za0001 string
-				var za0002 []idx.Node
-				za0001, err = dc.ReadString()
+			for zeff > 0 {
+				zeff--
+				var zdaf string
+				var zpks []idx.Node
+				zdaf, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				var zb0003 uint32
-				zb0003, err = dc.ReadArrayHeader()
+				var zrsw uint32
+				zrsw, err = dc.ReadArrayHeader()
 				if err != nil {
 					return
 				}
-				if cap(za0002) >= int(zb0003) {
-					za0002 = (za0002)[:zb0003]
+				if cap(zpks) >= int(zrsw) {
+					zpks = (zpks)[:zrsw]
 				} else {
-					za0002 = make([]idx.Node, zb0003)
+					zpks = make([]idx.Node, zrsw)
 				}
-				for za0003 := range za0002 {
-					err = za0002[za0003].DecodeMsg(dc)
+				for zjfb := range zpks {
+					err = zpks[zjfb].DecodeMsg(dc)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[za0001] = za0002
+				z.Nodes[zdaf] = zpks
 			}
 		default:
 			err = dc.Skip()
@@ -349,17 +352,17 @@ func (z *IndexFindResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for za0001, za0002 := range z.Nodes {
-		err = en.WriteString(za0001)
+	for zdaf, zpks := range z.Nodes {
+		err = en.WriteString(zdaf)
 		if err != nil {
 			return
 		}
-		err = en.WriteArrayHeader(uint32(len(za0002)))
+		err = en.WriteArrayHeader(uint32(len(zpks)))
 		if err != nil {
 			return
 		}
-		for za0003 := range za0002 {
-			err = za0002[za0003].EncodeMsg(en)
+		for zjfb := range zpks {
+			err = zpks[zjfb].EncodeMsg(en)
 			if err != nil {
 				return
 			}
@@ -375,11 +378,11 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Nodes"
 	o = append(o, 0x81, 0xa5, 0x4e, 0x6f, 0x64, 0x65, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Nodes)))
-	for za0001, za0002 := range z.Nodes {
-		o = msgp.AppendString(o, za0001)
-		o = msgp.AppendArrayHeader(o, uint32(len(za0002)))
-		for za0003 := range za0002 {
-			o, err = za0002[za0003].MarshalMsg(o)
+	for zdaf, zpks := range z.Nodes {
+		o = msgp.AppendString(o, zdaf)
+		o = msgp.AppendArrayHeader(o, uint32(len(zpks)))
+		for zjfb := range zpks {
+			o, err = zpks[zjfb].MarshalMsg(o)
 			if err != nil {
 				return
 			}
@@ -392,56 +395,56 @@ func (z *IndexFindResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zxpk uint32
+	zxpk, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zxpk > 0 {
+		zxpk--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Nodes":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zdnj uint32
+			zdnj, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if z.Nodes == nil && zb0002 > 0 {
-				z.Nodes = make(map[string][]idx.Node, zb0002)
+			if z.Nodes == nil && zdnj > 0 {
+				z.Nodes = make(map[string][]idx.Node, zdnj)
 			} else if len(z.Nodes) > 0 {
 				for key, _ := range z.Nodes {
 					delete(z.Nodes, key)
 				}
 			}
-			for zb0002 > 0 {
-				var za0001 string
-				var za0002 []idx.Node
-				zb0002--
-				za0001, bts, err = msgp.ReadStringBytes(bts)
+			for zdnj > 0 {
+				var zdaf string
+				var zpks []idx.Node
+				zdnj--
+				zdaf, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				var zb0003 uint32
-				zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				var zobc uint32
+				zobc, bts, err = msgp.ReadArrayHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				if cap(za0002) >= int(zb0003) {
-					za0002 = (za0002)[:zb0003]
+				if cap(zpks) >= int(zobc) {
+					zpks = (zpks)[:zobc]
 				} else {
-					za0002 = make([]idx.Node, zb0003)
+					zpks = make([]idx.Node, zobc)
 				}
-				for za0003 := range za0002 {
-					bts, err = za0002[za0003].UnmarshalMsg(bts)
+				for zjfb := range zpks {
+					bts, err = zpks[zjfb].UnmarshalMsg(bts)
 					if err != nil {
 						return
 					}
 				}
-				z.Nodes[za0001] = za0002
+				z.Nodes[zdaf] = zpks
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -458,11 +461,11 @@ func (z *IndexFindResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 func (z *IndexFindResp) Msgsize() (s int) {
 	s = 1 + 6 + msgp.MapHeaderSize
 	if z.Nodes != nil {
-		for za0001, za0002 := range z.Nodes {
-			_ = za0002
-			s += msgp.StringPrefixSize + len(za0001) + msgp.ArrayHeaderSize
-			for za0003 := range za0002 {
-				s += za0002[za0003].Msgsize()
+		for zdaf, zpks := range z.Nodes {
+			_ = zpks
+			s += msgp.StringPrefixSize + len(zdaf) + msgp.ArrayHeaderSize
+			for zjfb := range zpks {
+				s += zpks[zjfb].Msgsize()
 			}
 		}
 	}
@@ -473,44 +476,44 @@ func (z *IndexFindResp) Msgsize() (s int) {
 func (z *IndexTagDetailsResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
+	var zema uint32
+	zema, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zema > 0 {
+		zema--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Values":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zpez uint32
+			zpez, err = dc.ReadMapHeader()
 			if err != nil {
 				return
 			}
-			if z.Values == nil && zb0002 > 0 {
-				z.Values = make(map[string]uint64, zb0002)
+			if z.Values == nil && zpez > 0 {
+				z.Values = make(map[string]uint64, zpez)
 			} else if len(z.Values) > 0 {
 				for key, _ := range z.Values {
 					delete(z.Values, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
-				var za0001 string
-				var za0002 uint64
-				za0001, err = dc.ReadString()
+			for zpez > 0 {
+				zpez--
+				var zsnv string
+				var zkgt uint64
+				zsnv, err = dc.ReadString()
 				if err != nil {
 					return
 				}
-				za0002, err = dc.ReadUint64()
+				zkgt, err = dc.ReadUint64()
 				if err != nil {
 					return
 				}
-				z.Values[za0001] = za0002
+				z.Values[zsnv] = zkgt
 			}
 		default:
 			err = dc.Skip()
@@ -534,12 +537,12 @@ func (z *IndexTagDetailsResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for za0001, za0002 := range z.Values {
-		err = en.WriteString(za0001)
+	for zsnv, zkgt := range z.Values {
+		err = en.WriteString(zsnv)
 		if err != nil {
 			return
 		}
-		err = en.WriteUint64(za0002)
+		err = en.WriteUint64(zkgt)
 		if err != nil {
 			return
 		}
@@ -554,9 +557,9 @@ func (z *IndexTagDetailsResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Values"
 	o = append(o, 0x81, 0xa6, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Values)))
-	for za0001, za0002 := range z.Values {
-		o = msgp.AppendString(o, za0001)
-		o = msgp.AppendUint64(o, za0002)
+	for zsnv, zkgt := range z.Values {
+		o = msgp.AppendString(o, zsnv)
+		o = msgp.AppendUint64(o, zkgt)
 	}
 	return
 }
@@ -565,44 +568,44 @@ func (z *IndexTagDetailsResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexTagDetailsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zqke uint32
+	zqke, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zqke > 0 {
+		zqke--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Values":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zqyh uint32
+			zqyh, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if z.Values == nil && zb0002 > 0 {
-				z.Values = make(map[string]uint64, zb0002)
+			if z.Values == nil && zqyh > 0 {
+				z.Values = make(map[string]uint64, zqyh)
 			} else if len(z.Values) > 0 {
 				for key, _ := range z.Values {
 					delete(z.Values, key)
 				}
 			}
-			for zb0002 > 0 {
-				var za0001 string
-				var za0002 uint64
-				zb0002--
-				za0001, bts, err = msgp.ReadStringBytes(bts)
+			for zqyh > 0 {
+				var zsnv string
+				var zkgt uint64
+				zqyh--
+				zsnv, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
-				za0002, bts, err = msgp.ReadUint64Bytes(bts)
+				zkgt, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					return
 				}
-				z.Values[za0001] = za0002
+				z.Values[zsnv] = zkgt
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -619,9 +622,9 @@ func (z *IndexTagDetailsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 func (z *IndexTagDetailsResp) Msgsize() (s int) {
 	s = 1 + 7 + msgp.MapHeaderSize
 	if z.Values != nil {
-		for za0001, za0002 := range z.Values {
-			_ = za0002
-			s += msgp.StringPrefixSize + len(za0001) + msgp.Uint64Size
+		for zsnv, zkgt := range z.Values {
+			_ = zkgt
+			s += msgp.StringPrefixSize + len(zsnv) + msgp.Uint64Size
 		}
 	}
 	return
@@ -631,31 +634,31 @@ func (z *IndexTagDetailsResp) Msgsize() (s int) {
 func (z *IndexTagsResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
+	var zywj uint32
+	zywj, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zywj > 0 {
+		zywj--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Tags":
-			var zb0002 uint32
-			zb0002, err = dc.ReadArrayHeader()
+			var zjpj uint32
+			zjpj, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(zb0002) {
-				z.Tags = (z.Tags)[:zb0002]
+			if cap(z.Tags) >= int(zjpj) {
+				z.Tags = (z.Tags)[:zjpj]
 			} else {
-				z.Tags = make([]string, zb0002)
+				z.Tags = make([]string, zjpj)
 			}
-			for za0001 := range z.Tags {
-				z.Tags[za0001], err = dc.ReadString()
+			for zyzr := range z.Tags {
+				z.Tags[zyzr], err = dc.ReadString()
 				if err != nil {
 					return
 				}
@@ -682,8 +685,8 @@ func (z *IndexTagsResp) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for za0001 := range z.Tags {
-		err = en.WriteString(z.Tags[za0001])
+	for zyzr := range z.Tags {
+		err = en.WriteString(z.Tags[zyzr])
 		if err != nil {
 			return
 		}
@@ -698,8 +701,8 @@ func (z *IndexTagsResp) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Tags"
 	o = append(o, 0x81, 0xa4, 0x54, 0x61, 0x67, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Tags)))
-	for za0001 := range z.Tags {
-		o = msgp.AppendString(o, z.Tags[za0001])
+	for zyzr := range z.Tags {
+		o = msgp.AppendString(o, z.Tags[zyzr])
 	}
 	return
 }
@@ -708,31 +711,31 @@ func (z *IndexTagsResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *IndexTagsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zzpf uint32
+	zzpf, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zzpf > 0 {
+		zzpf--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "Tags":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zrfe uint32
+			zrfe, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Tags) >= int(zb0002) {
-				z.Tags = (z.Tags)[:zb0002]
+			if cap(z.Tags) >= int(zrfe) {
+				z.Tags = (z.Tags)[:zrfe]
 			} else {
-				z.Tags = make([]string, zb0002)
+				z.Tags = make([]string, zrfe)
 			}
-			for za0001 := range z.Tags {
-				z.Tags[za0001], bts, err = msgp.ReadStringBytes(bts)
+			for zyzr := range z.Tags {
+				z.Tags[zyzr], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					return
 				}
@@ -751,8 +754,8 @@ func (z *IndexTagsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *IndexTagsResp) Msgsize() (s int) {
 	s = 1 + 5 + msgp.ArrayHeaderSize
-	for za0001 := range z.Tags {
-		s += msgp.StringPrefixSize + len(z.Tags[za0001])
+	for zyzr := range z.Tags {
+		s += msgp.StringPrefixSize + len(z.Tags[zyzr])
 	}
 	return
 }
@@ -761,13 +764,13 @@ func (z *IndexTagsResp) Msgsize() (s int) {
 func (z *MetricsDeleteResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
+	var zgmo uint32
+	zgmo, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zgmo > 0 {
+		zgmo--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -817,13 +820,13 @@ func (z MetricsDeleteResp) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *MetricsDeleteResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var ztaf uint32
+	ztaf, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for ztaf > 0 {
+		ztaf--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return

--- a/api/models/series.go
+++ b/api/models/series.go
@@ -14,6 +14,7 @@ import (
 type Series struct {
 	Target       string // for fetched data, set from models.Req.Target, i.e. the metric graphite key. for function output, whatever should be shown as target string (legend)
 	Datapoints   []schema.Point
+	Tags         map[string]string
 	Interval     uint32
 	QueryPatt    string                     // to tie series back to request it came from. e.g. foo.bar.*, or if series outputted by func it would be e.g. scale(foo.bar.*,0.123456)
 	QueryFrom    uint32                     // to tie series back to request it came from
@@ -34,6 +35,17 @@ func (series SeriesByTarget) MarshalJSONFast(b []byte) ([]byte, error) {
 	for _, s := range series {
 		b = append(b, `{"target":`...)
 		b = strconv.AppendQuoteToASCII(b, s.Target)
+		if len(s.Tags) != 0 {
+			b = append(b, `,"tags":{`...)
+			for name, value := range s.Tags {
+				b = strconv.AppendQuoteToASCII(b, name)
+				b = append(b, ':')
+				b = strconv.AppendQuoteToASCII(b, value)
+				b = append(b, ',')
+			}
+			// Replace trailing comma with a closing bracket
+			b[len(b)-1] = '}'
+		}
 		b = append(b, `,"datapoints":[`...)
 		for _, p := range s.Datapoints {
 			b = append(b, '[')

--- a/api/models/series_gen.go
+++ b/api/models/series_gen.go
@@ -13,13 +13,13 @@ import (
 func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
+	var zcmr uint32
+	zcmr, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zcmr > 0 {
+		zcmr--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -31,21 +31,48 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Datapoints":
-			var zb0002 uint32
-			zb0002, err = dc.ReadArrayHeader()
+			var zajw uint32
+			zajw, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.Datapoints) >= int(zb0002) {
-				z.Datapoints = (z.Datapoints)[:zb0002]
+			if cap(z.Datapoints) >= int(zajw) {
+				z.Datapoints = (z.Datapoints)[:zajw]
 			} else {
-				z.Datapoints = make([]schema.Point, zb0002)
+				z.Datapoints = make([]schema.Point, zajw)
 			}
-			for za0001 := range z.Datapoints {
-				err = z.Datapoints[za0001].DecodeMsg(dc)
+			for zxvk := range z.Datapoints {
+				err = z.Datapoints[zxvk].DecodeMsg(dc)
 				if err != nil {
 					return
 				}
+			}
+		case "Tags":
+			var zwht uint32
+			zwht, err = dc.ReadMapHeader()
+			if err != nil {
+				return
+			}
+			if z.Tags == nil && zwht > 0 {
+				z.Tags = make(map[string]string, zwht)
+			} else if len(z.Tags) > 0 {
+				for key, _ := range z.Tags {
+					delete(z.Tags, key)
+				}
+			}
+			for zwht > 0 {
+				zwht--
+				var zbzg string
+				var zbai string
+				zbzg, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				zbai, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				z.Tags[zbzg] = zbai
 			}
 		case "Interval":
 			z.Interval, err = dc.ReadUint32()
@@ -89,9 +116,9 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 8
+	// map header, size 9
 	// write "Target"
-	err = en.Append(0x88, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
+	err = en.Append(0x89, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
 	if err != nil {
 		return err
 	}
@@ -108,8 +135,27 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for za0001 := range z.Datapoints {
-		err = z.Datapoints[za0001].EncodeMsg(en)
+	for zxvk := range z.Datapoints {
+		err = z.Datapoints[zxvk].EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	// write "Tags"
+	err = en.Append(0xa4, 0x54, 0x61, 0x67, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteMapHeader(uint32(len(z.Tags)))
+	if err != nil {
+		return
+	}
+	for zbzg, zbai := range z.Tags {
+		err = en.WriteString(zbzg)
+		if err != nil {
+			return
+		}
+		err = en.WriteString(zbai)
 		if err != nil {
 			return
 		}
@@ -174,18 +220,25 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 8
+	// map header, size 9
 	// string "Target"
-	o = append(o, 0x88, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
+	o = append(o, 0x89, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
 	o = msgp.AppendString(o, z.Target)
 	// string "Datapoints"
 	o = append(o, 0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Datapoints)))
-	for za0001 := range z.Datapoints {
-		o, err = z.Datapoints[za0001].MarshalMsg(o)
+	for zxvk := range z.Datapoints {
+		o, err = z.Datapoints[zxvk].MarshalMsg(o)
 		if err != nil {
 			return
 		}
+	}
+	// string "Tags"
+	o = append(o, 0xa4, 0x54, 0x61, 0x67, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Tags)))
+	for zbzg, zbai := range z.Tags {
+		o = msgp.AppendString(o, zbzg)
+		o = msgp.AppendString(o, zbai)
 	}
 	// string "Interval"
 	o = append(o, 0xa8, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c)
@@ -218,13 +271,13 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zhct uint32
+	zhct, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zb0001 > 0 {
-		zb0001--
+	for zhct > 0 {
+		zhct--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -236,21 +289,48 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Datapoints":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zcua uint32
+			zcua, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.Datapoints) >= int(zb0002) {
-				z.Datapoints = (z.Datapoints)[:zb0002]
+			if cap(z.Datapoints) >= int(zcua) {
+				z.Datapoints = (z.Datapoints)[:zcua]
 			} else {
-				z.Datapoints = make([]schema.Point, zb0002)
+				z.Datapoints = make([]schema.Point, zcua)
 			}
-			for za0001 := range z.Datapoints {
-				bts, err = z.Datapoints[za0001].UnmarshalMsg(bts)
+			for zxvk := range z.Datapoints {
+				bts, err = z.Datapoints[zxvk].UnmarshalMsg(bts)
 				if err != nil {
 					return
 				}
+			}
+		case "Tags":
+			var zxhx uint32
+			zxhx, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if z.Tags == nil && zxhx > 0 {
+				z.Tags = make(map[string]string, zxhx)
+			} else if len(z.Tags) > 0 {
+				for key, _ := range z.Tags {
+					delete(z.Tags, key)
+				}
+			}
+			for zxhx > 0 {
+				var zbzg string
+				var zbai string
+				zxhx--
+				zbzg, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				zbai, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Tags[zbzg] = zbai
 			}
 		case "Interval":
 			z.Interval, bts, err = msgp.ReadUint32Bytes(bts)
@@ -296,8 +376,15 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Series) Msgsize() (s int) {
 	s = 1 + 7 + msgp.StringPrefixSize + len(z.Target) + 11 + msgp.ArrayHeaderSize
-	for za0001 := range z.Datapoints {
-		s += z.Datapoints[za0001].Msgsize()
+	for zxvk := range z.Datapoints {
+		s += z.Datapoints[zxvk].Msgsize()
+	}
+	s += 5 + msgp.MapHeaderSize
+	if z.Tags != nil {
+		for zbzg, zbai := range z.Tags {
+			_ = zbai
+			s += msgp.StringPrefixSize + len(zbzg) + msgp.StringPrefixSize + len(zbai)
+		}
 	}
 	s += 9 + msgp.Uint32Size + 10 + msgp.StringPrefixSize + len(z.QueryPatt) + 10 + msgp.Uint32Size + 8 + msgp.Uint32Size + 10 + z.QueryCons.Msgsize() + 13 + z.Consolidator.Msgsize()
 	return
@@ -305,18 +392,18 @@ func (z *Series) Msgsize() (s int) {
 
 // DecodeMsg implements msgp.Decodable
 func (z *SeriesByTarget) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zb0002 uint32
-	zb0002, err = dc.ReadArrayHeader()
+	var zpks uint32
+	zpks, err = dc.ReadArrayHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zb0002) {
-		(*z) = (*z)[:zb0002]
+	if cap((*z)) >= int(zpks) {
+		(*z) = (*z)[:zpks]
 	} else {
-		(*z) = make(SeriesByTarget, zb0002)
+		(*z) = make(SeriesByTarget, zpks)
 	}
-	for zb0001 := range *z {
-		err = (*z)[zb0001].DecodeMsg(dc)
+	for zdaf := range *z {
+		err = (*z)[zdaf].DecodeMsg(dc)
 		if err != nil {
 			return
 		}
@@ -330,8 +417,8 @@ func (z SeriesByTarget) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zb0003 := range z {
-		err = z[zb0003].EncodeMsg(en)
+	for zjfb := range z {
+		err = z[zjfb].EncodeMsg(en)
 		if err != nil {
 			return
 		}
@@ -343,8 +430,8 @@ func (z SeriesByTarget) EncodeMsg(en *msgp.Writer) (err error) {
 func (z SeriesByTarget) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
-	for zb0003 := range z {
-		o, err = z[zb0003].MarshalMsg(o)
+	for zjfb := range z {
+		o, err = z[zjfb].MarshalMsg(o)
 		if err != nil {
 			return
 		}
@@ -354,18 +441,18 @@ func (z SeriesByTarget) MarshalMsg(b []byte) (o []byte, err error) {
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *SeriesByTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var zb0002 uint32
-	zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	var zeff uint32
+	zeff, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zb0002) {
-		(*z) = (*z)[:zb0002]
+	if cap((*z)) >= int(zeff) {
+		(*z) = (*z)[:zeff]
 	} else {
-		(*z) = make(SeriesByTarget, zb0002)
+		(*z) = make(SeriesByTarget, zeff)
 	}
-	for zb0001 := range *z {
-		bts, err = (*z)[zb0001].UnmarshalMsg(bts)
+	for zcxo := range *z {
+		bts, err = (*z)[zcxo].UnmarshalMsg(bts)
 		if err != nil {
 			return
 		}
@@ -377,8 +464,8 @@ func (z *SeriesByTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z SeriesByTarget) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for zb0003 := range z {
-		s += z[zb0003].Msgsize()
+	for zrsw := range z {
+		s += z[zrsw].Msgsize()
 	}
 	return
 }

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -50,12 +50,11 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 
 	// The tags for the aggregated series is only the tags that are
 	// common to all input series
-	var commonTags map[string]string
-	if len(series[0].Tags) == 0 {
-		commonTags = make(map[string]string, 0)
-	} else {
-		commonTags = series[0].Tags
+	commonTags := make(map[string]string, len(series[0].Tags))
+	for k, v := range series[0].Tags {
+		commonTags[k] = v
 	}
+
 	for _, serie := range series {
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -48,7 +48,8 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 	out := pointSlicePool.Get().([]schema.Point)
 	s.agg.function(series, &out)
 
-	// Build up the set of common tags to add to the tags map
+	// The tags for the aggregated series is only the tags that are
+	// common to all input series
 	var commonTags map[string]string
 	if len(series[0].Tags) == 0 {
 		commonTags = make(map[string]string, 0)

--- a/expr/func_aliasbynode.go
+++ b/expr/func_aliasbynode.go
@@ -32,6 +32,8 @@ func (s *FuncAliasByNode) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		return nil, err
 	}
 	for i, serie := range series {
+		// Extract metric may not find a target if `seriesByTag` was used.
+		// If so, then we can try to grab the "name" tag.
 		metric := extractMetric(serie.Target)
 		if len(metric) == 0 {
 			metric = serie.Tags["name"]

--- a/expr/func_aliasbynode.go
+++ b/expr/func_aliasbynode.go
@@ -33,6 +33,9 @@ func (s *FuncAliasByNode) Exec(cache map[Req][]models.Series) ([]models.Series, 
 	}
 	for i, serie := range series {
 		metric := extractMetric(serie.Target)
+		if len(metric) == 0 {
+			metric = serie.Tags["name"]
+		}
 		parts := strings.Split(metric, ".")
 		var name []string
 		for _, n64 := range s.nodes {

--- a/expr/func_aliasbynode.go
+++ b/expr/func_aliasbynode.go
@@ -38,7 +38,8 @@ func (s *FuncAliasByNode) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		if len(metric) == 0 {
 			metric = serie.Tags["name"]
 		}
-		parts := strings.Split(metric, ".")
+		// Trim off tags (if they are there) and split on '.'
+		parts := strings.Split(strings.SplitN(metric, ";", 2)[0], ".")
 		var name []string
 		for _, n64 := range s.nodes {
 			n := int(n64)

--- a/expr/func_aliassub.go
+++ b/expr/func_aliassub.go
@@ -38,7 +38,13 @@ func (s *FuncAliasSub) Exec(cache map[Req][]models.Series) ([]models.Series, err
 		return nil, err
 	}
 	for i := range series {
+		// TODO - graphite doesn't attempt to extract the
+		// metric/expression from the series. MT probably shouldn't either.
+		// This will almost certainly break some dashboards
 		metric := extractMetric(series[i].Target)
+		if metric == "" {
+			metric = series[i].Target
+		}
 		name := s.search.ReplaceAllString(metric, replace)
 		series[i].Target = name
 		series[i].QueryPatt = name

--- a/expr/func_aliassub_test.go
+++ b/expr/func_aliassub_test.go
@@ -33,6 +33,12 @@ func TestAliasSub(t *testing.T) {
 			[]string{"metrictank.stats.env.instance.input.pluginname.metrics_received.counter32"},
 			[]string{"pluginname in"},
 		},
+		{
+			".*host=([^;]+)(;.*)?",
+			"\\1",
+			[]string{"foo.bar.baz;a=b;host=ab1"},
+			[]string{"ab1"},
+		},
 	}
 	for i, c := range cases {
 		f := NewAliasSub()

--- a/expr/func_divideseries.go
+++ b/expr/func_divideseries.go
@@ -57,10 +57,12 @@ func (s *FuncDivideSeries) Exec(cache map[Req][]models.Series) ([]models.Series,
 			}
 			out = append(out, p)
 		}
-		name := fmt.Sprintf("divideSeries(%s,%s)", dividend.QueryPatt, divisor.QueryPatt)
+
+		name := fmt.Sprintf("divideSeries(%s,%s)", dividend.Target, divisor.Target)
 		output := models.Series{
 			Target:       name,
 			QueryPatt:    name,
+			Tags:         map[string]string{"name": name},
 			Datapoints:   out,
 			Interval:     divisor.Interval,
 			Consolidator: dividend.Consolidator,

--- a/expr/func_divideseries_test.go
+++ b/expr/func_divideseries_test.go
@@ -1,0 +1,191 @@
+package expr
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/test"
+	"gopkg.in/raintank/schema.v1"
+)
+
+func TestDivideSeriesSingle(t *testing.T) {
+	testDivideSeries(
+		"single",
+		[]models.Series{
+			{
+				Target:    "foo;a=a;b=b",
+				QueryPatt: `seriesByTag("name=foo")`,
+				Datapoints: []schema.Point{
+					{Val: 0, Ts: 10},
+					{Val: math.NaN(), Ts: 20},
+				},
+			},
+		},
+		[]models.Series{
+			{
+				Target:    "bar;a=a1;b=b",
+				QueryPatt: `seriesByTag("name=bar")`,
+				Datapoints: []schema.Point{
+					{Val: 1, Ts: 10},
+					{Val: 1, Ts: 20},
+				},
+			},
+		},
+		[]models.Series{
+			{
+				Target: "divideSeries(foo;a=a;b=b,bar;a=a1;b=b)",
+				Datapoints: []schema.Point{
+					{Val: 0, Ts: 10},
+					{Val: math.NaN(), Ts: 20},
+				},
+				Tags: map[string]string{
+					"name": "divideSeries(foo;a=a;b=b,bar;a=a1;b=b)",
+				},
+			},
+		},
+		t,
+	)
+}
+
+func TestDivideSeriesMultiple(t *testing.T) {
+	testDivideSeries(
+		"multiple",
+		[]models.Series{
+			{
+				Target:    "foo-1;a=1;b=2;c=3",
+				QueryPatt: "foo-1",
+				Datapoints: []schema.Point{
+					{Val: 0, Ts: 10},
+					{Val: math.NaN(), Ts: 20},
+				},
+			},
+			{
+				Target:    "foo-2;a=2;b=2;b=2",
+				QueryPatt: "foo-2",
+				Datapoints: []schema.Point{
+					{Val: 20, Ts: 10},
+					{Val: 100, Ts: 20},
+				},
+			},
+		},
+		[]models.Series{
+			{
+				Target:    "overbar;a=3;b=2;c=1",
+				QueryPatt: "overbar",
+				Datapoints: []schema.Point{
+					{Val: 2, Ts: 10},
+					{Val: math.NaN(), Ts: 20},
+				},
+			},
+		},
+		[]models.Series{
+			{
+				Target: "divideSeries(foo-1;a=1;b=2;c=3,overbar;a=3;b=2;c=1)",
+				Datapoints: []schema.Point{
+					{Val: 0, Ts: 10},
+					{Val: math.NaN(), Ts: 20},
+				},
+				Tags: map[string]string{
+					"name": "divideSeries(foo-1;a=1;b=2;c=3,overbar;a=3;b=2;c=1)",
+				},
+			},
+			{
+				Target: "divideSeries(foo-2;a=2;b=2;b=2,overbar;a=3;b=2;c=1)",
+				Datapoints: []schema.Point{
+					{Val: 10, Ts: 10},
+					{Val: math.NaN(), Ts: 20},
+				},
+				Tags: map[string]string{
+					"name": "divideSeries(foo-2;a=2;b=2;b=2,overbar;a=3;b=2;c=1)",
+				},
+			},
+		},
+		t,
+	)
+}
+
+func testDivideSeries(name string, dividend, divisor []models.Series, out []models.Series, t *testing.T) {
+	f := NewDivideSeries()
+	DivideSeries := f.(*FuncDivideSeries)
+	DivideSeries.dividend = NewMock(dividend)
+	DivideSeries.divisor = NewMock(divisor)
+	got, err := f.Exec(make(map[Req][]models.Series))
+	if err != nil {
+		t.Fatalf("case %q: err should be nil. got %q", name, err)
+	}
+	if len(got) != len(dividend) {
+		t.Fatalf("case %q: DivideSeries output should be same amount of series as dividend input: %d, not %d", name, len(dividend), len(got))
+	}
+	for i, o := range out {
+		g := got[i]
+		if o.Target != g.Target {
+			t.Fatalf("case %q: expected target %q, got %q", name, o.Target, g.Target)
+		}
+		if len(o.Datapoints) != len(g.Datapoints) {
+			t.Fatalf("case %q: len output expected %d, got %d", name, len(o.Datapoints), len(g.Datapoints))
+		}
+		for j, p := range o.Datapoints {
+			bothNaN := math.IsNaN(p.Val) && math.IsNaN(g.Datapoints[j].Val)
+			if (bothNaN || p.Val == g.Datapoints[j].Val) && p.Ts == g.Datapoints[j].Ts {
+				continue
+			}
+			t.Fatalf("case %q: output point %d - expected %v got %v", name, j, p, g.Datapoints[j])
+		}
+		if len(o.Tags) != len(g.Tags) {
+			t.Fatalf("case %q: len tags expected %d, got %d", name, len(o.Tags), len(g.Tags))
+		}
+		for k, v := range g.Tags {
+			if o.Tags[k] == v {
+				continue
+			}
+			t.Fatalf("case %q: output tag %q different, expected %q but got %q", name, k, o.Tags[k], v)
+		}
+	}
+}
+
+func BenchmarkDivideSeries10k_1AllSeriesHalfNulls(b *testing.B) {
+	benchmarkDivideSeries(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkDivideSeries10k_10AllSeriesHalfNulls(b *testing.B) {
+	benchmarkDivideSeries(b, 10, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkDivideSeries10k_100AllSeriesHalfNulls(b *testing.B) {
+	benchmarkDivideSeries(b, 100, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkDivideSeries10k_1000AllSeriesHalfNulls(b *testing.B) {
+	benchmarkDivideSeries(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+
+func benchmarkDivideSeries(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var dividends []models.Series
+	for i := 0; i < numSeries; i++ {
+		series := models.Series{
+			Target: strconv.Itoa(i),
+		}
+		if i%1 == 0 {
+			series.Datapoints = fn0()
+		} else {
+			series.Datapoints = fn1()
+		}
+		dividends = append(dividends, series)
+	}
+	divisor := models.Series{
+		Target:     "divisor",
+		Datapoints: fn0(),
+	}
+	b.ResetTimer()
+	var err error
+	for i := 0; i < b.N; i++ {
+		f := NewDivideSeries()
+		DivideSeries := f.(*FuncDivideSeries)
+		DivideSeries.dividend = NewMock(dividends)
+		DivideSeries.divisor = NewMock([]models.Series{divisor})
+		results, err = f.Exec(make(map[Req][]models.Series))
+		if err != nil {
+			b.Fatalf("%s", err)
+		}
+	}
+	b.SetBytes(int64(numSeries * len(results[0].Datapoints) * 12))
+}

--- a/expr/func_get.go
+++ b/expr/func_get.go
@@ -1,6 +1,10 @@
 package expr
 
-import "github.com/grafana/metrictank/api/models"
+import (
+	"strings"
+
+	"github.com/grafana/metrictank/api/models"
+)
 
 // internal function just for getting data
 type FuncGet struct {
@@ -20,5 +24,32 @@ func (s FuncGet) Context(context Context) Context {
 }
 
 func (s FuncGet) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
-	return cache[s.req], nil
+	series := cache[s.req]
+
+	if len(series) == 0 {
+		return series, nil
+	}
+
+	var out []models.Series
+
+	for _, serie := range series {
+		tagSplits := strings.Split(serie.Target, ";")
+
+		if serie.Tags == nil {
+			serie.Tags = make(map[string]string, len(tagSplits))
+		}
+
+		for _, tagPair := range tagSplits[1:] {
+			parts := strings.SplitN(tagPair, "=", 2)
+			if len(parts) != 2 {
+				// Shouldn't happen
+				continue
+			}
+			serie.Tags[parts[0]] = parts[1]
+		}
+		serie.Tags["name"] = tagSplits[0]
+		out = append(out, serie)
+	}
+
+	return out, nil
 }

--- a/expr/func_get.go
+++ b/expr/func_get.go
@@ -1,8 +1,6 @@
 package expr
 
 import (
-	"strings"
-
 	"github.com/grafana/metrictank/api/models"
 )
 
@@ -26,30 +24,9 @@ func (s FuncGet) Context(context Context) Context {
 func (s FuncGet) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
 	series := cache[s.req]
 
-	if len(series) == 0 {
-		return series, nil
+	for k := range series {
+		series[k].SetTags()
 	}
 
-	var out []models.Series
-
-	for _, serie := range series {
-		tagSplits := strings.Split(serie.Target, ";")
-
-		if serie.Tags == nil {
-			serie.Tags = make(map[string]string, len(tagSplits))
-		}
-
-		for _, tagPair := range tagSplits[1:] {
-			parts := strings.SplitN(tagPair, "=", 2)
-			if len(parts) != 2 {
-				// Shouldn't happen
-				continue
-			}
-			serie.Tags[parts[0]] = parts[1]
-		}
-		serie.Tags["name"] = tagSplits[0]
-		out = append(out, serie)
-	}
-
-	return out, nil
+	return series, nil
 }

--- a/expr/func_mock_test.go
+++ b/expr/func_mock_test.go
@@ -20,5 +20,9 @@ func (s FuncMock) Context(context Context) Context {
 }
 
 func (s FuncMock) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
+	for i := range s.data {
+		s.data[i].SetTags()
+	}
+
 	return s.data, nil
 }

--- a/expr/func_persecond.go
+++ b/expr/func_persecond.go
@@ -61,6 +61,7 @@ func (s *FuncPerSecond) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		s := models.Series{
 			Target:     fmt.Sprintf("perSecond(%s)", serie.Target),
 			QueryPatt:  fmt.Sprintf("perSecond(%s)", serie.QueryPatt),
+			Tags:       serie.Tags,
 			Datapoints: out,
 			Interval:   serie.Interval,
 		}

--- a/expr/func_scale.go
+++ b/expr/func_scale.go
@@ -43,6 +43,7 @@ func (s *FuncScale) Exec(cache map[Req][]models.Series) ([]models.Series, error)
 		s := models.Series{
 			Target:       fmt.Sprintf("scale(%s,%f)", serie.Target, s.factor),
 			QueryPatt:    fmt.Sprintf("scale(%s,%f)", serie.QueryPatt, s.factor),
+			Tags:         serie.Tags,
 			Datapoints:   out,
 			Interval:     serie.Interval,
 			Consolidator: serie.Consolidator,

--- a/expr/func_transformnull.go
+++ b/expr/func_transformnull.go
@@ -50,6 +50,7 @@ func (s *FuncTransformNull) Exec(cache map[Req][]models.Series) ([]models.Series
 		transformed := models.Series{
 			Target:       target,
 			QueryPatt:    target,
+			Tags:         serie.Tags,
 			Datapoints:   pointSlicePool.Get().([]schema.Point),
 			Interval:     serie.Interval,
 			Consolidator: serie.Consolidator,

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -337,8 +337,12 @@ func parseString(s string) (string, string, error) {
 	return s[:i], s[i+1:], nil
 }
 
-// extractMetric searches for a metric name in `m'
-// metric name is defined to be a series of name characters terminated by a comma
+// extractMetric searches for a metric name or path Expression in `m'
+// metric name / path expression is defined by the following criteria:
+// 1. Not a function name
+// 2. Consists only of name characters
+// 2.1 '=' is conditionally allowed if ';' is found (denoting tag format)
+// 3. Is not a string literal (i.e. contained within single/double quote pairs)
 func extractMetric(m string) string {
 	start := 0
 	end := 0

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -428,6 +428,30 @@ func TestExtractMetric(t *testing.T) {
 			"divideSeries(foo.bar,baz.quux)",
 			"foo.bar",
 		},
+		{
+			"sumSeries(seriesByTag('name=singleQuoted'))",
+			"",
+		},
+		{
+			`sumSeries(seriesByTag("name=doubleQuoted"))`,
+			"",
+		},
+		{
+			`sumSeries(seriesByTag('name=embeddedQuote"'))`,
+			"",
+		},
+		{
+			`sumSeries(seriesByTag('name=nonterminatedQuote"))`,
+			"",
+		},
+		{
+			`sumSeries(seriesByTag('name=\'escapedQuotes\''))`,
+			"",
+		},
+		{
+			"divideSeries(foo.bar;host=1;dc=test,baz.quux;host=1;dc=test)",
+			"foo.bar;host=1;dc=test",
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/plan.go
+++ b/expr/plan.go
@@ -98,8 +98,20 @@ func newplan(e *expr, context Context, stable bool, reqs []Req) (GraphiteFunc, [
 		req := NewReq(e.str, context.from, context.to, context.consol)
 		reqs = append(reqs, req)
 		return NewGet(req), reqs, nil
+	} else if e.etype == etFunc && e.str == "seriesByTag" {
+		// convert back to function syntax
+		expressionStr := "seriesByTag("
+		for i, ex := range e.args {
+			expressionStr += "'" + ex.str + "'"
+			if i != len(e.args)-1 {
+				expressionStr += ","
+			}
+		}
+		expressionStr += ")"
+		req := NewReq(expressionStr, context.from, context.to, context.consol)
+		reqs = append(reqs, req)
+		return NewGet(req), reqs, nil
 	}
-
 	// here e.type is guaranteed to be etFunc
 	fdef, ok := funcs[e.str]
 	if !ok {

--- a/expr/plan.go
+++ b/expr/plan.go
@@ -99,7 +99,11 @@ func newplan(e *expr, context Context, stable bool, reqs []Req) (GraphiteFunc, [
 		reqs = append(reqs, req)
 		return NewGet(req), reqs, nil
 	} else if e.etype == etFunc && e.str == "seriesByTag" {
-		// convert back to function syntax
+		// `seriesByTag` function requires resolving expressions to series
+		// (similar to path expressions handled above). Since we need the
+		// arguments of seriesByTag to do the resolution, we store the function
+		// string back into the Query member of a new request to be parsed later.
+		// TODO - find a way to prevent this parse/encode/parse/encode loop
 		expressionStr := "seriesByTag("
 		for i, ex := range e.args {
 			expressionStr += "'" + ex.str + "'"

--- a/expr/plan_test.go
+++ b/expr/plan_test.go
@@ -283,18 +283,22 @@ func TestConsolidateBy(t *testing.T) {
 		input := map[Req][]models.Series{
 			NewReq("a", from, to, 0): {{
 				QueryPatt:    "a",
+				Target:       "a",
 				Consolidator: consolidation.Avg, // emulate the fact that a by default will use avg
 			}},
 			NewReq("a", from, to, consolidation.Min): {{
 				QueryPatt:    "a",
+				Target:       "a",
 				Consolidator: consolidation.Min,
 			}},
 			NewReq("a", from, to, consolidation.Sum): {{
 				QueryPatt:    "a",
+				Target:       "a",
 				Consolidator: consolidation.Sum,
 			}},
 			NewReq("b", from, to, consolidation.Max): {{
 				QueryPatt:    "b",
+				Target:       "b",
 				Consolidator: consolidation.Max,
 			}},
 		}

--- a/expr/plan_test.go
+++ b/expr/plan_test.go
@@ -391,6 +391,15 @@ func TestNamingChains(t *testing.T) {
 			},
 		},
 		{
+			`aliasByNode(avg(perSecond(seriesByTag('name=~.*.bar'))), 0)`,
+			[]string{
+				"a.bar;key1=val1",
+			},
+			[]string{
+				"a",
+			},
+		},
+		{
 			`alias(perSecond(*.bar), 'a')`,
 			[]string{
 				"a.bar",

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -133,7 +133,7 @@ type MetricIndex interface {
 
 	// FindByTag takes a list of expressions in the format key<operator>value.
 	// The allowed operators are: =, !=, =~, !=~.
-	// It returns a slice of metric names that match the given conditions, the
+	// It returns a slice of Node structs that match the given conditions, the
 	// conditions are logically AND-ed.
 	// If the third argument is > 0 then the results will be filtered and only those
 	// where the LastUpdate time is >= from will be returned as results.

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -139,7 +139,7 @@ type MetricIndex interface {
 	// where the LastUpdate time is >= from will be returned as results.
 	// The returned results are not deduplicated and in certain cases it is possible
 	// that duplicate entries will be returned.
-	FindByTag(int, []string, int64) ([]string, error)
+	FindByTag(int, []string, int64) ([]Node, error)
 
 	// Tags returns a list of all tag keys associated with the metrics of a given
 	// organization. The return values are filtered by the regex in the second parameter.

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -542,8 +542,7 @@ KEYS:
 // Node structs. It assumes that at least a read lock is already
 // held by the caller
 func (m *MemoryIdx) resolveIDs(orgId int, ids TagIDs) []idx.Node {
-	res := make([]idx.Node, len(ids))
-	i := uint32(0)
+	res := make([]idx.Node, 0, len(ids))
 	tree := m.Tree[orgId]
 	for id := range ids {
 		def, ok := m.DefById[id.String()]
@@ -561,13 +560,12 @@ func (m *MemoryIdx) resolveIDs(orgId int, ids TagIDs) []idx.Node {
 			continue
 		}
 
-		res[i] = idx.Node{
+		res = append(res, idx.Node{
 			Path:        name,
 			Leaf:        node.Leaf(),
 			HasChildren: node.HasChildren(),
 			Defs:        []idx.Archive{*def},
-		}
-		i++
+		})
 	}
 	return res
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -539,8 +539,8 @@ KEYS:
 }
 
 // resolveIDs resolves a list of ids (TagIDs) into a list of complete
-// metric names, including tags. it assumes that at least a read lock
-// is already held by the caller
+// Node structs. It assumes that at least a read lock is already
+// held by the caller
 func (m *MemoryIdx) resolveIDs(ids TagIDs) []idx.Node {
 	res := make([]idx.Node, len(ids))
 	i := uint32(0)

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -535,7 +535,7 @@ func ixFindByTag(b *testing.B, org, q int) {
 	if len(series) != tagQueries[q].ExpectedResults {
 		for _, s := range series {
 			memoryIdx := ix.(*MemoryIdx)
-			b.Log(memoryIdx.DefById[s].Tags)
+			b.Log(memoryIdx.DefById[s.Path].Tags)
 		}
 		b.Fatalf("%+v expected %d got %d results instead", tagQueries[q].Expressions, tagQueries[q].ExpectedResults, len(series))
 	}

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -281,9 +281,14 @@ func TestGetByTag(t *testing.T) {
 		if len(tc.expectation) != len(res) {
 			t.Fatalf("Result does not match expectation for expressions %+v\nExpected:\n%+v\nGot:\n%+v\n", tc.expressions, tc.expectation, res)
 		}
+
+		resPaths := make([]string, 0, len(res))
+		for _, r := range res {
+			resPaths = append(resPaths, r.Path)
+		}
 		sort.Strings(tc.expectation)
-		sort.Strings(res)
-		if !reflect.DeepEqual(res, tc.expectation) {
+		sort.Strings(resPaths)
+		if !reflect.DeepEqual(resPaths, tc.expectation) {
 			t.Fatalf("Result does not match expectation\nGot:\n%+v\nExpected:\n%+v\n", res, tc.expectation)
 		}
 	}


### PR DESCRIPTION
This PR adds support for [seriesByTag](http://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag) natively into metrictank.

The change was a bit more intrusive than I would have hoped.

1. Change `idx` to return nodes (similar to `Find`)
2. Use either `findSeries` or `clusterFindByTag` dependent on if seriesByTag is used or old pattern expressions.
3. Add the new `tags` element to the response JSON