### PR TITLE
Fix multi-interval series issue

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -170,7 +170,7 @@ func (s *Server) getTargets(ctx context.Context, reqs []models.Req) ([]models.Se
 	if len(remoteReqs) > 0 {
 		wg.Add(1)
 		go func() {
-			// all errors returned returned are *response.Error.
+			// all errors returned are *response.Error.
 			series, err := s.getTargetsRemote(getCtx, remoteReqs)
 			if err != nil {
 				cancel()

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -126,6 +126,19 @@ func testGetAddKey(t *testing.T) {
 			So(defs, ShouldHaveLength, 15)
 		})
 	})
+
+	if TagSupport {
+		Convey("When adding metricDefs with the same series name as existing metricDefs (tagged)", t, func() {
+			Convey("then findByTag", func() {
+				nodes, _ := ix.FindByTag(1, []string{"name!="}, 0)
+				defs := make([]idx.Archive, 0, len(nodes))
+				for i := range nodes {
+					defs = append(defs, nodes[i].Defs...)
+				}
+				So(defs, ShouldHaveLength, 10)
+			})
+		})
+	}
 }
 
 func TestFind(t *testing.T) {
@@ -673,7 +686,12 @@ func TestPruneTaggedSeriesWithCollidingTagSets(t *testing.T) {
 	Convey("After purge", t, func() {
 		nodes, err := ix.FindByTag(1, findExpressions, 0)
 		So(err, ShouldBeNil)
-		So(nodes, ShouldHaveLength, 2)
+		So(nodes, ShouldHaveLength, 1)
+		defs := make([]idx.Archive, 0, len(nodes))
+		for i := range nodes {
+			defs = append(defs, nodes[i].Defs...)
+		}
+		So(defs, ShouldHaveLength, 2)
 	})
 
 	Convey("When purging newer series", t, func() {

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -130,12 +130,13 @@ func testGetAddKey(t *testing.T) {
 	if TagSupport {
 		Convey("When adding metricDefs with the same series name as existing metricDefs (tagged)", t, func() {
 			Convey("then findByTag", func() {
-				nodes, _ := ix.FindByTag(1, []string{"name!="}, 0)
+				nodes, err := ix.FindByTag(1, []string{"name!="}, 0)
+				So(err, ShouldBeNil)
 				defs := make([]idx.Archive, 0, len(nodes))
 				for i := range nodes {
 					defs = append(defs, nodes[i].Defs...)
 				}
-				So(defs, ShouldHaveLength, 10)
+				So(defs, ShouldHaveLength, 2*len(org1Series))
 			})
 		})
 	}


### PR DESCRIPTION
Because we were not combining multiple intervals for the same series into a single idx.Node we were hitting issues with the code deduping the series on the remote end. This change should fix both cases:

multiple defs on a single node should be collapsed into a single idx.Node element
multiple defs across nodes should not overwrite one another and should be merged later (by mergeSeries)

The symptom was data sort of "flashing" on refresh, switching between the old and new intervals data (since only one was winning).