### PR TITLE
No tags in tree index

### DIFF
--- a/api/models/ccache.go
+++ b/api/models/ccache.go
@@ -5,7 +5,10 @@ import (
 )
 
 type CCacheDelete struct {
-	Patterns  []string `json:"patterns" form:"patterns" binding:"Required"`
+	// patterns with name globbing
+	Patterns []string `json:"patterns" form:"patterns" `
+	// tag expressions to select series
+	Expr      []string `json:"expr" form:"expr"`
 	OrgId     int      `json:"orgId" form:"orgId" binding:"Required"`
 	Propagate bool     `json:"propagate" form:"propagate"`
 }

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -42,3 +42,8 @@ type IndexTagDetailsResp struct {
 type IndexFindByTagResp struct {
 	Metrics []idx.Node `json:"metrics"`
 }
+
+//go:generate msgp
+type IndexTagDelSeriesResp struct {
+	Count int
+}

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -473,6 +473,100 @@ func (z *IndexFindResp) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *IndexTagDelSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, err = dc.ReadInt()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z IndexTagDelSeriesResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Count"
+	err = en.Append(0x81, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt(z.Count)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z IndexTagDelSeriesResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Count"
+	o = append(o, 0x81, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	o = msgp.AppendInt(o, z.Count)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexTagDelSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z IndexTagDelSeriesResp) Msgsize() (s int) {
+	s = 1 + 6 + msgp.IntSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *IndexTagDetailsResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/api/models/cluster_gen_test.go
+++ b/api/models/cluster_gen_test.go
@@ -350,6 +350,119 @@ func BenchmarkDecodeIndexFindResp(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalIndexTagDelSeriesResp(t *testing.T) {
+	v := IndexTagDelSeriesResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexTagDelSeriesResp(b *testing.B) {
+	v := IndexTagDelSeriesResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexTagDelSeriesResp(b *testing.B) {
+	v := IndexTagDelSeriesResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexTagDelSeriesResp(b *testing.B) {
+	v := IndexTagDelSeriesResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexTagDelSeriesResp(t *testing.T) {
+	v := IndexTagDelSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexTagDelSeriesResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexTagDelSeriesResp(b *testing.B) {
+	v := IndexTagDelSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexTagDelSeriesResp(b *testing.B) {
+	v := IndexTagDelSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalIndexTagDetailsResp(t *testing.T) {
 	v := IndexTagDetailsResp{}
 	bts, err := v.MarshalMsg(nil)

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-macaron/binding"
 	"github.com/grafana/metrictank/idx"
 	pickle "github.com/kisielk/og-rek"
+	opentracing "github.com/opentracing/opentracing-go"
 	"gopkg.in/macaron.v1"
 )
 
@@ -123,6 +124,24 @@ type GraphiteTagFindSeries struct {
 
 type GraphiteTagFindSeriesResp struct {
 	Series []string `json:"series"`
+}
+
+type GraphiteTagDelSeries struct {
+	Paths     []string `json:"path" form:"path"`
+	Propagate bool     `json:"propagate" form:"propagate" binding:"Default(true)"`
+}
+
+func (g GraphiteTagDelSeries) Trace(span opentracing.Span) {
+	span.SetTag("paths", g.Paths)
+	span.SetTag("propagate", g.Propagate)
+}
+
+func (g GraphiteTagDelSeries) TraceDebug(span opentracing.Span) {
+}
+
+type GraphiteTagDelSeriesResp struct {
+	Count int            `json:"count"`
+	Peers map[string]int `json:"peers"`
 }
 
 type GraphiteFind struct {

--- a/api/models/graphite_gen.go
+++ b/api/models/graphite_gen.go
@@ -9,6 +9,339 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *GraphiteTagDelSeries) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Paths":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				return
+			}
+			if cap(z.Paths) >= int(zb0002) {
+				z.Paths = (z.Paths)[:zb0002]
+			} else {
+				z.Paths = make([]string, zb0002)
+			}
+			for za0001 := range z.Paths {
+				z.Paths[za0001], err = dc.ReadString()
+				if err != nil {
+					return
+				}
+			}
+		case "Propagate":
+			z.Propagate, err = dc.ReadBool()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GraphiteTagDelSeries) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Paths"
+	err = en.Append(0x82, 0xa5, 0x50, 0x61, 0x74, 0x68, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Paths)))
+	if err != nil {
+		return
+	}
+	for za0001 := range z.Paths {
+		err = en.WriteString(z.Paths[za0001])
+		if err != nil {
+			return
+		}
+	}
+	// write "Propagate"
+	err = en.Append(0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.Propagate)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GraphiteTagDelSeries) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Paths"
+	o = append(o, 0x82, 0xa5, 0x50, 0x61, 0x74, 0x68, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Paths)))
+	for za0001 := range z.Paths {
+		o = msgp.AppendString(o, z.Paths[za0001])
+	}
+	// string "Propagate"
+	o = append(o, 0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
+	o = msgp.AppendBool(o, z.Propagate)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GraphiteTagDelSeries) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Paths":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if cap(z.Paths) >= int(zb0002) {
+				z.Paths = (z.Paths)[:zb0002]
+			} else {
+				z.Paths = make([]string, zb0002)
+			}
+			for za0001 := range z.Paths {
+				z.Paths[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+			}
+		case "Propagate":
+			z.Propagate, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *GraphiteTagDelSeries) Msgsize() (s int) {
+	s = 1 + 6 + msgp.ArrayHeaderSize
+	for za0001 := range z.Paths {
+		s += msgp.StringPrefixSize + len(z.Paths[za0001])
+	}
+	s += 10 + msgp.BoolSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *GraphiteTagDelSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, err = dc.ReadInt()
+			if err != nil {
+				return
+			}
+		case "Peers":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				return
+			}
+			if z.Peers == nil && zb0002 > 0 {
+				z.Peers = make(map[string]int, zb0002)
+			} else if len(z.Peers) > 0 {
+				for key, _ := range z.Peers {
+					delete(z.Peers, key)
+				}
+			}
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				var za0002 int
+				za0001, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				za0002, err = dc.ReadInt()
+				if err != nil {
+					return
+				}
+				z.Peers[za0001] = za0002
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GraphiteTagDelSeriesResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Count"
+	err = en.Append(0x82, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt(z.Count)
+	if err != nil {
+		return
+	}
+	// write "Peers"
+	err = en.Append(0xa5, 0x50, 0x65, 0x65, 0x72, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteMapHeader(uint32(len(z.Peers)))
+	if err != nil {
+		return
+	}
+	for za0001, za0002 := range z.Peers {
+		err = en.WriteString(za0001)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(za0002)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GraphiteTagDelSeriesResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Count"
+	o = append(o, 0x82, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	o = msgp.AppendInt(o, z.Count)
+	// string "Peers"
+	o = append(o, 0xa5, 0x50, 0x65, 0x65, 0x72, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Peers)))
+	for za0001, za0002 := range z.Peers {
+		o = msgp.AppendString(o, za0001)
+		o = msgp.AppendInt(o, za0002)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GraphiteTagDelSeriesResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Peers":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if z.Peers == nil && zb0002 > 0 {
+				z.Peers = make(map[string]int, zb0002)
+			} else if len(z.Peers) > 0 {
+				for key, _ := range z.Peers {
+					delete(z.Peers, key)
+				}
+			}
+			for zb0002 > 0 {
+				var za0001 string
+				var za0002 int
+				zb0002--
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				za0002, bts, err = msgp.ReadIntBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Peers[za0001] = za0002
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *GraphiteTagDelSeriesResp) Msgsize() (s int) {
+	s = 1 + 6 + msgp.IntSize + 6 + msgp.MapHeaderSize
+	if z.Peers != nil {
+		for za0001, za0002 := range z.Peers {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + msgp.IntSize
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *SeriesPickle) DecodeMsg(dc *msgp.Reader) (err error) {
 	var zb0002 uint32
 	zb0002, err = dc.ReadArrayHeader()

--- a/api/models/graphite_gen_test.go
+++ b/api/models/graphite_gen_test.go
@@ -11,6 +11,232 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+func TestMarshalUnmarshalGraphiteTagDelSeries(t *testing.T) {
+	v := GraphiteTagDelSeries{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGraphiteTagDelSeries(b *testing.B) {
+	v := GraphiteTagDelSeries{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGraphiteTagDelSeries(b *testing.B) {
+	v := GraphiteTagDelSeries{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGraphiteTagDelSeries(b *testing.B) {
+	v := GraphiteTagDelSeries{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGraphiteTagDelSeries(t *testing.T) {
+	v := GraphiteTagDelSeries{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GraphiteTagDelSeries{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGraphiteTagDelSeries(b *testing.B) {
+	v := GraphiteTagDelSeries{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGraphiteTagDelSeries(b *testing.B) {
+	v := GraphiteTagDelSeries{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalGraphiteTagDelSeriesResp(t *testing.T) {
+	v := GraphiteTagDelSeriesResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGraphiteTagDelSeriesResp(b *testing.B) {
+	v := GraphiteTagDelSeriesResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGraphiteTagDelSeriesResp(b *testing.B) {
+	v := GraphiteTagDelSeriesResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGraphiteTagDelSeriesResp(b *testing.B) {
+	v := GraphiteTagDelSeriesResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGraphiteTagDelSeriesResp(t *testing.T) {
+	v := GraphiteTagDelSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GraphiteTagDelSeriesResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGraphiteTagDelSeriesResp(b *testing.B) {
+	v := GraphiteTagDelSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGraphiteTagDelSeriesResp(b *testing.B) {
+	v := GraphiteTagDelSeriesResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalSeriesPickle(t *testing.T) {
 	v := SeriesPickle{}
 	bts, err := v.MarshalMsg(nil)

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -122,6 +122,19 @@ func (t IndexAutoCompleteTagValues) Trace(span opentracing.Span) {
 func (i IndexAutoCompleteTagValues) TraceDebug(span opentracing.Span) {
 }
 
+type IndexTagDelSeries struct {
+	OrgId int      `json:"orgId" binding:"Required"`
+	Paths []string `json:"path" form:"path"`
+}
+
+func (t IndexTagDelSeries) Trace(span opentracing.Span) {
+	span.SetTag("org", t.OrgId)
+	span.SetTag("paths", t.Paths)
+}
+
+func (i IndexTagDelSeries) TraceDebug(span opentracing.Span) {
+}
+
 type IndexGet struct {
 	Id string `json:"id" form:"id" binding:"Required"`
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -44,6 +44,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/tag_details", ready, bind(models.IndexTagDetails{})).Get(s.indexTagDetails).Post(s.indexTagDetails)
 	r.Combo("/index/tags/autoComplete/tags", ready, bind(models.IndexAutoCompleteTags{})).Get(s.indexAutoCompleteTags).Post(s.indexAutoCompleteTags)
 	r.Combo("/index/tags/autoComplete/values", ready, bind(models.IndexAutoCompleteTagValues{})).Get(s.indexAutoCompleteTagValues).Post(s.indexAutoCompleteTagValues)
+	r.Combo("/index/tags/delSeries", ready, bind(models.IndexTagDelSeries{})).Get(s.indexTagDelSeries).Post(s.indexTagDelSeries)
 
 	r.Combo("/ccache/delete", bind(models.CCacheDelete{})).Post(s.ccacheDelete).Get(s.ccacheDelete)
 
@@ -61,7 +62,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/metrics/tags/findSeries", withOrg, ready, bind(models.GraphiteTagFindSeries{})).Get(s.graphiteTagFindSeries).Post(s.graphiteTagFindSeries)
 	r.Combo("/tags/autoComplete/tags", withOrg, ready, bind(models.GraphiteAutoCompleteTags{})).Get(s.graphiteAutoCompleteTags).Post(s.graphiteAutoCompleteTags)
 	r.Combo("/tags/autoComplete/values", withOrg, ready, bind(models.GraphiteAutoCompleteTagValues{})).Get(s.graphiteAutoCompleteTagValues).Post(s.graphiteAutoCompleteTagValues)
-
+	r.Post("/tags/delSeries", withOrg, ready, bind(models.GraphiteTagDelSeries{}), s.graphiteTagDelSeries)
 	r.Combo("/functions", withOrg, ready).Get(s.graphiteFunctions).Post(s.graphiteFunctions)
 	r.Combo("/functions/:func(.+)", withOrg, ready).Get(s.graphiteFunctions).Post(s.graphiteFunctions)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -168,4 +168,8 @@ type MetricIndex interface {
 	// If the fourth parameter is > 0 then only those metrics of which the LastUpdate
 	// time is >= the from timestamp will be included.
 	TagDetails(int, string, string, int64) (map[string]uint64, error)
+
+	// DeleteTagged deletes the specified series from the tag index and also the
+	// DefById index.
+	DeleteTagged(int, []string) ([]Archive, error)
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -103,7 +103,8 @@ func (t *TagIndex) delTagId(name, value string, id idx.MetricID) {
 	}
 }
 
-// org id -> <name>;<key>=<name> -> Set of references to schema.MetricDefinition
+// org id -> nameWithTags -> Set of references to schema.MetricDefinition
+// nameWithTags is the name plus all tags in the <name>;<tag>=<value>... format.
 type defByTagSet map[int]map[string]map[*schema.MetricDefinition]struct{}
 
 func (defs defByTagSet) add(def *schema.MetricDefinition) {
@@ -175,22 +176,16 @@ func (n *Node) String() string {
 type MemoryIdx struct {
 	sync.RWMutex
 
-	// MetricDefinitions keyed by their ID as string. Includes all MDs, with
-	// and also without tags. It also mixes all orgs into one flat map.
-	DefById map[string]*idx.Archive
+	// used for both hierarchy and tag index, so includes all MDs, with
+	// and without tags. It also mixes all orgs into one flat map.
+	DefById map[string]*idx.Archive // by ID string
 
-	// Index trees keyed by org id. Each tree is keyed by the node paths in
-	// the format .node1.node2" and refers to a Node struct.
-	Tree map[int]*Tree
+	// used by hierarchy index only
+	Tree map[int]*Tree // by orgId
 
-	// Tag indices keyed by org id. Each tag index is keyed first by the tag
-	// name and then the key value, each combo refers to a set of metric IDs
-	// as strings.
-	tags map[int]TagIndex
-
-	// DefByTagSet is keyed by org id, and then by a string which is the name
-	// plus all tags in the <name>;<tag>=<value>... format.
+	// used by tag index
 	DefByTagSet defByTagSet
+	tags        map[int]TagIndex // by orgId
 }
 
 func New() *MemoryIdx {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -45,15 +45,15 @@ var (
 
 	Enabled         bool
 	matchCacheSize  int
-	tagSupport      bool
-	tagQueryWorkers int // number of workers to spin up when evaluation tag expressions
+	TagSupport      bool
+	TagQueryWorkers int // number of workers to spin up when evaluation tag expressions
 )
 
 func ConfigSetup() {
 	memoryIdx := flag.NewFlagSet("memory-idx", flag.ExitOnError)
 	memoryIdx.BoolVar(&Enabled, "enabled", false, "")
-	memoryIdx.BoolVar(&tagSupport, "tag-support", false, "enables/disables querying based on tags")
-	memoryIdx.IntVar(&tagQueryWorkers, "tag-query-workers", 50, "number of workers to spin up to evaluate tag queries")
+	memoryIdx.BoolVar(&TagSupport, "tag-support", false, "enables/disables querying based on tags")
+	memoryIdx.IntVar(&TagQueryWorkers, "tag-query-workers", 50, "number of workers to spin up to evaluate tag queries")
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
 	globalconf.Register("memory-idx", memoryIdx)
 }
@@ -170,7 +170,7 @@ func (m *MemoryIdx) AddOrUpdate(data *schema.MetricData, partition int32) idx.Ar
 	statMetricsActive.Inc()
 	statAddDuration.Value(time.Since(pre))
 
-	if tagSupport {
+	if TagSupport {
 		m.indexTags(def)
 	}
 
@@ -269,7 +269,7 @@ func (m *MemoryIdx) Load(defs []schema.MetricDefinition) int {
 
 		m.add(def)
 
-		if tagSupport {
+		if TagSupport {
 			m.indexTags(def)
 		}
 
@@ -298,7 +298,7 @@ func (m *MemoryIdx) add(def *schema.MetricDefinition) idx.Archive {
 		AggId:            aggId,
 	}
 
-	if tagSupport && len(def.Tags) > 0 {
+	if TagSupport && len(def.Tags) > 0 {
 		if _, ok := m.DefById[def.Id]; !ok {
 			m.DefById[def.Id] = archive
 			statAdd.Inc()
@@ -413,7 +413,7 @@ func (m *MemoryIdx) GetPath(orgId int, path string) []idx.Archive {
 }
 
 func (m *MemoryIdx) TagDetails(orgId int, key, filter string, from int64) (map[string]uint64, error) {
-	if !tagSupport {
+	if !TagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil, nil
 	}
@@ -485,7 +485,7 @@ func (m *MemoryIdx) TagDetails(orgId int, key, filter string, from int64) (map[s
 //
 // the results will always be sorted alphabetically for consistency
 func (m *MemoryIdx) FindTags(orgId int, prefix string, expressions []string, from int64, limit uint) ([]string, error) {
-	if !tagSupport {
+	if !TagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil, nil
 	}
@@ -568,7 +568,7 @@ func (m *MemoryIdx) FindTags(orgId int, prefix string, expressions []string, fro
 //
 // the results will always be sorted alphabetically for consistency
 func (m *MemoryIdx) FindTagValues(orgId int, tag, prefix string, expressions []string, from int64, limit uint) ([]string, error) {
-	if !tagSupport {
+	if !TagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil, nil
 	}
@@ -671,7 +671,7 @@ func (m *MemoryIdx) FindTagValues(orgId int, tag, prefix string, expressions []s
 // If the third parameter is >0 then only metrics will be accounted of which the
 // LastUpdate time is >= the given value.
 func (m *MemoryIdx) Tags(orgId int, filter string, from int64) ([]string, error) {
-	if !tagSupport {
+	if !TagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil, nil
 	}
@@ -741,7 +741,7 @@ func (m *MemoryIdx) hasOneMetricFrom(tags TagIndex, tag string, from int64) bool
 }
 
 func (m *MemoryIdx) FindByTag(orgId int, expressions []string, from int64) ([]idx.Node, error) {
-	if !tagSupport {
+	if !TagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil, nil
 	}
@@ -955,7 +955,7 @@ func (m *MemoryIdx) List(orgId int) []idx.Archive {
 }
 
 func (m *MemoryIdx) DeleteTagged(orgId int, paths []string) ([]idx.Archive, error) {
-	if !tagSupport {
+	if !TagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
 		return nil, nil
 	}
@@ -1146,7 +1146,7 @@ func (m *MemoryIdx) Prune(orgId int, oldest time.Time) ([]idx.Archive, error) {
 		for org := range m.Tree {
 			orgs[org] = struct{}{}
 		}
-		if tagSupport {
+		if TagSupport {
 			for org := range m.tags {
 				orgs[org] = struct{}{}
 			}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -252,6 +252,9 @@ func (m *MemoryIdx) indexTags(def *schema.MetricDefinition) {
 
 // deindexTags takes a given metric definition and removes all references
 // to it from the tag index. It assumes a lock is already held.
+// a return value of "false" means there was an error and the deindexing was
+// unsuccessful, "true" means the indexing was at least partially or completely
+// successful
 func (m *MemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDefinition) bool {
 	id, err := idx.NewMetricIDFromString(def.Id)
 	if err != nil {

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -147,9 +147,9 @@ func diskMetrics(dcCount, hostCount, hostOffset, diskCount int, prefix string) [
 }
 
 func TestMain(m *testing.M) {
-	defer func(t bool) { tagSupport = t }(tagSupport)
-	tagSupport = true
-	tagQueryWorkers = 5
+	defer func(t bool) { TagSupport = t }(TagSupport)
+	TagSupport = true
+	TagQueryWorkers = 5
 	matchCacheSize = 1000
 	os.Exit(m.Run())
 }

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -770,7 +770,7 @@ func ixFindByTag(b *testing.B, org, q int) {
 	if len(series) != tagQueries[q].ExpectedResults {
 		for _, s := range series {
 			memoryIdx := ix.(*MemoryIdx)
-			b.Log(memoryIdx.DefById[s.Path].Tags)
+			b.Log(memoryIdx.defById[s.Path].Tags)
 		}
 		b.Fatalf("%+v expected %d got %d results instead", tagQueries[q].Expressions, tagQueries[q].ExpectedResults, len(series))
 	}

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -61,16 +61,16 @@ func getMetricData(orgId, depth, count, interval int, prefix string, tagged bool
 }
 
 // testWithAndWithoutTagSupport calls a test with all combinations of
-// the settings tagSupport and tagsInTree. In some cases those settings can
+// the settings TagSupport and tagsInTree. In some cases those settings can
 // affect the logic quite a lot, so we need to test all combinations
 func testWithAndWithoutTagSupport(t *testing.T, f func(*testing.T)) {
 	t.Helper()
-	_tagSupport := tagSupport
-	defer func() { tagSupport = _tagSupport }()
+	_tagSupport := TagSupport
+	defer func() { TagSupport = _tagSupport }()
 
-	tagSupport = true
+	TagSupport = true
 	f(t)
-	tagSupport = false
+	TagSupport = false
 	f(t)
 }
 

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -60,9 +60,10 @@ func getMetricData(orgId, depth, count, interval int, prefix string, tagged bool
 	return data
 }
 
-// testWithAndWithoutTagSupport calls a test with all combinations of
-// the settings TagSupport and tagsInTree. In some cases those settings can
-// affect the logic quite a lot, so we need to test all combinations
+// testWithAndWithoutTagSupport calls a test with the TagSupprt setting
+// turned on and off. This is to verify that something works as expected
+// no matter what this flag is set to, it does not mean that the behavior
+// of a method should be changing dependent on that setting.
 func testWithAndWithoutTagSupport(t *testing.T, f func(*testing.T)) {
 	t.Helper()
 	_tagSupport := TagSupport

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -785,8 +785,8 @@ func (q *TagQuery) Run(index TagIndex, byId map[string]*idx.Archive) IdSet {
 	// evaluate for each of them whether it satisfies all the conditions
 	// defined in the query expressions. those that satisfy all conditions
 	// will be pushed into the resCh
-	q.wg.Add(tagQueryWorkers)
-	for i := 0; i < tagQueryWorkers; i++ {
+	q.wg.Add(TagQueryWorkers)
+	for i := 0; i < TagQueryWorkers; i++ {
 		go q.filterIdsFromChan(idCh, resCh)
 	}
 
@@ -980,8 +980,8 @@ func (q *TagQuery) RunGetTags(index TagIndex, byId map[string]*idx.Archive) map[
 	// evaluate for each of them whether it satisfies all the conditions
 	// defined in the query expressions. then they will extract the tags of
 	// those that satisfy all conditions and push them into tagCh.
-	q.wg.Add(tagQueryWorkers)
-	for i := 0; i < tagQueryWorkers; i++ {
+	q.wg.Add(TagQueryWorkers)
+	for i := 0; i < TagQueryWorkers; i++ {
 		go q.filterTagsFromChan(idCh, tagCh, stopCh, matchName)
 	}
 

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -384,9 +384,9 @@ func TestTagExpressionQueryByTagWithFrom(t *testing.T) {
 }
 
 func TestGetByTag(t *testing.T) {
-	_tagSupport := tagSupport
-	defer func() { tagSupport = _tagSupport }()
-	tagSupport = true
+	_tagSupport := TagSupport
+	defer func() { TagSupport = _tagSupport }()
+	TagSupport = true
 
 	ix := New()
 	ix.Init()
@@ -484,55 +484,6 @@ func TestGetByTag(t *testing.T) {
 		if !reflect.DeepEqual(resPaths, tc.expectation) {
 			t.Fatalf("Result does not match expectation\nGot:\n%+v\nExpected:\n%+v\n", res, tc.expectation)
 		}
-	}
-}
-
-func TestDeleteTaggedSeries(t *testing.T) {
-	_tagSupport := tagSupport
-	defer func() { tagSupport = _tagSupport }()
-	tagSupport = true
-
-	ix := New()
-	ix.Init()
-
-	orgId := 1
-
-	mds := getMetricData(orgId, 2, 50, 10, "metric.public")
-	mds[10].Tags = []string{"key1=value1", "key2=value2"}
-	mds[10].SetId()
-
-	for _, md := range mds {
-		ix.AddOrUpdate(md, 1)
-	}
-
-	tagQuery, _ := NewTagQuery([]string{"key1=value1", "key2=value2"}, 0)
-	res := ix.idsByTagQuery(orgId, tagQuery)
-
-	if len(res) != 1 {
-		t.Fatalf("Expected to get 1 result, but got %d", len(res))
-	}
-
-	if len(ix.tags[orgId]) != 3 {
-		t.Fatalf("Expected tag index to contain 3 keys, but it has %d: %+v", len(ix.tags), ix.tags)
-	}
-
-	deleted, err := ix.Delete(orgId, schema.MetricDefinitionFromMetricData(mds[10]).NameWithTags())
-	if err != nil {
-		t.Fatalf("Error deleting metric: %s", err)
-	}
-
-	if len(deleted) != 1 {
-		t.Fatalf("Expected 1 metric to get deleted, but got %d", len(deleted))
-	}
-
-	res = ix.idsByTagQuery(orgId, tagQuery)
-
-	if len(res) != 0 {
-		t.Fatalf("Expected to get 0 results, but got %d", len(res))
-	}
-
-	if len(ix.tags[orgId]) > 1 {
-		t.Fatalf("Expected tag index to only have one (name) tag, but it has more: %+v", ix.tags)
 	}
 }
 

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -472,8 +472,12 @@ func TestGetByTag(t *testing.T) {
 		}
 
 		resPaths := make([]string, 0, len(res))
-		for _, r := range res {
-			resPaths = append(resPaths, r.Path)
+		for id := range res {
+			def, ok := ix.DefById[id.String()]
+			if !ok {
+				t.Fatalf("Tag query returned ID that did not exist in DefByID: %s", id.String())
+			}
+			resPaths = append(resPaths, def.NameWithTags())
 		}
 		sort.Strings(tc.expectation)
 		sort.Strings(resPaths)

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -473,7 +473,7 @@ func TestGetByTag(t *testing.T) {
 
 		resPaths := make([]string, 0, len(res))
 		for id := range res {
-			def, ok := ix.DefById[id.String()]
+			def, ok := ix.defById[id.String()]
 			if !ok {
 				t.Fatalf("Tag query returned ID that did not exist in DefByID: %s", id.String())
 			}

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -17,6 +17,7 @@ type MockCache struct {
 	DelMetricArchives int
 	DelMetricSeries   int
 	DelMetricKeys     []string
+	ResetCalls        int
 }
 
 func NewMockCache() *MockCache {
@@ -57,5 +58,6 @@ func (mc *MockCache) DelMetric(rawMetric string) (int, int) {
 }
 
 func (mc *MockCache) Reset() (int, int) {
+	mc.ResetCalls++
 	return mc.DelMetricSeries, mc.DelMetricArchives
 }


### PR DESCRIPTION
As described in #798, tagged series should not be added into the tree index anymore.

This also means that we'll now need separate methods to delete by tag expressions, as described here: http://graphite.readthedocs.io/en/latest/tags.html#removing-series-from-the-tagdb

Furthermore, pruning needs to be fixed so it also takes the tag index into account.

Fixes #798 