### PR TITLE
Version was invalid for dpkg based packages used tag-commitssincetag

### DIFF
--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -12,7 +12,7 @@ sudo apt-get install rpm # to be able to make rpms
 
 ARCH="$(uname -m)"
 VERSION=$(git describe --long --abbrev=7)
-
+DEBIAN_VERSION=$(git describe --tags  | cut -d '-' -f 1-2)
 
 ## debian wheezy ##
 
@@ -27,9 +27,9 @@ cp ${BASE}/config/storage-schemas.conf ${BUILD}/etc/metrictank/
 cp ${BASE}/config/storage-aggregation.conf ${BUILD}/etc/metrictank/
 cp ${BUILD_ROOT}/{metrictank,mt-*} ${BUILD}/usr/bin/
 
-PACKAGE_NAME="${PKG}/metrictank-${VERSION}_${ARCH}.deb"
+PACKAGE_NAME="${PKG}/metrictank-${DEBIAN_VERSION}_${ARCH}.deb"
 fpm -s dir -t deb \
-  -v ${VERSION} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \
+  -v ${DEBIAN_VERSION} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \
   --deb-init ${BASE}/config/sysvinit/init.d/metrictank \
   --deb-default ${BASE}/config/sysvinit/default/metrictank \
   --replaces metric-tank --provides metric-tank \
@@ -52,9 +52,9 @@ cp ${BASE}/config/storage-schemas.conf ${BUILD}/etc/metrictank/
 cp ${BASE}/config/storage-aggregation.conf ${BUILD}/etc/metrictank/
 cp ${BUILD_ROOT}/{metrictank,mt-*} ${BUILD}/usr/bin/
 
-PACKAGE_NAME="${PKG}/metrictank-${VERSION}_${ARCH}.deb"
+PACKAGE_NAME="${PKG}/metrictank-${DEBIAN_VERSION}_${ARCH}.deb"
 fpm -s dir -t deb \
-  -v ${VERSION} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \
+  -v ${DEBIAN_VERSION} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \
   --deb-upstart ${BASE}/config/upstart/metrictank \
   --replaces metric-tank --provides metric-tank \
   --conflicts metric-tank \
@@ -78,9 +78,9 @@ cp ${BASE}/config/storage-aggregation.conf ${BUILD}/etc/metrictank/
 cp ${BASE}/config/systemd/metrictank.service $BUILD/lib/systemd/system/
 cp ${BUILD_ROOT}/{metrictank,mt-*} ${BUILD}/usr/bin/
 
-PACKAGE_NAME="${PKG}/metrictank-${VERSION}_${ARCH}.deb"
+PACKAGE_NAME="${PKG}/metrictank-${DEBIAN_VERSION}_${ARCH}.deb"
 fpm -s dir -t deb \
-  -v ${VERSION} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \
+  -v ${DEBIAN_VERSION} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \
   --config-files /etc/metrictank/ \
   -m "Raintank Inc. <hello@grafana.com>" --vendor "grafana.com" \
   --license "Apache2.0" -C ${BUILD} -p ${PACKAGE_NAME} .


### PR DESCRIPTION
This should fix issue #887 

the generated string for version was : 0.8.3-113-gef6c1192

According to debian documentation 

_The version number format is: [epoch:]upstream_version[-debian_revision]_

which would give here 0.8.3-113
