### PR TITLE
Orgid uint

### DIFF
--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -12,7 +12,7 @@ import (
 
 type Context struct {
 	*macaron.Context
-	OrgId int
+	OrgId uint32
 	Body  io.ReadCloser
 }
 
@@ -31,7 +31,7 @@ func OrgMiddleware(multiTenant bool) macaron.Handler {
 	}
 }
 
-func getOrg(req *http.Request, multiTenant bool) (int, error) {
+func getOrg(req *http.Request, multiTenant bool) (uint32, error) {
 	if !multiTenant {
 		return 1, nil
 	}
@@ -40,10 +40,10 @@ func getOrg(req *http.Request, multiTenant bool) (int, error) {
 		return 0, nil
 	}
 	org, err := strconv.Atoi(orgStr)
-	if err != nil {
+	if err != nil || org < 1 {
 		return 0, errors.New("bad org-id")
 	}
-	return org, nil
+	return uint32(org), nil
 }
 
 func RequireOrg() macaron.Handler {

--- a/api/models/ccache.go
+++ b/api/models/ccache.go
@@ -9,7 +9,7 @@ type CCacheDelete struct {
 	Patterns []string `json:"patterns" form:"patterns" `
 	// tag expressions to select series
 	Expr      []string `json:"expr" form:"expr"`
-	OrgId     int      `json:"orgId" form:"orgId" binding:"Required"`
+	OrgId     uint32   `json:"orgId" form:"orgId" binding:"Required"`
 	Propagate bool     `json:"propagate" form:"propagate"`
 }
 

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -26,7 +26,7 @@ type ClusterMembersResp struct {
 }
 
 type IndexList struct {
-	OrgId int `json:"orgId" form:"orgId" binding:"Required"`
+	OrgId uint32 `json:"orgId" form:"orgId" binding:"Required"`
 }
 
 func (i IndexList) Trace(span opentracing.Span) {
@@ -37,7 +37,7 @@ func (i IndexList) TraceDebug(span opentracing.Span) {
 }
 
 type IndexFindByTag struct {
-	OrgId int      `json:"orgId" binding:"Required"`
+	OrgId uint32   `json:"orgId" binding:"Required"`
 	Expr  []string `json:"expressions"`
 	From  int64    `json:"from"`
 }
@@ -52,7 +52,7 @@ func (i IndexFindByTag) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTagDetails struct {
-	OrgId  int    `json:"orgId" binding:"Required"`
+	OrgId  uint32 `json:"orgId" binding:"Required"`
 	Filter string `json:"filter"`
 	Tag    string `json:"tag" binding:"Required"`
 	From   int64  `json:"from"`
@@ -69,7 +69,7 @@ func (i IndexTagDetails) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTags struct {
-	OrgId  int    `json:"orgId" binding:"Required"`
+	OrgId  uint32 `json:"orgId" binding:"Required"`
 	Filter string `json:"filter"`
 	From   int64  `json:"from"`
 }
@@ -84,7 +84,7 @@ func (i IndexTags) TraceDebug(span opentracing.Span) {
 }
 
 type IndexAutoCompleteTags struct {
-	OrgId  int      `json:"orgId" binding:"Required"`
+	OrgId  uint32   `json:"orgId" binding:"Required"`
 	Prefix string   `json:"Prefix"`
 	Expr   []string `json:"expressions"`
 	From   int64    `json:"from"`
@@ -103,7 +103,7 @@ func (i IndexAutoCompleteTags) TraceDebug(span opentracing.Span) {
 }
 
 type IndexAutoCompleteTagValues struct {
-	OrgId  int      `json:"orgId" binding:"Required"`
+	OrgId  uint32   `json:"orgId" binding:"Required"`
 	Tag    string   `json:"tag"`
 	Prefix string   `json:"prefix"`
 	Expr   []string `json:"expressions"`
@@ -124,7 +124,7 @@ func (i IndexAutoCompleteTagValues) TraceDebug(span opentracing.Span) {
 }
 
 type IndexTagDelSeries struct {
-	OrgId int      `json:"orgId" binding:"Required"`
+	OrgId uint32   `json:"orgId" binding:"Required"`
 	Paths []string `json:"path" form:"path"`
 }
 
@@ -142,7 +142,7 @@ type IndexGet struct {
 
 type IndexFind struct {
 	Patterns []string `json:"patterns" form:"patterns" binding:"Required"`
-	OrgId    int      `json:"orgId" form:"orgId" binding:"Required"`
+	OrgId    uint32   `json:"orgId" form:"orgId" binding:"Required"`
 	From     int64    `json:"from" form:"from"`
 }
 
@@ -177,7 +177,7 @@ func (g GetData) TraceDebug(span opentracing.Span) {
 
 type IndexDelete struct {
 	Query string `json:"query" form:"query" binding:"Required"`
-	OrgId int    `json:"orgId" form:"orgId" binding:"Required"`
+	OrgId uint32 `json:"orgId" form:"orgId" binding:"Required"`
 }
 
 func (i IndexDelete) Trace(span opentracing.Span) {

--- a/api/prometheus_querier.go
+++ b/api/prometheus_querier.go
@@ -21,7 +21,7 @@ import (
 func (s *Server) Querier(ctx context.Context, min, max int64) (storage.Querier, error) {
 	from := uint32(min / 1000)
 	to := uint32(max / 1000)
-	return NewQuerier(ctx, s, from, to, ctx.Value(orgID("org-id")).(int), false), nil
+	return NewQuerier(ctx, s, from, to, ctx.Value(orgID("org-id")).(uint32), false), nil
 }
 
 // querier implements Prometheus' Querier interface
@@ -29,12 +29,12 @@ type querier struct {
 	*Server
 	from         uint32
 	to           uint32
-	OrgID        int
+	OrgID        uint32
 	metadataOnly bool
 	ctx          context.Context
 }
 
-func NewQuerier(ctx context.Context, s *Server, from, to uint32, orgId int, metadataOnly bool) storage.Querier {
+func NewQuerier(ctx context.Context, s *Server, from, to uint32, orgId uint32, metadataOnly bool) storage.Querier {
 	return &querier{
 		s,
 		from,

--- a/cmd/mt-index-migrate/main.go
+++ b/cmd/mt-index-migrate/main.go
@@ -156,7 +156,7 @@ func getDefs(session *gocql.Session, defsChan chan *schema.MetricDefinition) {
 		}
 		mdef := schema.MetricDefinition{
 			Id:         mkey,
-			OrgId:      orgId,
+			OrgId:      uint32(orgId),
 			Partition:  partition,
 			Name:       name,
 			Interval:   interval,

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -399,10 +399,13 @@ func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, cutoff u
 			log.Error(3, "cassandra-idx: load() could not parse ID %q: %s -> skipping", id, err)
 			continue
 		}
+		if orgId < 0 {
+			orgId = int(idx.OrgIdPublic)
+		}
 
 		mdef := &schema.MetricDefinition{
 			Id:         mkey,
-			OrgId:      orgId,
+			OrgId:      uint32(orgId),
 			Partition:  partition,
 			Name:       name,
 			Interval:   interval,
@@ -487,7 +490,7 @@ func (c *CasIdx) processWriteQueue() {
 	c.wg.Done()
 }
 
-func (c *CasIdx) Delete(orgId int, pattern string) ([]idx.Archive, error) {
+func (c *CasIdx) Delete(orgId uint32, pattern string) ([]idx.Archive, error) {
 	pre := time.Now()
 	defs, err := c.MemoryIdx.Delete(orgId, pattern)
 	if err != nil {

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -104,14 +104,14 @@ func getRandomString(n int, alphabets ...byte) string {
 	return string(bytes)
 }
 
-func getMetricData(orgId, depth, count, interval int, prefix string) []*schema.MetricData {
+func getMetricData(orgId uint32, depth, count, interval int, prefix string) []*schema.MetricData {
 	data := make([]*schema.MetricData, count)
 	series := getSeriesNames(depth, count, prefix)
 	for i, s := range series {
 
 		data[i] = &schema.MetricData{
 			Name:     s,
-			OrgId:    orgId,
+			OrgId:    int(orgId),
 			Interval: interval,
 		}
 		data[i].SetId()
@@ -131,7 +131,7 @@ func TestGetAddKey(t *testing.T) {
 	org2Series := getMetricData(2, 2, 5, 10, "metric.org2")
 
 	for _, series := range [][]*schema.MetricData{publicSeries, org1Series, org2Series} {
-		orgId := series[0].OrgId
+		orgId := uint32(series[0].OrgId)
 		Convey(fmt.Sprintf("When indexing metrics for orgId %d", orgId), t, func() {
 			for _, s := range series {
 				mkey, err := schema.MKeyFromString(s.Id)

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -9,7 +9,7 @@ import (
 	schema "gopkg.in/raintank/schema.v1"
 )
 
-var OrgIdPublic = 0
+var OrgIdPublic = uint32(0)
 
 var (
 	BothBranchAndLeaf = errors.New("node can't be both branch and leaf")
@@ -69,23 +69,23 @@ type MetricIndex interface {
 	Get(key schema.MKey) (Archive, bool)
 
 	// GetPath returns the archives under the given path.
-	GetPath(orgId int, path string) []Archive
+	GetPath(orgId uint32, path string) []Archive
 
 	// Delete deletes items from the index
 	// If the pattern matches a branch node, then
 	// all leaf nodes on that branch are deleted. So if the pattern is
 	// "*", all items in the index are deleted.
 	// It returns a copy of all of the Archives deleted.
-	Delete(orgId int, pattern string) ([]Archive, error)
+	Delete(orgId uint32, pattern string) ([]Archive, error)
 
 	// Find searches the index for matching nodes.
 	// * orgId describes the org to search in (public data in orgIdPublic is automatically included)
 	// * pattern is handled like graphite does. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
 	// * from is a unix timestamp. series not updated since then are excluded.
-	Find(orgId int, pattern string, from int64) ([]Node, error)
+	Find(orgId uint32, pattern string, from int64) ([]Node, error)
 
 	// List returns all Archives for the passed OrgId and the public orgId
-	List(orgId int) []Archive
+	List(orgId uint32) []Archive
 
 	// Prune deletes all metrics that haven't been seen since the given timestamp.
 	// It returns all Archives deleted and any error encountered.
@@ -99,24 +99,24 @@ type MetricIndex interface {
 	// where the LastUpdate time is >= from will be returned as results.
 	// The returned results are not deduplicated and in certain cases it is possible
 	// that duplicate entries will be returned.
-	FindByTag(orgId int, expressions []string, from int64) ([]Node, error)
+	FindByTag(orgId uint32, expressions []string, from int64) ([]Node, error)
 
 	// Tags returns a list of all tag keys associated with the metrics of a given
 	// organization. The return values are filtered by the regex in the second parameter.
 	// If the third parameter is >0 then only metrics will be accounted of which the
 	// LastUpdate time is >= the given value.
-	Tags(orgId int, filter string, from int64) ([]string, error)
+	Tags(orgId uint32, filter string, from int64) ([]string, error)
 
 	// FindTags generates a list of possible tags that could complete a
 	// given prefix. It also accepts additional tag conditions to further narrow
 	// down the result set in the format of graphite's tag queries
-	FindTags(orgId int, prefix string, expressions []string, from int64, limit uint) ([]string, error)
+	FindTags(orgId uint32, prefix string, expressions []string, from int64, limit uint) ([]string, error)
 
 	// FindTagValues generates a list of possible values that could
 	// complete a given value prefix. It requires a tag to be specified and only values
 	// of the given tag will be returned. It also accepts additional conditions to
 	// further narrow down the result set in the format of graphite's tag queries
-	FindTagValues(orgId int, tag string, prefix string, expressions []string, from int64, limit uint) ([]string, error)
+	FindTagValues(orgId uint32, tag string, prefix string, expressions []string, from int64, limit uint) ([]string, error)
 
 	// TagDetails returns a list of all values associated with a given tag key in the
 	// given org. The occurrences of each value is counted and the count is referred to by
@@ -125,9 +125,9 @@ type MetricIndex interface {
 	// the values before accounting for them.
 	// If the fourth parameter is > 0 then only those metrics of which the LastUpdate
 	// time is >= the from timestamp will be included.
-	TagDetails(orgId int, key string, filter string, from int64) (map[string]uint64, error)
+	TagDetails(orgId uint32, key string, filter string, from int64) (map[string]uint64, error)
 
 	// DeleteTagged deletes the specified series from the tag index and also the
 	// DefById index.
-	DeleteTagged(orgId int, paths []string) ([]Archive, error)
+	DeleteTagged(orgId uint32, paths []string) ([]Archive, error)
 }

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -686,7 +686,7 @@ func BenchmarkTagsWithoutFromNorFilter(b *testing.B) {
 	}
 }
 
-func ixFind(b *testing.B, org, q int) {
+func ixFind(b *testing.B, org uint32, q int) {
 	b.Helper()
 	nodes, err := ix.Find(org, queries[q].Pattern, 0)
 	if err != nil {
@@ -707,14 +707,14 @@ func BenchmarkFind(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		q := n % queryCount
-		org := (n % 2) + 1
+		org := uint32((n % 2) + 1)
 		ixFind(b, org, q)
 	}
 }
 
 type testQ struct {
 	q   int
-	org int
+	org uint32
 }
 
 func BenchmarkConcurrent4Find(b *testing.B) {
@@ -733,7 +733,7 @@ func BenchmarkConcurrent4Find(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		q := n % queryCount
-		org := (n % 2) + 1
+		org := uint32((n % 2) + 1)
 		ch <- testQ{q: q, org: org}
 	}
 	close(ch)
@@ -755,13 +755,13 @@ func BenchmarkConcurrent8Find(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		q := n % queryCount
-		org := (n % 2) + 1
+		org := uint32((n % 2) + 1)
 		ch <- testQ{q: q, org: org}
 	}
 	close(ch)
 }
 
-func ixFindByTag(b *testing.B, org, q int) {
+func ixFindByTag(b *testing.B, org uint32, q int) {
 	series, err := ix.FindByTag(org, tagQueries[q].Expressions, 0)
 	if err != nil {
 		panic(err)
@@ -781,7 +781,7 @@ func BenchmarkTagFindSimpleIntersect(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		q := n % 2
-		org := (n % 2) + 1
+		org := uint32((n % 2) + 1)
 		ixFindByTag(b, org, q)
 	}
 }
@@ -792,7 +792,7 @@ func BenchmarkTagFindRegexIntersect(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		q := (n % 2) + 2
-		org := (n % 2) + 1
+		org := uint32((n % 2) + 1)
 		ixFindByTag(b, org, q)
 	}
 }
@@ -803,7 +803,7 @@ func BenchmarkTagFindMatchingAndFiltering(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		q := (n % 2) + 4
-		org := (n % 2) + 1
+		org := uint32((n % 2) + 1)
 		ixFindByTag(b, org, q)
 	}
 }
@@ -814,7 +814,7 @@ func BenchmarkTagFindMatchingAndFilteringWithRegex(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		q := (n % 2) + 6
-		org := (n % 2) + 1
+		org := uint32((n % 2) + 1)
 		ixFindByTag(b, org, q)
 	}
 }

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -46,14 +46,14 @@ func getRandomString(n int, alphabets ...byte) string {
 }
 
 // getMetricData returns a count-length slice of MetricData's with random Name and the given org id
-func getMetricData(orgId, depth, count, interval int, prefix string, tagged bool) []*schema.MetricData {
+func getMetricData(orgId uint32, depth, count, interval int, prefix string, tagged bool) []*schema.MetricData {
 	data := make([]*schema.MetricData, count)
 	series := getSeriesNames(depth, count, prefix)
 
 	for i, s := range series {
 		data[i] = &schema.MetricData{
 			Name:     s,
-			OrgId:    orgId,
+			OrgId:    int(orgId),
 			Interval: interval,
 		}
 		if tagged {
@@ -96,7 +96,7 @@ func testGetAddKey(t *testing.T) {
 	org2Series := getMetricData(2, 2, 5, 10, "metric.org2", false)
 
 	for _, series := range [][]*schema.MetricData{publicSeries, org1Series, org2Series} {
-		orgId := series[0].OrgId
+		orgId := uint32(series[0].OrgId)
 		Convey(fmt.Sprintf("When indexing metrics for orgId %d", orgId), t, func() {
 			for _, s := range series {
 				mkey, _ := schema.MKeyFromString(s.Id)

--- a/metrictank.go
+++ b/metrictank.go
@@ -329,7 +329,7 @@ func main() {
 		log.Fatal(4, "public-org cannot be <0")
 	}
 
-	idx.OrgIdPublic = *publicOrg
+	idx.OrgIdPublic = uint32(*publicOrg)
 
 	if memory.Enabled {
 		if metricIndex != nil {

--- a/vendor/gopkg.in/raintank/schema.v1/metric.go
+++ b/vendor/gopkg.in/raintank/schema.v1/metric.go
@@ -107,7 +107,7 @@ type MetricDataArray []*MetricData
 
 type MetricDefinition struct {
 	Id       MKey   `json:"mkey"`
-	OrgId    int    `json:"org_id"`
+	OrgId    uint32 `json:"org_id"`
 	Name     string `json:"name"`
 	Interval int    `json:"interval"`
 	Unit     string `json:"unit"`
@@ -235,7 +235,7 @@ func MetricDefinitionFromMetricData(d *MetricData) *MetricDefinition {
 	md := &MetricDefinition{
 		Id:         mkey,
 		Name:       d.Name,
-		OrgId:      d.OrgId,
+		OrgId:      uint32(d.OrgId),
 		Mtype:      d.Mtype,
 		Interval:   d.Interval,
 		LastUpdate: d.Time,

--- a/vendor/gopkg.in/raintank/schema.v1/metric_gen.go
+++ b/vendor/gopkg.in/raintank/schema.v1/metric_gen.go
@@ -453,7 +453,7 @@ func (z *MetricDefinition) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "OrgId":
-			z.OrgId, err = dc.ReadInt()
+			z.OrgId, err = dc.ReadUint32()
 			if err != nil {
 				return
 			}
@@ -531,7 +531,7 @@ func (z *MetricDefinition) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteInt(z.OrgId)
+	err = en.WriteUint32(z.OrgId)
 	if err != nil {
 		return
 	}
@@ -619,7 +619,7 @@ func (z *MetricDefinition) MarshalMsg(b []byte) (o []byte, err error) {
 	}
 	// string "OrgId"
 	o = append(o, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
-	o = msgp.AppendInt(o, z.OrgId)
+	o = msgp.AppendUint32(o, z.OrgId)
 	// string "Name"
 	o = append(o, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	o = msgp.AppendString(o, z.Name)
@@ -669,7 +669,7 @@ func (z *MetricDefinition) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "OrgId":
-			z.OrgId, bts, err = msgp.ReadIntBytes(bts)
+			z.OrgId, bts, err = msgp.ReadUint32Bytes(bts)
 			if err != nil {
 				return
 			}
@@ -733,7 +733,7 @@ func (z *MetricDefinition) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *MetricDefinition) Msgsize() (s int) {
-	s = 1 + 3 + z.Id.Msgsize() + 6 + msgp.IntSize + 5 + msgp.StringPrefixSize + len(z.Name) + 9 + msgp.IntSize + 5 + msgp.StringPrefixSize + len(z.Unit) + 6 + msgp.StringPrefixSize + len(z.Mtype) + 5 + msgp.ArrayHeaderSize
+	s = 1 + 3 + z.Id.Msgsize() + 6 + msgp.Uint32Size + 5 + msgp.StringPrefixSize + len(z.Name) + 9 + msgp.IntSize + 5 + msgp.StringPrefixSize + len(z.Unit) + 6 + msgp.StringPrefixSize + len(z.Mtype) + 5 + msgp.ArrayHeaderSize
 	for za0001 := range z.Tags {
 		s += msgp.StringPrefixSize + len(z.Tags[za0001])
 	}


### PR DESCRIPTION
this helps us save some memory.
math.MaxUint32 == 4294967295

I don't anticipate we will ever have more orgs than that.

when loading from cassandra, if <0 -> assign OrgIdPublic
