### PR TITLE
set kafka offset to retention - segmentSize

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,3 +7,4 @@ scripts/dev       for MT developers. tools to sync config files and docs
 scripts/push      to push out to packagecloud, docker, etc (used by CI)
 scripts/qa        quality assurance tools (can be called by users or by CI)
 scripts/util      utility scripts, used by other scripts
+scripts/k8s       docker image and needed scripts for running in k8s

--- a/scripts/k8s/Dockerfile
+++ b/scripts/k8s/Dockerfile
@@ -1,4 +1,6 @@
 FROM grafana/metrictank
-RUN apk add --no-cache curl jq ca-certificates
+RUN apk add --no-cache curl jq ca-certificates python py-pip
+RUN pip install kazoo
 COPY entrypoint.sh /entrypoint.sh
+COPY getOffset.py /getOffset.py
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/k8s/entrypoint.sh
+++ b/scripts/k8s/entrypoint.sh
@@ -10,12 +10,12 @@ if ! mkdir -p $MT_PROFTRIGGER_PATH; then
 fi
 
 # set offsets
-if [ x"$MT_KAFKA_MDM_IN_OFFSET" = "xoldest" ]; then
-  MT_KAFKA_MDM_IN_OFFSET=$(/getOffset.py $MT_KAFKA_MDM_IN_TOPICS)
+if [ x"$MT_KAFKA_MDM_IN_OFFSET" = "xauto" ]; then
+  export MT_KAFKA_MDM_IN_OFFSET=$(/getOffset.py $MT_KAFKA_MDM_IN_TOPICS)
 fi
 
-if [ x"$MT_KAFKA_CLUSTER_OFFSET" = "xoldest" ]; then
-  MT_KAFKA_CLUSTER_OFFSET=$(/getOffset.py $MT_KAFKA_CLUSTER_TOPIC)
+if [ x"$MT_KAFKA_CLUSTER_OFFSET" = "xauto" ]; then
+  export MT_KAFKA_CLUSTER_OFFSET=$(/getOffset.py $MT_KAFKA_CLUSTER_TOPIC)
 fi
 
 # set cluster PEERs

--- a/scripts/k8s/entrypoint.sh
+++ b/scripts/k8s/entrypoint.sh
@@ -9,6 +9,15 @@ if ! mkdir -p $MT_PROFTRIGGER_PATH; then
 	exit 1
 fi
 
+# set offsets
+if [ x"$MT_KAFKA_MDM_IN_OFFSET" = "xoldest" ]; then
+  MT_KAFKA_MDM_IN_OFFSET=$(/getOffset.py $MT_KAFKA_MDM_IN_TOPICS)
+fi
+
+if [ x"$MT_KAFKA_CLUSTER_OFFSET" = "xoldest" ]; then
+  MT_KAFKA_CLUSTER_OFFSET=$(/getOffset.py $MT_KAFKA_CLUSTER_TOPIC)
+fi
+
 # set cluster PEERs
 if [ ! -z "$LABEL_SELECTOR" ]; then
 	export MT_CLUSTER_MODE="multi"

--- a/scripts/k8s/getOffset.py
+++ b/scripts/k8s/getOffset.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+from kazoo.client import KazooClient
+import json
+import sys
+import time
+
+
+def default():
+  print "oldest"
+  sys.exit(0)
+
+if len(sys.argv) < 2:
+  print "Usage: %s <topic>" % sys.argv[0]
+  sys.exit(1)
+
+topic = sys.argv[1]
+
+zk = KazooClient(hosts='zookeeper:2181')
+zk.start()
+try:
+  resp = zk.get("/config/topics/%s" % topic)
+except:
+  default()
+finally:
+  zk.stop()
+
+if len(resp) < 1:
+  default()
+
+try:
+  data = json.loads(resp[0])
+except:
+  default()
+
+try:
+  retention=int(data.get('config', {}).get('retention.ms', 0))
+  segmentSize=int(data.get('config', {}).get('segment.ms', 1800000))
+except:
+  default()
+
+if retention == 0:
+  default()
+
+# oldest we can safetly consume from in minutes
+oldest = (retention - segmentSize)/(1000 * 60)
+
+print "%dm" % oldest


### PR DESCRIPTION
If the kafka offset is set to "oldest", query zookeeper for the topic retention
and segment size.  Then set the offset config var to retention - segmentSize.
This ensures that MT doesnt start consuming from the oldest log segment which
could be deleted while MT is still consuming it, which leads to MT having to shutdown and restart


this is a step towards improving backlog replay
relates to https://github.com/raintank/hosted-metrics-api/issues/82
and 
issue #614 