### PR TITLE
proxy /functions to graphite

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1151,3 +1151,8 @@ func (s *Server) clusterAutoCompleteTagValues(ctx context.Context, orgId int, ta
 
 	return vals, nil
 }
+
+func (s *Server) graphiteFunctions(ctx *middleware.Context) {
+	ctx.Req.Request.Body = ctx.Body
+	graphiteProxy.ServeHTTP(ctx.Resp, ctx.Req.Request)
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -61,4 +61,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/metrics/tags/findSeries", withOrg, ready, bind(models.GraphiteTagFindSeries{})).Get(s.graphiteTagFindSeries).Post(s.graphiteTagFindSeries)
 	r.Combo("/tags/autoComplete/tags", withOrg, ready, bind(models.GraphiteAutoCompleteTags{})).Get(s.graphiteAutoCompleteTags).Post(s.graphiteAutoCompleteTags)
 	r.Combo("/tags/autoComplete/values", withOrg, ready, bind(models.GraphiteAutoCompleteTagValues{})).Get(s.graphiteAutoCompleteTagValues).Post(s.graphiteAutoCompleteTagValues)
+
+	r.Combo("/functions", withOrg, ready).Get(s.graphiteFunctions).Post(s.graphiteFunctions)
+	r.Combo("/functions/:func(.+)", withOrg, ready).Get(s.graphiteFunctions).Post(s.graphiteFunctions)
 }


### PR DESCRIPTION
This simply proxies calls to `/functions(.*)` to graphite. The latest version of `graphite-mt` already supports that.

Works in dev & QA

call to `/functions`:
```
root@hosted-metrics-api-2954441641-084f6:/# curl -s -H 'X-Org-Id: 1' 'http://mt-read-1-small-raintank:6060/functions' | jq '.' | more                                                                                                                                     
{
  "cumulative": {
    "function": "cumulative(seriesList)",
    "group": "Special",
    "name": "cumulative",
    "module": "graphite.render.functions",
    "params": [
      {
        "required": true,
        "type": "seriesList",
        "name": "seriesList"
      }
    ],
    "description": "Takes one metric or a wildcard seriesList.\n\nWhen a graph is drawn where width of the graph size in pixels is smaller than\nthe number of datapoints to be graphed, Graphite consolidates the values to\nto prevent line overlap. The cumulative() f$
nction changes the consolidation\nfunction from the default of 'average' to 'sum'. This is especially useful in\nsales graphs, where fractional values make no sense and a 'sum' of consolidated\nvalues is appropriate.\n\nAlias for :func:`consolidateBy(series, 'sum') 
<graphite.render.functions.consolidateBy>`\n\n.. code-block:: none\n\n  &target=cumulative(Sales.widgets.largeBlue)"
  },

```

call to `/functions/cumulative`
```
root@hosted-metrics-api-2954441641-084f6:/# curl -s -H 'X-Org-Id: 1' 'http://mt-read-1-small-raintank:6060/functions/cumulative' | jq '.' | more
{
  "function": "cumulative(seriesList)",
  "group": "Special",
  "name": "cumulative",
  "module": "graphite.render.functions",
  "params": [
    {
      "required": true,
      "type": "seriesList",
      "name": "seriesList"
    }
  ],
  "description": "Takes one metric or a wildcard seriesList.\n\nWhen a graph is drawn where width of the graph size in pixels is smaller than\nthe number of datapoints to be graphed, Graphite consolidates the values to\nto prevent line overlap. The cumulative() func
tion changes the consolidation\nfunction from the default of 'average' to 'sum'. This is especially useful in\nsales graphs, where fractional values make no sense and a 'sum' of consolidated\nvalues is appropriate.\n\nAlias for :func:`consolidateBy(series, 'sum') <g
raphite.render.functions.consolidateBy>`\n\n.. code-block:: none\n\n  &target=cumulative(Sales.widgets.largeBlue)"
}
```

fixes #794