### PR TITLE
Initial tag query performance improvements

### DIFF
--- a/idx/memory/stats.go
+++ b/idx/memory/stats.go
@@ -8,11 +8,6 @@ var (
 	// each time this happens, an error is logged with more details.
 	corruptIndex = stats.NewCounter32("recovered_errors.idx.memory.corrupt-index")
 
-	// metric recovered_errors.idx.memory.invalid-id is how many times
-	// an invalid metric id is encountered.
-	// each time this happens, an error is logged with more details.
-	invalidId = stats.NewCounter32("recovered_errors.idx.memory.invalid-id")
-
 	// metric recovered_errors.idx.memory.invalid-tag is how many times
 	// an invalid tag for a metric is encountered.
 	// each time this happens, an error is logged with more details.

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -11,9 +11,9 @@ import (
 	"gopkg.in/raintank/schema.v1"
 )
 
-var ids []idx.MetricID
+var ids []string
 
-func getTestIDs(t *testing.T) []idx.MetricID {
+func getTestIDs(t *testing.T) []string {
 	if len(ids) > 0 {
 		return ids
 	}
@@ -29,11 +29,7 @@ func getTestIDs(t *testing.T) []idx.MetricID {
 		"1.72345678901234567890123456789012",
 	}
 	for _, idStr := range idStrings {
-		id, err := idx.NewMetricIDFromString(idStr)
-		if err != nil {
-			t.Fatalf("Did not expect an error when converting id string to object: %s", idStr)
-		}
-		ids = append(ids, id)
+		ids = append(ids, idStr)
 	}
 
 	return ids
@@ -41,7 +37,7 @@ func getTestIDs(t *testing.T) []idx.MetricID {
 
 func getTestIndex(t *testing.T) (TagIndex, map[string]*idx.Archive) {
 	type testCase struct {
-		id         idx.MetricID
+		id         string
 		lastUpdate int64
 		tags       []string
 	}
@@ -63,7 +59,7 @@ func getTestIndex(t *testing.T) (TagIndex, map[string]*idx.Archive) {
 	byId := make(map[string]*idx.Archive)
 
 	for i, d := range data {
-		idStr := d.id.String()
+		idStr := d.id
 		byId[idStr] = &idx.Archive{}
 		byId[idStr].Name = fmt.Sprintf("metric%d", i)
 		byId[idStr].Tags = d.tags
@@ -393,12 +389,12 @@ func TestGetByTag(t *testing.T) {
 
 	idString := "1.000000000000000000000000000000%02x"
 	mds := make([]schema.MetricData, 20)
-	ids := make([]idx.MetricID, 20)
+	ids := make([]string, 20)
 	for i := range mds {
-		ids[i], _ = idx.NewMetricIDFromString(fmt.Sprintf(idString, i))
+		ids[i] = fmt.Sprintf(idString, i)
 		mds[i].Metric = fmt.Sprintf("metric.%d", i)
 		mds[i].Name = mds[i].Metric
-		mds[i].Id = ids[i].String()
+		mds[i].Id = ids[i]
 		mds[i].OrgId = 1
 		mds[i].Interval = 1
 		mds[i].Time = 12345
@@ -473,9 +469,9 @@ func TestGetByTag(t *testing.T) {
 
 		resPaths := make([]string, 0, len(res))
 		for id := range res {
-			def, ok := ix.defById[id.String()]
+			def, ok := ix.defById[id]
 			if !ok {
-				t.Fatalf("Tag query returned ID that did not exist in DefByID: %s", id.String())
+				t.Fatalf("Tag query returned ID that did not exist in DefByID: %s", id)
 			}
 			resPaths = append(resPaths, def.NameWithTags())
 		}


### PR DESCRIPTION
The basic idea here is that the string representation of an id is already in use by the defById map. During the course of indexing and querying, we are repeatedly doing fmt calls to translate between the two types. I think the original motivation behind using Id over string was to reduce pointer usage for the GC but this results in many allocations during a tag query. Here is my comparison with the existing benchmark (1m benchtime):

Improvements across the board (especially in allocations) except for indexing, which is pretty close.

```
benchmark                                          old ns/op     new ns/op     delta
BenchmarkTagQueryFilterAndIntersect-8              74609352      55922356      -25.05%
BenchmarkTagQueryFilterAndIntersectOnlyRegex-8     146186085     117200507     -19.83%
BenchmarkTagQueryKeysByPrefixSimple-8              3825          3298          -13.78%
BenchmarkTagQueryKeysByPrefixExpressions-8         1082002       793130        -26.70%
BenchmarkIndexing-8                                11962         12970         +8.43%

benchmark                                          old allocs     new allocs     delta
BenchmarkTagQueryFilterAndIntersect-8              403615         3256           -99.19%
BenchmarkTagQueryFilterAndIntersectOnlyRegex-8     1005682        205082         -79.61%
BenchmarkTagQueryKeysByPrefixSimple-8              14             6              -57.14%
BenchmarkTagQueryKeysByPrefixExpressions-8         5389           1065           -80.24%
BenchmarkIndexing-8                                27             26             -3.70%

benchmark                                          old bytes     new bytes     delta
BenchmarkTagQueryFilterAndIntersect-8              9180205       383341        -95.82%
BenchmarkTagQueryFilterAndIntersectOnlyRegex-8     31116455      13526309      -56.53%
BenchmarkTagQueryKeysByPrefixSimple-8              528           352           -33.33%
BenchmarkTagQueryKeysByPrefixExpressions-8         332176        253633        -23.64%
BenchmarkIndexing-8                                2007          1911          -4.78%
```

Once a numeric Id representation is used all over metrictank, these two maps will still use the same key, but it will be even more efficient!