### PR TITLE
keep import position in whisper reader

### DIFF
--- a/cmd/mt-whisper-importer-reader/main.go
+++ b/cmd/mt-whisper-importer-reader/main.go
@@ -121,9 +121,9 @@ func main() {
 
 	var pos *posTracker
 	if len(*positionFile) > 0 {
-		pos, err = NewPositionKeeper(*positionFile)
+		pos, err = NewPositionTracker(*positionFile)
 		if err != nil {
-			log.Fatalf("Error instantiating position keeper: %s", err)
+			log.Fatalf("Error instantiating position tracker: %s", err)
 		}
 		defer pos.Close()
 	}

--- a/cmd/mt-whisper-importer-reader/pos_tracker.go
+++ b/cmd/mt-whisper-importer-reader/pos_tracker.go
@@ -16,7 +16,7 @@ type posTracker struct {
 	wg           sync.WaitGroup
 }
 
-func NewPositionKeeper(file string) (*posTracker, error) {
+func NewPositionTracker(file string) (*posTracker, error) {
 	p := &posTracker{file: file}
 
 	fd, err := os.Open(file)

--- a/cmd/mt-whisper-importer-reader/pos_tracker.go
+++ b/cmd/mt-whisper-importer-reader/pos_tracker.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+type posTracker struct {
+	sync.Mutex
+	file         string
+	fd           *os.File
+	completedMap sync.Map
+	wg           sync.WaitGroup
+}
+
+func NewPositionKeeper(file string) (*posTracker, error) {
+	p := &posTracker{file: file}
+
+	fd, err := os.Open(file)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		reader := bufio.NewReader(fd)
+		var path string
+		for {
+			line, isPrefix, err := reader.ReadLine()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return nil, err
+			}
+
+			path += string(line)
+			if isPrefix {
+				continue
+			} else {
+				p.completedMap.Store(path, struct{}{})
+				path = ""
+			}
+		}
+
+		fd.Close()
+	}
+
+	p.fd, err = os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (p *posTracker) IsDone(path string) bool {
+	_, ok := p.completedMap.Load(path)
+	return ok
+}
+
+func (p *posTracker) Done(path string) {
+	p.completedMap.Store(path, struct{}{})
+	p.wg.Add(1)
+	go func() {
+		p.Lock()
+		defer p.Unlock()
+		p.fd.WriteString(fmt.Sprintf("%s\n", path))
+		p.fd.Sync()
+		p.wg.Done()
+	}()
+}
+
+func (p *posTracker) Close() {
+	p.wg.Wait()
+	p.fd.Close()
+}

--- a/cmd/mt-whisper-importer-reader/pos_tracker_test.go
+++ b/cmd/mt-whisper-importer-reader/pos_tracker_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestPositionKeeper(t *testing.T) {
-	filePath := "/tmp/positionKeeperTest"
+func TestPositionTracker(t *testing.T) {
+	filePath := "/tmp/positionTrackerTest"
 	clearFile := func() { os.Remove(filePath) }
 	clearFile()
 	defer clearFile()
@@ -15,9 +15,9 @@ func TestPositionKeeper(t *testing.T) {
 	testValue2 := "file2"
 	testValue3 := "file3"
 
-	p1, err := NewPositionKeeper(filePath)
+	p1, err := NewPositionTracker(filePath)
 	if err != nil {
-		t.Fatalf("Error instantiating position keeper: %s", err)
+		t.Fatalf("Error instantiating position tracker: %s", err)
 	}
 	p1.Done(testValue1)
 	if !p1.IsDone(testValue1) {
@@ -32,10 +32,10 @@ func TestPositionKeeper(t *testing.T) {
 	}
 	p1.Close()
 
-	// read the file into new instance of position keeper
-	p2, err := NewPositionKeeper(filePath)
+	// read the file into new instance of position tracker
+	p2, err := NewPositionTracker(filePath)
 	if err != nil {
-		t.Fatalf("Error instantiating position keeper: %s", err)
+		t.Fatalf("Error instantiating position tracker: %s", err)
 	}
 	if !p2.IsDone(testValue1) || !p2.IsDone(testValue2) {
 		t.Fatalf("Expected %s and %s to be done, but it was not", testValue1, testValue2)
@@ -48,10 +48,10 @@ func TestPositionKeeper(t *testing.T) {
 	p2.Done(testValue3)
 	p2.Close()
 
-	// read the file into new instance of position keeper
-	p3, err := NewPositionKeeper(filePath)
+	// read the file into new instance of position tracker
+	p3, err := NewPositionTracker(filePath)
 	if err != nil {
-		t.Fatalf("Error instantiating position keeper: %s", err)
+		t.Fatalf("Error instantiating position tracker: %s", err)
 	}
 	if !p3.IsDone(testValue1) || !p3.IsDone(testValue2) || !p3.IsDone(testValue3) {
 		t.Fatalf("Expected %s, %s and %s to be done, but it was not", testValue1, testValue2, testValue3)

--- a/cmd/mt-whisper-importer-reader/pos_tracker_test.go
+++ b/cmd/mt-whisper-importer-reader/pos_tracker_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPositionKeeper(t *testing.T) {
+	filePath := "/tmp/positionKeeperTest"
+	clearFile := func() { os.Remove(filePath) }
+	clearFile()
+	defer clearFile()
+
+	testValue1 := "file1"
+	testValue2 := "file2"
+	testValue3 := "file3"
+
+	p1, err := NewPositionKeeper(filePath)
+	if err != nil {
+		t.Fatalf("Error instantiating position keeper: %s", err)
+	}
+	p1.Done(testValue1)
+	if !p1.IsDone(testValue1) {
+		t.Fatalf("Expected %s to be done, but it was not", testValue1)
+	}
+	if p1.IsDone(testValue2) {
+		t.Fatalf("Expected %s to not be done, but it was", testValue2)
+	}
+	p1.Done(testValue2)
+	if !p1.IsDone(testValue2) {
+		t.Fatalf("Expected %s to be done, but it was not", testValue2)
+	}
+	p1.Close()
+
+	// read the file into new instance of position keeper
+	p2, err := NewPositionKeeper(filePath)
+	if err != nil {
+		t.Fatalf("Error instantiating position keeper: %s", err)
+	}
+	if !p2.IsDone(testValue1) || !p2.IsDone(testValue2) {
+		t.Fatalf("Expected %s and %s to be done, but it was not", testValue1, testValue2)
+	}
+
+	if p2.IsDone(testValue3) {
+		t.Fatalf("Expected %s to not be done, but it was", testValue3)
+	}
+
+	p2.Done(testValue3)
+	p2.Close()
+
+	// read the file into new instance of position keeper
+	p3, err := NewPositionKeeper(filePath)
+	if err != nil {
+		t.Fatalf("Error instantiating position keeper: %s", err)
+	}
+	if !p3.IsDone(testValue1) || !p3.IsDone(testValue2) || !p3.IsDone(testValue3) {
+		t.Fatalf("Expected %s, %s and %s to be done, but it was not", testValue1, testValue2, testValue3)
+	}
+}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -471,6 +471,8 @@ Usage of ./mt-whisper-importer-reader:
     	Prefix to prepend before every metric name, should include the '.' if necessary
   -orgid int
     	Organization ID the data belongs to  (default 1)
+  -position-file string
+    	file to store position and load position from
   -threads int
     	Number of workers threads to process and convert .wsp files (default 10)
   -verbose


### PR DESCRIPTION
Tested in my test env. I ran the importer-reader with the following command:

```
./mt-whisper-importer-reader \
-dst-schemas /home/mst/documents/code/go/src/github.com/grafana/metrictank/scripts/config/storage-schemas.conf \
-http-endpoint http://localhost:5432/chunks \
-name-prefix my.test. \
-orgid 1 \
-threads 3 \
-verbose \
-whisper-directory ziggurat  \
-position-file /tmp/mypos
```

After a few seconds I aborted with Ctrl+C. The file `/tmp/mypos` now contains the list of files that have already been processed: 

```
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ cat /tmp/mypos
ziggurat/GenericJMX/cassandra_ClientRequest/counter/RangeSliceLatency_count.wsp
ziggurat/GenericJMX/cassandra_ClientRequest/counter/RangeSliceFailures_count.wsp
ziggurat/GenericJMX/cassandra_ClientRequest/counter/RangeSliceLatency_sum.wsp
```

When I now restart the same command it skips those that have already been completed:

```
DEBU[0000] Skipping file ziggurat/GenericJMX/cassandra_ClientRequest/counter/RangeSliceFailures_count.wsp because it was listed as already done 
DEBU[0000] Skipping file ziggurat/GenericJMX/cassandra_ClientRequest/counter/RangeSliceLatency_count.wsp because it was listed as already done 
DEBU[0000] Skipping file ziggurat/GenericJMX/cassandra_ClientRequest/counter/RangeSliceLatency_sum.wsp because it was listed as already done 
```

fixes issue #727 
