### PR TITLE
add flag to import data only after a certain timestamp

### DIFF
--- a/cmd/mt-whisper-importer-reader/conversion.go
+++ b/cmd/mt-whisper-importer-reader/conversion.go
@@ -239,6 +239,9 @@ func decResolution(points []whisper.Point, method string, inRes, outRes, rawRes 
 		if boundary > uint32(*importUpTo) {
 			break
 		}
+		if boundary < uint32(*importAfter) {
+			continue
+		}
 
 		if boundary == currentBoundary {
 			agg.Add(inPoint.Value)

--- a/cmd/mt-whisper-importer-reader/conversion.go
+++ b/cmd/mt-whisper-importer-reader/conversion.go
@@ -75,7 +75,7 @@ func (c *conversion) getPoints(retIdx int, spp, nop uint32) map[string][]whisper
 			rawFactor := float64(spp) / float64(rawRes)
 			if retIdx == 0 || c.method != "avg" {
 				for _, p := range in {
-					if p.Timestamp > uint32(*importUpTo) {
+					if p.Timestamp > uint32(*importUpTo) || p.Timestamp < uint32(*importAfter) {
 						continue
 					}
 					adjustedPoints[c.method][p.Timestamp] = p.Value
@@ -85,7 +85,7 @@ func (c *conversion) getPoints(retIdx int, spp, nop uint32) map[string][]whisper
 				}
 			} else {
 				for _, p := range in {
-					if p.Timestamp > uint32(*importUpTo) {
+					if p.Timestamp > uint32(*importUpTo) || p.Timestamp < uint32(*importAfter) {
 						continue
 					}
 					adjustedPoints["sum"][p.Timestamp] = p.Value * rawFactor
@@ -111,7 +111,7 @@ func (c *conversion) getPoints(retIdx int, spp, nop uint32) map[string][]whisper
 	// merge the results that are keyed by timestamp into a slice of points
 	for m, p := range adjustedPoints {
 		for t, v := range p {
-			if t <= uint32(*importUpTo) {
+			if t <= uint32(*importUpTo) && t >= uint32(*importAfter) {
 				res[m] = append(res[m], whisper.Point{Timestamp: t, Value: v})
 			}
 		}
@@ -148,7 +148,7 @@ func incResolution(points []whisper.Point, method string, inRes, outRes, rawRes 
 		// generate datapoints based on inPoint in reverse order
 		var outPoints []whisper.Point
 		for ts := rangeEnd; ts > inPoint.Timestamp-inRes; ts = ts - outRes {
-			if ts > uint32(*importUpTo) {
+			if ts > uint32(*importUpTo) || ts < uint32(*importAfter) {
 				continue
 			}
 			outPoints = append(outPoints, whisper.Point{Timestamp: ts})

--- a/cmd/mt-whisper-importer-reader/main.go
+++ b/cmd/mt-whisper-importer-reader/main.go
@@ -83,6 +83,11 @@ var (
 		math.MaxUint32,
 		"Only import up to the specified timestamp",
 	)
+	importAfter = flag.Uint(
+		"import-after",
+		0,
+		"Only import after the specified timestamp",
+	)
 	verbose = flag.Bool(
 		"verbose",
 		false,


### PR DESCRIPTION
Some imports require a more specific time range. This allows us to specify a range rather than an upper timestamp for imports.