### PR TITLE
reduce default kafka-mdm channel-buffer-size

### DIFF
--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -192,7 +192,7 @@ offset-commit-interval = 5s
 # it will be created (incl parent dirs) if not existing.
 data-dir = /var/lib/metrictank
 # The number of metrics to buffer in internal and external channels
-channel-buffer-size = 1000000
+channel-buffer-size = 1000
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -192,7 +192,7 @@ offset-commit-interval = 5s
 # it will be created (incl parent dirs) if not existing.
 data-dir = /var/lib/metrictank
 # The number of metrics to buffer in internal and external channels
-channel-buffer-size = 1000000
+channel-buffer-size = 1000
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -192,7 +192,7 @@ offset-commit-interval = 5s
 # it will be created (incl parent dirs) if not existing.
 data-dir = /var/lib/metrictank
 # The number of metrics to buffer in internal and external channels
-channel-buffer-size = 1000000
+channel-buffer-size = 1000
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request

--- a/docs/config.md
+++ b/docs/config.md
@@ -240,7 +240,7 @@ offset-commit-interval = 5s
 # it will be created (incl parent dirs) if not existing.
 data-dir =
 # The number of metrics to buffer in internal and external channels
-channel-buffer-size = 1000000
+channel-buffer-size = 1000
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -79,7 +79,7 @@ func ConfigSetup() {
 	inKafkaMdm.StringVar(&partitionStr, "partitions", "*", "kafka partitions to consume. use '*' or a comma separated list of id's")
 	inKafkaMdm.DurationVar(&offsetCommitInterval, "offset-commit-interval", time.Second*5, "Interval at which offsets should be saved.")
 	inKafkaMdm.StringVar(&DataDir, "data-dir", "", "Directory to store partition offsets index")
-	inKafkaMdm.IntVar(&channelBufferSize, "channel-buffer-size", 1000000, "The number of metrics to buffer in internal and external channels")
+	inKafkaMdm.IntVar(&channelBufferSize, "channel-buffer-size", 1000, "The number of metrics to buffer in internal and external channels")
 	inKafkaMdm.IntVar(&consumerFetchMin, "consumer-fetch-min", 1, "The minimum number of message bytes to fetch in a request")
 	inKafkaMdm.IntVar(&consumerFetchDefault, "consumer-fetch-default", 32768, "The default number of message bytes to fetch in a request")
 	inKafkaMdm.DurationVar(&consumerMaxWaitTime, "consumer-max-wait-time", time.Second, "The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it returns fewer than that anyway")

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -195,7 +195,7 @@ offset-commit-interval = 5s
 # it will be created (incl parent dirs) if not existing.
 data-dir =
 # The number of metrics to buffer in internal and external channels
-channel-buffer-size = 1000000
+channel-buffer-size = 1000
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -192,7 +192,7 @@ offset-commit-interval = 5s
 # it will be created (incl parent dirs) if not existing.
 data-dir = /var/lib/metrictank
 # The number of metrics to buffer in internal and external channels
-channel-buffer-size = 1000000
+channel-buffer-size = 1000
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -192,7 +192,7 @@ offset-commit-interval = 5s
 # it will be created (incl parent dirs) if not existing.
 data-dir = /var/lib/metrictank
 # The number of metrics to buffer in internal and external channels
-channel-buffer-size = 1000000
+channel-buffer-size = 1000
 # The minimum number of message bytes to fetch in a request
 consumer-fetch-min = 1
 # The default number of message bytes to fetch in a request


### PR DESCRIPTION
in prod we use 1000.
using too high values will cause the sarama library to consume too much
memory when backfilling, which is not reclaimed, leaving a permament
increased memory usage footprint.
see
https://snapshot.raintank.io/dashboard/snapshot/lu1Aw1kPcbx4fk8qdtgZPQ61yyeTwbBk?orgId=2

Even though we plan to switch to the confluent kafka library imminently
(https://github.com/grafana/metrictank/pull/879)
it's worthwhile to set this straight, for the record.

cc @shanson7 