### PR TITLE
export mdata.ChunkWriteRequest fields

### DIFF
--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -363,12 +363,12 @@ func (a *AggMetric) persist(pos int) {
 	pending := make([]*ChunkWriteRequest, 1)
 	// add the current chunk to the list of chunks to send to the writeQueue
 	pending[0] = &ChunkWriteRequest{
-		metric:    a,
-		key:       a.Key,
-		span:      a.ChunkSpan,
-		ttl:       a.ttl,
-		chunk:     chunk,
-		timestamp: time.Now(),
+		Metric:    a,
+		Key:       a.Key,
+		Span:      a.ChunkSpan,
+		TTL:       a.ttl,
+		Chunk:     chunk,
+		Timestamp: time.Now(),
 	}
 
 	// if we recently became the primary, there may be older chunks
@@ -384,12 +384,12 @@ func (a *AggMetric) persist(pos int) {
 			log.Debug("AM persist(): old chunk needs saving. Adding %s:%d to writeQueue", a.Key, previousChunk.T0)
 		}
 		pending = append(pending, &ChunkWriteRequest{
-			metric:    a,
-			key:       a.Key,
-			span:      a.ChunkSpan,
-			ttl:       a.ttl,
-			chunk:     previousChunk,
-			timestamp: time.Now(),
+			Metric:    a,
+			Key:       a.Key,
+			Span:      a.ChunkSpan,
+			TTL:       a.ttl,
+			Chunk:     previousChunk,
+			Timestamp: time.Now(),
 		})
 		previousPos--
 		if previousPos < 0 {

--- a/mdata/cwr.go
+++ b/mdata/cwr.go
@@ -18,12 +18,12 @@ type ChunkReadRequest struct {
 }
 
 type ChunkWriteRequest struct {
-	metric    *AggMetric
-	key       string
-	chunk     *chunk.Chunk
-	ttl       uint32
-	timestamp time.Time
-	span      uint32
+	Metric    *AggMetric
+	Key       string
+	Chunk     *chunk.Chunk
+	TTL       uint32
+	Timestamp time.Time
+	Span      uint32
 }
 
 func NewChunkWriteRequest(metric *AggMetric, key string, chunk *chunk.Chunk, ttl, span uint32, ts time.Time) ChunkWriteRequest {

--- a/mdata/store_mock.go
+++ b/mdata/store_mock.go
@@ -23,8 +23,8 @@ func (c *MockStore) ResetMock() {
 
 // Add adds a chunk to the store
 func (c *MockStore) Add(cwr *ChunkWriteRequest) {
-	itgen := chunk.NewBareIterGen(cwr.chunk.Series.Bytes(), cwr.chunk.Series.T0, cwr.span)
-	c.results[cwr.key] = append(c.results[cwr.key], *itgen)
+	itgen := chunk.NewBareIterGen(cwr.Chunk.Series.Bytes(), cwr.Chunk.Series.T0, cwr.Span)
+	c.results[cwr.Key] = append(c.results[cwr.Key], *itgen)
 }
 
 // searches through the mock results and returns the right ones according to start / end


### PR DESCRIPTION
If users want to build their own backend stores they need to be able to
process mdata.ChunkWriteRequest payloads.  TO be able to do this, the
fields of the ChunkWriteRequest need to be exported.