### PR TITLE
fix bad argument error display

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -521,7 +521,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sortByName(aliasByNode(metrictank.stats.$environment.$instance.cluster.notifier.kafka.partition.*.lag.gauge64, 3, 8), 'true')"
+              "target": "sortByName(aliasByNode(metrictank.stats.$environment.$instance.cluster.notifier.kafka.partition.*.lag.gauge64, 3, 8), true)"
             }
           ],
           "thresholds": [],
@@ -591,7 +591,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sortByName(aliasByNode(metrictank.stats.$environment.$instance.input.kafka-mdm.partition.*.lag.gauge64, 3, 7), 'true')"
+              "target": "sortByName(aliasByNode(metrictank.stats.$environment.$instance.input.kafka-mdm.partition.*.lag.gauge64, 3, 7), true)"
             }
           ],
           "thresholds": [],
@@ -1171,7 +1171,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(sortByName(sumSeriesWithWildcards(perSecond(metrictank.stats.$environment.$instance.api.request.*.status.*.counter32), 3), 'true'), 5, 7)"
+              "target": "aliasByNode(sortByName(sumSeriesWithWildcards(perSecond(metrictank.stats.$environment.$instance.api.request.*.status.*.counter32), 3), true), 5, 7)"
             }
           ],
           "thresholds": [],

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -67,11 +67,11 @@ func (e expr) consumeBasicArg(pos int, exp Arg) (int, error) {
 	switch v := exp.(type) {
 	case ArgSeries, ArgSeriesList:
 		if got.etype != etName && got.etype != etFunc {
-			return 0, ErrBadArgumentStr{"func or name", string(got.etype)}
+			return 0, ErrBadArgumentStr{"func or name", got.etype.String()}
 		}
 	case ArgSeriesLists:
 		if got.etype != etName && got.etype != etFunc {
-			return 0, ErrBadArgumentStr{"func or name", string(got.etype)}
+			return 0, ErrBadArgumentStr{"func or name", got.etype.String()}
 		}
 		// special case! consume all subsequent args (if any) in args that will also yield a seriesList
 		for len(e.args) > pos+1 && (e.args[pos+1].etype == etName || e.args[pos+1].etype == etFunc) {
@@ -79,7 +79,7 @@ func (e expr) consumeBasicArg(pos int, exp Arg) (int, error) {
 		}
 	case ArgInt:
 		if got.etype != etInt {
-			return 0, ErrBadArgumentStr{"int", string(got.etype)}
+			return 0, ErrBadArgumentStr{"int", got.etype.String()}
 		}
 		for _, va := range v.validator {
 			if err := va(got); err != nil {
@@ -101,7 +101,7 @@ func (e expr) consumeBasicArg(pos int, exp Arg) (int, error) {
 	case ArgFloat:
 		// integer is also a valid float, just happened to have no decimals
 		if got.etype != etFloat && got.etype != etInt {
-			return 0, ErrBadArgumentStr{"float", string(got.etype)}
+			return 0, ErrBadArgumentStr{"float", got.etype.String()}
 		}
 		for _, va := range v.validator {
 			if err := va(got); err != nil {
@@ -115,7 +115,7 @@ func (e expr) consumeBasicArg(pos int, exp Arg) (int, error) {
 		}
 	case ArgString:
 		if got.etype != etString {
-			return 0, ErrBadArgumentStr{"string", string(got.etype)}
+			return 0, ErrBadArgumentStr{"string", got.etype.String()}
 		}
 		for _, va := range v.validator {
 			if err := va(got); err != nil {
@@ -136,7 +136,7 @@ func (e expr) consumeBasicArg(pos int, exp Arg) (int, error) {
 		return pos, nil
 	case ArgRegex:
 		if got.etype != etString {
-			return 0, ErrBadArgumentStr{"string (regex)", string(got.etype)}
+			return 0, ErrBadArgumentStr{"string (regex)", got.etype.String()}
 		}
 		for _, va := range v.validator {
 			if err := va(got); err != nil {
@@ -150,7 +150,7 @@ func (e expr) consumeBasicArg(pos int, exp Arg) (int, error) {
 		*v.val = re
 	case ArgBool:
 		if got.etype != etBool {
-			return 0, ErrBadArgumentStr{"string", string(got.etype)}
+			return 0, ErrBadArgumentStr{"string", got.etype.String()}
 		}
 		*v.val = got.bool
 	case ArgStringsOrInts:
@@ -192,7 +192,7 @@ func (e expr) consumeSeriesArg(pos int, exp Arg, context Context, stable bool, r
 	switch v := exp.(type) {
 	case ArgSeries:
 		if got.etype != etName && got.etype != etFunc {
-			return 0, nil, ErrBadArgumentStr{"func or name", string(got.etype)}
+			return 0, nil, ErrBadArgumentStr{"func or name", got.etype.String()}
 		}
 		fn, reqs, err = newplan(got, context, stable, reqs)
 		if err != nil {
@@ -201,7 +201,7 @@ func (e expr) consumeSeriesArg(pos int, exp Arg, context Context, stable bool, r
 		*v.val = fn
 	case ArgSeriesList:
 		if got.etype != etName && got.etype != etFunc {
-			return 0, nil, ErrBadArgumentStr{"func or name", string(got.etype)}
+			return 0, nil, ErrBadArgumentStr{"func or name", got.etype.String()}
 		}
 		fn, reqs, err = newplan(got, context, stable, reqs)
 		if err != nil {
@@ -210,7 +210,7 @@ func (e expr) consumeSeriesArg(pos int, exp Arg, context Context, stable bool, r
 		*v.val = fn
 	case ArgSeriesLists:
 		if got.etype != etName && got.etype != etFunc {
-			return 0, nil, ErrBadArgumentStr{"func or name", string(got.etype)}
+			return 0, nil, ErrBadArgumentStr{"func or name", got.etype.String()}
 		}
 		fn, reqs, err = newplan(got, context, stable, reqs)
 		if err != nil {


### PR DESCRIPTION
you can't just cast an int to a string.
since we already use Stringer, can just call the method

before:
Error while planning argument bad type. expected string - got

after:
Error while planning argument bad type. expected string - got etBool