### PR TITLE
fix seriesByTag() expression parsing

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -685,9 +685,8 @@ func (s *Server) executePlan(ctx context.Context, orgId int, plan expr.Plan) ([]
 			startPos := len(SeriesByTagIdent)
 			endPos := strings.LastIndex(r.Query, ")")
 			exprs := strings.Split(r.Query[startPos:endPos], ",")
-			// Trim quotes
 			for i, e := range exprs {
-				exprs[i] = e[1 : len(e)-1]
+				exprs[i] = strings.Trim(e, " '\"")
 			}
 			series, err = s.clusterFindByTag(ctx, orgId, exprs, int64(r.From))
 		} else {


### PR DESCRIPTION
graphite encodes `seriesByTag()` as following:
```
target=seriesByTag%28%27type%3Dcpu%27%2C+%27host%3Dbastion-1%27%29
```
notice the `+` which is a ` `. so we need to fix the parsing to be able to handle spaces