### PR TITLE
set deadline before stats write/read

### DIFF
--- a/stats/config/init.go
+++ b/stats/config/init.go
@@ -3,6 +3,7 @@ package config
 import (
 	"flag"
 	"strings"
+	"time"
 
 	"github.com/grafana/metrictank/stats"
 	"github.com/raintank/worldping-api/pkg/log"
@@ -14,6 +15,7 @@ var prefix string
 var addr string
 var interval int
 var bufferSize int
+var timeout time.Duration
 
 func ConfigSetup() {
 	inStats := flag.NewFlagSet("stats", flag.ExitOnError)
@@ -21,6 +23,7 @@ func ConfigSetup() {
 	inStats.StringVar(&prefix, "prefix", "metrictank.stats.default.$instance", "stats prefix (will add trailing dot automatically if needed)")
 	inStats.StringVar(&addr, "addr", "localhost:2003", "graphite address")
 	inStats.IntVar(&interval, "interval", 1, "interval at which to send statistics")
+	inStats.DurationVar(&timeout, "timeout", time.Second*10, "timeout after which a read/write is considered not successful")
 	inStats.IntVar(&bufferSize, "buffer-size", 20000, "how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable. With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed")
 	globalconf.Register("stats", inStats)
 }
@@ -36,7 +39,7 @@ func ConfigProcess(instance string) {
 func Start() {
 	if enabled {
 		stats.NewMemoryReporter()
-		stats.NewGraphite(prefix, addr, interval, bufferSize)
+		stats.NewGraphite(prefix, addr, interval, bufferSize, timeout)
 	} else {
 		stats.NewDevnull()
 		log.Warn("running metrictank without instrumentation.")

--- a/stats/config/init.go
+++ b/stats/config/init.go
@@ -23,7 +23,7 @@ func ConfigSetup() {
 	inStats.StringVar(&prefix, "prefix", "metrictank.stats.default.$instance", "stats prefix (will add trailing dot automatically if needed)")
 	inStats.StringVar(&addr, "addr", "localhost:2003", "graphite address")
 	inStats.IntVar(&interval, "interval", 1, "interval at which to send statistics")
-	inStats.DurationVar(&timeout, "timeout", time.Second*10, "timeout after which a read/write is considered not successful")
+	inStats.DurationVar(&timeout, "timeout", time.Second*10, "timeout after which a write is considered not successful")
 	inStats.IntVar(&bufferSize, "buffer-size", 20000, "how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable. With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed")
 	globalconf.Register("stats", inStats)
 }

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -144,7 +144,7 @@ func (g *Graphite) checkEOF(conn net.Conn) {
 		}
 
 		if err != io.EOF {
-			log.Warn("Graphite.checkEOF: closing conn: %s\n", err)
+			log.Warn("Graphite.checkEOF: %s. closing conn\n", err)
 			conn.Close()
 			return
 		}

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -137,7 +137,7 @@ func (g *Graphite) checkEOF(conn net.Conn) {
 			return
 		}
 
-		// just in case i misunderstand something or the remote behaves badly
+		// in case the remote behaves badly (out of spec for carbon protocol)
 		if num != 0 {
 			log.Warn("Graphite.checkEOF: read unexpected data from peer: %s\n", b[:num])
 			continue

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -132,19 +132,19 @@ func (g *Graphite) checkEOF(conn net.Conn) {
 	for {
 		num, err := conn.Read(b)
 		if err == io.EOF {
-			log.Info("checkEOF conn.Read returned EOF -> conn is closed. closing conn explicitly")
+			log.Info("Graphite.checkEOF: remote closed conn. closing conn")
 			conn.Close()
 			return
 		}
 
 		// just in case i misunderstand something or the remote behaves badly
 		if num != 0 {
-			log.Info("checkEOF conn.Read data? did not expect that.  data: %s\n", b[:num])
+			log.Warn("Graphite.checkEOF: read unexpected data from peer: %s\n", b[:num])
 			continue
 		}
 
 		if err != io.EOF {
-			log.Warn("checkEOF conn.Read returned err != EOF, which is unexpected.  closing conn. error: %s\n", err)
+			log.Warn("Graphite.checkEOF: %s\n", err)
 			conn.Close()
 			return
 		}

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -144,7 +144,7 @@ func (g *Graphite) checkEOF(conn net.Conn) {
 		}
 
 		if err != io.EOF {
-			log.Warn("Graphite.checkEOF: %s\n", err)
+			log.Warn("Graphite.checkEOF: closing conn: %s\n", err)
 			conn.Close()
 			return
 		}

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -108,7 +108,7 @@ func (g *Graphite) writer() {
 		var ok bool
 		for !ok {
 			conn = assureConn()
-			conn.SetDeadline(time.Now().Add(g.timeout))
+			conn.SetWriteDeadline(time.Now().Add(g.timeout))
 			pre := time.Now()
 			_, err = conn.Write(buf)
 			if err == nil {


### PR DESCRIPTION
I created this patch, but so far i was not able to reproduce the problem in my test env that this is supposed to fix. I think the reason why reproducing it is hard is because when i run a service like f.e. `nc -l -p 2003` and make MT connect to that, at the moment when i kill the service a `FIN` gets sent to the client, which notifies the client of the connection closing and MT immediately starts trying to reconnect. In prod this might be different when a carbon-relay-ng pod gets killed, which lets MT wait for a response. 