### PR TITLE
fix benchmarks

### DIFF
--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -34,26 +34,26 @@ type metric struct {
 
 var queries = []query{
 	//LEAF queries
-	{Pattern: "collectd.dc1.host960.disk.disk1.disk_ops.read", ExpectedResults: 1},
+	{Pattern: "collectd.dc1.host960.disk.disk1.disk_ops.read;dc=dc1;device=disk;direction=read;disk=disk1;host=host960;metric=disk_ops", ExpectedResults: 1},
 	{Pattern: "collectd.dc1.host960.disk.disk1.disk_ops.*", ExpectedResults: 2},
-	{Pattern: "collectd.*.host960.disk.disk1.disk_ops.read", ExpectedResults: 5},
+	{Pattern: "collectd.*.host960.disk.disk1.disk_ops.read;*", ExpectedResults: 5},
 	{Pattern: "collectd.*.host960.disk.disk1.disk_ops.*", ExpectedResults: 10},
 	{Pattern: "collectd.d*.host960.disk.disk1.disk_ops.*", ExpectedResults: 10},
 	{Pattern: "collectd.[abcd]*.host960.disk.disk1.disk_ops.*", ExpectedResults: 10},
 	{Pattern: "collectd.{dc1,dc50}.host960.disk.disk1.disk_ops.*", ExpectedResults: 2},
 
-	{Pattern: "collectd.dc3.host960.cpu.1.idle", ExpectedResults: 1},
-	{Pattern: "collectd.dc30.host960.cpu.1.idle", ExpectedResults: 0},
-	{Pattern: "collectd.dc3.host960.*.*.idle", ExpectedResults: 32},
-	{Pattern: "collectd.dc3.host960.*.*.idle", ExpectedResults: 32},
+	{Pattern: "collectd.dc3.host960.cpu.1.idle;cpu=cpu1;dc=dc3;device=cpu;host=host960;metric=idle", ExpectedResults: 1},
+	{Pattern: "collectd.dc30.host960.cpu.1.idle;cpu=cpu1;dc=dc30;device=cpu;host=host960;metric=idle", ExpectedResults: 0},
+	{Pattern: "collectd.dc3.host960.*.*.idle;*", ExpectedResults: 32},
+	{Pattern: "collectd.dc3.host960.*.*.idle;*", ExpectedResults: 32},
 
-	{Pattern: "collectd.dc3.host96[0-9].cpu.1.idle", ExpectedResults: 10},
-	{Pattern: "collectd.dc30.host96[0-9].cpu.1.idle", ExpectedResults: 0},
-	{Pattern: "collectd.dc3.host96[0-9].*.*.idle", ExpectedResults: 320},
-	{Pattern: "collectd.dc3.host96[0-9].*.*.idle", ExpectedResults: 320},
+	{Pattern: "collectd.dc3.host96[0-9].cpu.1.idle;*", ExpectedResults: 10},
+	{Pattern: "collectd.dc30.host96[0-9].cpu.1.idle;*", ExpectedResults: 0},
+	{Pattern: "collectd.dc3.host96[0-9].*.*.idle;*", ExpectedResults: 320},
+	{Pattern: "collectd.dc3.host96[0-9].*.*.idle;*", ExpectedResults: 320},
 
-	{Pattern: "collectd.{dc1,dc2,dc3}.host960.cpu.1.idle", ExpectedResults: 3},
-	{Pattern: "collectd.{dc*, a*}.host960.cpu.1.idle", ExpectedResults: 5},
+	{Pattern: "collectd.{dc1,dc2,dc3}.host960.cpu.1.idle;*", ExpectedResults: 3},
+	{Pattern: "collectd.{dc*, a*}.host960.cpu.1.idle;*", ExpectedResults: 5},
 
 	//Branch queries
 	{Pattern: "collectd.dc1.host960.*", ExpectedResults: 2},
@@ -96,10 +96,10 @@ func cpuMetrics(dcCount, hostCount, hostOffset, cpuCount int, prefix string) []m
 					series = append(series, metric{
 						Name: p + "." + m,
 						Tags: []string{
-							"dc=dc" + strconv.Itoa(dc),
-							"host=host" + strconv.Itoa(host),
-							"device=cpu",
 							"cpu=cpu" + strconv.Itoa(cpu),
+							"dc=dc" + strconv.Itoa(dc),
+							"device=cpu",
+							"host=host" + strconv.Itoa(host),
 							"metric=" + m,
 						},
 					})
@@ -121,22 +121,22 @@ func diskMetrics(dcCount, hostCount, hostOffset, diskCount int, prefix string) [
 						Name: p + "." + m + ".read",
 						Tags: []string{
 							"dc=dc" + strconv.Itoa(dc),
-							"host=host" + strconv.Itoa(host),
 							"device=disk",
-							"disk=disk" + strconv.Itoa(disk),
-							"metric=" + m,
 							"direction=read",
+							"disk=disk" + strconv.Itoa(disk),
+							"host=host" + strconv.Itoa(host),
+							"metric=" + m,
 						},
 					})
 					series = append(series, metric{
 						Name: p + "." + m + ".write",
 						Tags: []string{
 							"dc=dc" + strconv.Itoa(dc),
-							"host=host" + strconv.Itoa(host),
 							"device=disk",
-							"disk=disk" + strconv.Itoa(disk),
-							"metric=" + m,
 							"direction=write",
+							"disk=disk" + strconv.Itoa(disk),
+							"host=host" + strconv.Itoa(host),
+							"metric=" + m,
 						},
 					})
 				}
