### PR TITLE
Init Logger before Configs

### DIFF
--- a/metrictank.go
+++ b/metrictank.go
@@ -103,6 +103,11 @@ func main() {
 	startupTime = time.Now()
 
 	/***********************************
+		Initialize Logger
+	***********************************/
+	log.NewLogger(0, "console", fmt.Sprintf(`{"level": %d, "formatting":false}`, logLevel))
+
+	/***********************************
 		Initialize Configuration
 	***********************************/
 	flag.Parse()
@@ -152,9 +157,8 @@ func main() {
 	config.ParseAll()
 
 	/***********************************
-		Initialize Logging
+		Set logging levels
 	***********************************/
-	log.NewLogger(0, "console", fmt.Sprintf(`{"level": %d, "formatting":false}`, logLevel))
 	mdata.LogLevel = logLevel
 	inKafkaMdm.LogLevel = logLevel
 	api.LogLevel = logLevel


### PR DESCRIPTION
The project attempts to use the logger before it's initialized.
For example, it would never print out log.Fatal(4, "error with configuration file: %s", err) and merely exit. Additionally the logger is used in loading configs meaning they silently fail.

The user specified logging levels are applied after configs are parsed.
golang's init function runs first so log-level will be parsed already

> oopsie fixed from #823 