### PR TITLE
do something with err

### DIFF
--- a/idx/idx.go
+++ b/idx/idx.go
@@ -60,6 +60,9 @@ func (id *MetricID) FromString(s string) error {
 
 	dst := make([]byte, 16)
 	n, err := hex.Decode(dst, []byte(splits[1]))
+	if err != nil {
+		return err
+	}
 	if n != 16 {
 		return errInvalidIdString
 	}


### PR DESCRIPTION
IneffAssign detects ineffectual assignments in Go code.
metrictank/idx/idx.go
Line 62: warning: err assigned and not used (ineffassign)