### PR TITLE
Fix panic and convey assertion

### DIFF
--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -530,8 +530,8 @@ func testMixedBranchLeafDelete(t *testing.T) {
 		for i, d := range defs {
 			deletedIds[i] = d.Id
 		}
-		So(test.MustMKeyFromString(series[0].Id), ShouldBeIn, deletedIds)
-		So(test.MustMKeyFromString(series[1].Id), ShouldBeIn, deletedIds)
+		So(test.MustMKeyFromString(series[0].Id), test.ShouldContainMKey, deletedIds)
+		So(test.MustMKeyFromString(series[1].Id), test.ShouldContainMKey, deletedIds)
 		Convey("series should not be present in the metricDef index", func() {
 			_, ok := ix.Get(mkeys[0])
 			So(ok, ShouldEqual, false)

--- a/test/key.go
+++ b/test/key.go
@@ -1,6 +1,11 @@
 package test
 
-import schema "gopkg.in/raintank/schema.v1"
+import (
+	"fmt"
+	"reflect"
+
+	schema "gopkg.in/raintank/schema.v1"
+)
 
 func GetAMKey(suffix int) schema.AMKey {
 	return schema.AMKey{
@@ -20,6 +25,23 @@ func MustMKeyFromString(id string) schema.MKey {
 	if err != nil {
 		panic(err)
 	}
-	panic(err)
 	return mkey
+}
+
+func ContainsMKey(list []schema.MKey, subject schema.MKey) bool {
+	for _, v := range list {
+		if reflect.DeepEqual(v, subject) {
+			return true
+		}
+	}
+	return false
+}
+
+func ShouldContainMKey(actual interface{}, expected ...interface{}) string {
+	list := expected[0].([]schema.MKey)
+	subject := actual.(schema.MKey)
+	if !ContainsMKey(list, subject) {
+		return fmt.Sprintf("slice of MKey's did not contain %v", subject)
+	}
+	return ""
 }


### PR DESCRIPTION
1) remove panic that shouldn't be there (no idea why the test was previously passing, that code was being called)
2) once the panic removed it became clear ShouldBeIn doesn't support structs. when comparing structs we need to use ShouldResemble instead of ShouldEqual.   Structs are only "equal" when they are the same data (ie use the same memory), but there's no ShouldBeIn alternative using ShouldResemble, so i manually made one