### PR TITLE
Make sure rollup data is persisted before GC

### DIFF
--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -117,11 +117,11 @@ func (agg *Aggregator) GC(chunkMinTs, metricMinTs, lastWriteTime uint32) bool {
 	ret := true
 
 	if lastWriteTime+agg.span > chunkMinTs {
-		// Last datapoint was less than one chunkSpan before chunkMinTs, hold out for more data
+		// Last datapoint was less than one aggregation window before chunkMinTs, hold out for more data
 		return false
 	}
 
-	// Haven't seen datapoints in an entire chunkSpan, time to flush
+	// Haven't seen datapoints in an entire aggregation window before chunkMinTs, time to flush
 	if agg.agg.Cnt != 0 {
 		agg.flush()
 	}

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -112,3 +112,35 @@ func (agg *Aggregator) Add(ts uint32, val float64) {
 		panic("aggregator: boundary < agg.currentBoundary. ts > lastSeen should already have been asserted")
 	}
 }
+
+func (agg *Aggregator) GC(chunkMinTs, metricMinTs, lastWriteTime uint32) bool {
+	ret := true
+
+	if lastWriteTime+agg.span > chunkMinTs {
+		// Last datapoint was less than one chunkSpan before chunkMinTs, hold out for more data
+		return false
+	}
+
+	// Haven't seen datapoints in an entire chunkSpan, time to flush
+	if agg.agg.Cnt != 0 {
+		agg.flush()
+	}
+
+	if agg.minMetric != nil {
+		ret = agg.minMetric.GC(chunkMinTs, metricMinTs) && ret
+	}
+	if agg.maxMetric != nil {
+		ret = agg.maxMetric.GC(chunkMinTs, metricMinTs) && ret
+	}
+	if agg.sumMetric != nil {
+		ret = agg.sumMetric.GC(chunkMinTs, metricMinTs) && ret
+	}
+	if agg.cntMetric != nil {
+		ret = agg.cntMetric.GC(chunkMinTs, metricMinTs) && ret
+	}
+	if agg.lstMetric != nil {
+		ret = agg.lstMetric.GC(chunkMinTs, metricMinTs) && ret
+	}
+
+	return ret
+}


### PR DESCRIPTION
Fixes #834 

This PR is less than perfect but functional.

Essentially, everywhere that we used to return `true` in GC now returns `true` iff all aggregators are also eligible for GC. 

For an aggregator to be eligible for GC, it must first be flushed, then gets the same check as the base aggregator. As written, flushing updates the lastWriteTime, delaying GC eligibility.