### PR TITLE
Membersforquery fixes

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -105,12 +105,13 @@ func MembersForQuery() ([]Node, error) {
 				}
 				continue
 			}
-			if membersMap[part].priority == member.GetPriority() {
+			priority := member.GetPriority()
+			if membersMap[part].priority == priority {
 				membersMap[part].nodes = append(membersMap[part].nodes, member)
-			} else if membersMap[part].priority > member.GetPriority() {
+			} else if membersMap[part].priority > priority {
 				// this node has higher priority (lower number) then previously seen candidates
 				membersMap[part] = &partitionCandidates{
-					priority: member.GetPriority(),
+					priority: priority,
 					nodes:    []Node{member},
 				}
 			}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -73,17 +73,17 @@ func TestPeersForQueryMulti(t *testing.T) {
 		So(nodeNames, ShouldContain, manager.thisNode().GetName())
 		Convey("members should be selected randomly with even distribution", func() {
 			peerCount := make(map[string]int)
-			for i := 0; i < 10000; i++ {
+			for i := 0; i < 100; i++ {
 				selected, err = MembersForQuery()
 				So(err, ShouldBeNil)
 				for _, p := range selected {
 					peerCount[p.GetName()]++
 				}
 			}
-			So(peerCount["node1"], ShouldEqual, 10000)
+			So(peerCount["node1"], ShouldEqual, 100)
 			So(peerCount["node2"], ShouldEqual, 0)
-			So(peerCount["node3"], ShouldAlmostEqual, 5000)
-			So(peerCount["node4"], ShouldAlmostEqual, 5000)
+			So(peerCount["node3"], ShouldEqual, 50)
+			So(peerCount["node4"], ShouldEqual, 50)
 			for p, count := range peerCount {
 				t.Logf("%s: %d", p, count)
 			}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -73,17 +73,17 @@ func TestPeersForQueryMulti(t *testing.T) {
 		So(nodeNames, ShouldContain, manager.thisNode().GetName())
 		Convey("members should be selected randomly with even distribution", func() {
 			peerCount := make(map[string]int)
-			for i := 0; i < 1000; i++ {
+			for i := 0; i < 10000; i++ {
 				selected, err = MembersForQuery()
 				So(err, ShouldBeNil)
 				for _, p := range selected {
 					peerCount[p.GetName()]++
 				}
 			}
-			So(peerCount["node1"], ShouldEqual, 1000)
+			So(peerCount["node1"], ShouldEqual, 10000)
 			So(peerCount["node2"], ShouldEqual, 0)
-			So(peerCount["node3"], ShouldAlmostEqual, 500)
-			So(peerCount["node4"], ShouldAlmostEqual, 500)
+			So(peerCount["node3"], ShouldAlmostEqual, 5000)
+			So(peerCount["node4"], ShouldAlmostEqual, 5000)
 			for p, count := range peerCount {
 				t.Logf("%s: %d", p, count)
 			}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -82,8 +82,8 @@ func TestPeersForQueryMulti(t *testing.T) {
 			}
 			So(peerCount["node1"], ShouldEqual, 1000)
 			So(peerCount["node2"], ShouldEqual, 0)
-			So(peerCount["node3"], ShouldNotAlmostEqual, 500)
-			So(peerCount["node4"], ShouldNotAlmostEqual, 500)
+			So(peerCount["node3"], ShouldAlmostEqual, 500)
+			So(peerCount["node4"], ShouldAlmostEqual, 500)
 			for p, count := range peerCount {
 				t.Logf("%s: %d", p, count)
 			}

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -163,6 +164,7 @@ func (c *MemberlistManager) memberList() []HTTPNode {
 		i++
 	}
 	c.RUnlock()
+	sort.Sort(HTTPNodesByName(list))
 	return list
 }
 

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -206,3 +206,9 @@ func handleResp(rsp *http.Response) ([]byte, error) {
 	}
 	return ioutil.ReadAll(rsp.Body)
 }
+
+type HTTPNodesByName []HTTPNode
+
+func (n HTTPNodesByName) Len() int           { return len(n) }
+func (n HTTPNodesByName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n HTTPNodesByName) Less(i, j int) bool { return n[i].GetName() < n[j].GetName() }


### PR DESCRIPTION
TestPeersForQueryMulti occasionally fails in CI. I've seen this in various non-cluster-related PR's and I think also in master.  I think this has been more frequent recently, but i'm not sure.
when I run `for i in $(seq 1 200); do go test -run=TestPeersForQueryMulti >> master.txt; done` I observed 2 failures, 198 passes.

see the indiviual commit messages for how i've gone about addressing this.