@@ -444,7 +444,7 @@ func BenchmarkTagsWithFromAndFilter(b *testing.B) {
 
 func BenchmarkTagsWithoutFromNorFilter(b *testing.B) {
 	InitLargeIndex()
-	expected := []string{"dc", "device", "direction", "disk", "cpu", "metric", "host"}
+	expected := []string{"dc", "device", "direction", "disk", "cpu", "metric", "name", "host"}
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -454,6 +454,7 @@ func BenchmarkTagsWithoutFromNorFilter(b *testing.B) {
 }
 
 func ixFind(b *testing.B, org, q int) {
+	b.Helper()
 	nodes, err := ix.Find(org, queries[q].Pattern, 0)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
```
pkg: github.com/grafana/metrictank/idx/memory
BenchmarkTagDetailsWithoutFromNorFilter-8         	 1000000	      1705 ns/op	     702 B/op	       3 allocs/op
BenchmarkTagDetailsWithFromAndFilter-8            	       3	 435094047 ns/op	43455234 B/op	 1973367 allocs/op
BenchmarkTagsWithFromAndFilter-8                  	  100000	     29821 ns/op	   41237 B/op	      43 allocs/op
BenchmarkTagsWithoutFromNorFilter-8               	  500000	      3478 ns/op	     656 B/op	      23 allocs/op
BenchmarkFind-8                                   	   10000	    176636 ns/op	   33328 B/op	     591 allocs/op
BenchmarkConcurrent4Find-8                        	   20000	     60620 ns/op	   33303 B/op	     590 allocs/op
BenchmarkConcurrent8Find-8                        	   30000	     47855 ns/op	   33294 B/op	     590 allocs/op
BenchmarkTagFindSimpleIntersect-8                 	    2000	    685975 ns/op	  247762 B/op	     134 allocs/op
BenchmarkTagFindRegexIntersect-8                  	      10	 112391628 ns/op	11876946 B/op	  330240 allocs/op
BenchmarkTagFindMatchingAndFiltering-8            	    2000	    806488 ns/op	  281039 B/op	     682 allocs/op
BenchmarkTagFindMatchingAndFilteringWithRegex-8   	     100	  36210718 ns/op	 5027403 B/op	  112745 allocs/op
BenchmarkTagQueryFilterAndIntersect-8             	      20	  67469543 ns/op	10376007 B/op	   95536 allocs/op
BenchmarkTagQueryFilterAndIntersectOnlyRegex-8    	       3	 344564257 ns/op	38117266 B/op	  971995 allocs/op
BenchmarkIndexing-8                               	  300000	      4444 ns/op	    1805 B/op	      25 allocs/op
BenchmarkDeletes-8                                	  500000	      2640 ns/op	    1454 B/op	       9 allocs/op
BenchmarkExpressionParsing-8                      	  200000	      9035 ns/op	    6736 B/op	      86 allocs/op
PASS
ok  	github.com/grafana/metrictank/idx/memory	351.137s
```