### PR TITLE
Cassandra config

### DIFF
--- a/cmd/mt-split-metrics-by-ttl/main.go
+++ b/cmd/mt-split-metrics-by-ttl/main.go
@@ -14,25 +14,25 @@ import (
 
 func main() {
 	storeConfig := cassandra.NewStoreConfig()
-	// we dont need to allocate resources for reads as this tool does not read from the Store
+	// we don't need to allocate resources for reads as this tool does not read from the Store
 	storeConfig.ReadConcurrency = 1
 	storeConfig.ReadQueueSize = 0
 
 	// flags from cassandra/config.go
-	flag.StringVar(&storeConfig.Addrs, "cassandra-addrs", "localhost", "cassandra host (may be given multiple times as comma-separated list)")
-	flag.StringVar(&storeConfig.Keyspace, "cassandra-keyspace", "metrictank", "cassandra keyspace to use for storing the metric data table")
-	flag.StringVar(&storeConfig.Consistency, "cassandra-consistency", "one", "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
-	flag.StringVar(&storeConfig.HostSelectionPolicy, "cassandra-host-selection-policy", "tokenaware,hostpool-epsilon-greedy", "")
-	flag.IntVar(&storeConfig.Timeout, "cassandra-timeout", 1000, "cassandra timeout in milliseconds")
-	flag.IntVar(&storeConfig.Retries, "cassandra-retries", 0, "how many times to retry a query before failing it")
-	flag.IntVar(&storeConfig.CqlProtocolVersion, "cql-protocol-version", 4, "cql protocol version to use")
-	flag.BoolVar(&storeConfig.DisableInitialHostLookup, "cassandra-disable-initial-host-lookup", false, "instruct the driver to not attempt to get host info from the system.peers table")
-	flag.BoolVar(&storeConfig.SSL, "cassandra-ssl", false, "enable SSL connection to cassandra")
-	flag.StringVar(&storeConfig.CaPath, "cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")
-	flag.BoolVar(&storeConfig.HostVerification, "cassandra-host-verification", true, "host (hostname and server cert) verification when using SSL")
-	flag.BoolVar(&storeConfig.Auth, "cassandra-auth", false, "enable cassandra authentication")
-	flag.StringVar(&storeConfig.Username, "cassandra-username", "cassandra", "username for authentication")
-	flag.StringVar(&storeConfig.Password, "cassandra-password", "cassandra", "password for authentication")
+	flag.StringVar(&storeConfig.Addrs, "cassandra-addrs", storeConfig.Addrs, "cassandra host (may be given multiple times as comma-separated list)")
+	flag.StringVar(&storeConfig.Keyspace, "cassandra-keyspace", storeConfig.Keyspace, "cassandra keyspace to use for storing the metric data table")
+	flag.StringVar(&storeConfig.Consistency, "cassandra-consistency", storeConfig.Consistency, "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
+	flag.StringVar(&storeConfig.HostSelectionPolicy, "cassandra-host-selection-policy", storeConfig.HostSelectionPolicy, "")
+	flag.IntVar(&storeConfig.Timeout, "cassandra-timeout", storeConfig.Timeout, "cassandra timeout in milliseconds")
+	flag.IntVar(&storeConfig.Retries, "cassandra-retries", storeConfig.Retries, "how many times to retry a query before failing it")
+	flag.IntVar(&storeConfig.CqlProtocolVersion, "cql-protocol-version", storeConfig.CqlProtocolVersion, "cql protocol version to use")
+	flag.BoolVar(&storeConfig.DisableInitialHostLookup, "cassandra-disable-initial-host-lookup", storeConfig.DisableInitialHostLookup, "instruct the driver to not attempt to get host info from the system.peers table")
+	flag.BoolVar(&storeConfig.SSL, "cassandra-ssl", storeConfig.SSL, "enable SSL connection to cassandra")
+	flag.StringVar(&storeConfig.CaPath, "cassandra-ca-path", storeConfig.CaPath, "cassandra CA certificate path when using SSL")
+	flag.BoolVar(&storeConfig.HostVerification, "cassandra-host-verification", storeConfig.HostVerification, "host (hostname and server cert) verification when using SSL")
+	flag.BoolVar(&storeConfig.Auth, "cassandra-auth", storeConfig.Auth, "enable cassandra authentication")
+	flag.StringVar(&storeConfig.Username, "cassandra-username", storeConfig.Username, "username for authentication")
+	flag.StringVar(&storeConfig.Password, "cassandra-password", storeConfig.Password, "password for authentication")
 
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "mt-split-metrics-by-ttl [flags] ttl [ttl...]")

--- a/cmd/mt-split-metrics-by-ttl/main.go
+++ b/cmd/mt-split-metrics-by-ttl/main.go
@@ -12,36 +12,30 @@ import (
 	"github.com/raintank/dur"
 )
 
-var (
-	// flags from metrictank.go, Cassandra
-	cassandraAddrs               = flag.String("cassandra-addrs", "localhost", "cassandra host (may be given multiple times as comma-separated list)")
-	cassandraKeyspace            = flag.String("cassandra-keyspace", "metrictank", "cassandra keyspace to use for storing the metric data table")
-	cassandraConsistency         = flag.String("cassandra-consistency", "one", "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
-	cassandraHostSelectionPolicy = flag.String("cassandra-host-selection-policy", "tokenaware,hostpool-epsilon-greedy", "")
-	cassandraTimeout             = flag.Int("cassandra-timeout", 1000, "cassandra timeout in milliseconds")
-	cassandraRetries             = flag.Int("cassandra-retries", 0, "how many times to retry a query before failing it")
-	cqlProtocolVersion           = flag.Int("cql-protocol-version", 4, "cql protocol version to use")
-	cassandraCreateKeyspace      = flag.Bool("cassandra-create-keyspace", true, "enable the creation of the metrictank keyspace")
-	cassandraSchemaFile          = flag.String("cassandra-schema-file", "/etc/metrictank/schema-store-cassandra.toml", "File containing the needed schemas in case database needs initializing")
-
-	cassandraSSL              = flag.Bool("cassandra-ssl", false, "enable SSL connection to cassandra")
-	cassandraCaPath           = flag.String("cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")
-	cassandraHostVerification = flag.Bool("cassandra-host-verification", true, "host (hostname and server cert) verification when using SSL")
-
-	cassandraAuth     = flag.Bool("cassandra-auth", false, "enable cassandra authentication")
-	cassandraUsername = flag.String("cassandra-username", "cassandra", "username for authentication")
-	cassandraPassword = flag.String("cassandra-password", "cassandra", "password for authentication")
-
-	cassandraDisableInitialHostLookup = flag.Bool("cassandra-disable-initial-host-lookup", false, "instruct the driver to not attempt to get host info from the system.peers table")
-
-	// hard coded to default because those have no effect in the case of this tool anyway
-	windowFactor             = 20
-	cassandraOmitReadTimeout = 60
-	cassandraReadConcurrency = 20
-	cassandraReadQueueSize   = 100
-)
-
 func main() {
+	storeConfig := cassandra.NewStoreConfig()
+	// hard coded to default because those have no effect in the case of this tool anyway
+	storeConfig.WindowFactor = 20
+	storeConfig.OmitReadTimeout = 60
+	storeConfig.ReadConcurrency = 20
+	storeConfig.ReadQueueSize = 100
+
+	// flags from cassandra/config.go
+	flag.StringVar(&storeConfig.Addrs, "cassandra-addrs", "localhost", "cassandra host (may be given multiple times as comma-separated list)")
+	flag.StringVar(&storeConfig.Keyspace, "cassandra-keyspace", "metrictank", "cassandra keyspace to use for storing the metric data table")
+	flag.StringVar(&storeConfig.Consistency, "cassandra-consistency", "one", "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
+	flag.StringVar(&storeConfig.HostSelectionPolicy, "cassandra-host-selection-policy", "tokenaware,hostpool-epsilon-greedy", "")
+	flag.IntVar(&storeConfig.Timeout, "cassandra-timeout", 1000, "cassandra timeout in milliseconds")
+	flag.IntVar(&storeConfig.Retries, "cassandra-retries", 0, "how many times to retry a query before failing it")
+
+	flag.BoolVar(&storeConfig.DisableInitialHostLookup, "cassandra-disable-initial-host-lookup", false, "instruct the driver to not attempt to get host info from the system.peers table")
+	flag.BoolVar(&storeConfig.SSL, "cassandra-ssl", false, "enable SSL connection to cassandra")
+	flag.StringVar(&storeConfig.CaPath, "cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")
+	flag.BoolVar(&storeConfig.HostVerification, "cassandra-host-verification", true, "host (hostname and server cert) verification when using SSL")
+	flag.BoolVar(&storeConfig.Auth, "cassandra-auth", false, "enable cassandra authentication")
+	flag.StringVar(&storeConfig.Username, "cassandra-username", "cassandra", "username for authentication")
+	flag.StringVar(&storeConfig.Password, "cassandra-password", "cassandra", "password for authentication")
+
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "mt-split-metrics-by-ttl [flags] ttl [ttl...]")
 		fmt.Fprintln(os.Stderr)
@@ -62,7 +56,7 @@ func main() {
 		ttls = append(ttls, uint32(dur.MustParseNDuration("ttl", flag.Arg(i))))
 	}
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), *cassandraKeyspace)
+	tmpDir, err := ioutil.TempDir(os.TempDir(), storeConfig.Keyspace)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to get temp dir: %s", tmpDir))
 	}
@@ -72,20 +66,20 @@ func main() {
 		panic(fmt.Sprintf("Error creating directory: %s", err))
 	}
 
-	store, err := cassandra.NewCassandraStore(*cassandraAddrs, *cassandraKeyspace, *cassandraConsistency, *cassandraCaPath, *cassandraUsername, *cassandraPassword, *cassandraHostSelectionPolicy, *cassandraTimeout, cassandraReadConcurrency, cassandraReadConcurrency, cassandraReadQueueSize, 0, *cassandraRetries, *cqlProtocolVersion, windowFactor, cassandraOmitReadTimeout, *cassandraSSL, *cassandraAuth, *cassandraHostVerification, *cassandraCreateKeyspace, *cassandraSchemaFile, ttls, *cassandraDisableInitialHostLookup)
+	store, err := cassandra.NewCassandraStore(storeConfig, ttls)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to instantiate cassandra: %s", err))
 	}
 	tables := store.GetTableNames()
 
 	// create directory/link structure that we need to define the future table names
-	err = os.Mkdir(path.Join(tmpDir, *cassandraKeyspace), 0700)
+	err = os.Mkdir(path.Join(tmpDir, storeConfig.Keyspace), 0700)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create directory: %s", err))
 	}
 	namedTableLinks := make([]string, len(tables))
 	for i, table := range tables {
-		namedTableLinks[i] = path.Join(tmpDir, *cassandraKeyspace, table)
+		namedTableLinks[i] = path.Join(tmpDir, storeConfig.Keyspace, table)
 		err := os.Symlink(snapshotDir, namedTableLinks[i])
 		if err != nil {
 			panic(fmt.Sprintf("Error when creating symlink: %s", err))
@@ -97,12 +91,12 @@ func main() {
 	fmt.Println("- Recreate (or copy) this directory structure on each cassandra node:")
 	fmt.Printf("  %s\n", tmpDir)
 	fmt.Println("- Stop writes by stopping the metrictanks or set their cluster status to secondary")
-	fmt.Printf("- Use `nodetool snapshot --table metric %s` on all cluster nodes to create\n", *cassandraKeyspace)
+	fmt.Printf("- Use `nodetool snapshot --table metric %s` on all cluster nodes to create\n", storeConfig.Keyspace)
 	fmt.Println("  a snapshot of the metric table")
 	fmt.Println("  https://docs.datastax.com/en/cassandra/3.0/cassandra/tools/toolsSnapShot.html")
 	fmt.Println(fmt.Sprintf("- Move snapshot files to directory %s", snapshotDir))
 	fmt.Println("- Load the data by executing:")
 	for _, dir := range namedTableLinks {
-		fmt.Println(fmt.Sprintf("  sstableloader -d %s %s", *cassandraAddrs, dir))
+		fmt.Println(fmt.Sprintf("  sstableloader -d %s %s", storeConfig.Addrs, dir))
 	}
 }

--- a/cmd/mt-split-metrics-by-ttl/main.go
+++ b/cmd/mt-split-metrics-by-ttl/main.go
@@ -14,11 +14,9 @@ import (
 
 func main() {
 	storeConfig := cassandra.NewStoreConfig()
-	// hard coded to default because those have no effect in the case of this tool anyway
-	storeConfig.WindowFactor = 20
-	storeConfig.OmitReadTimeout = 60
-	storeConfig.ReadConcurrency = 20
-	storeConfig.ReadQueueSize = 100
+	// we dont need to allocate resources for reads as this tool does not read from the Store
+	storeConfig.ReadConcurrency = 1
+	storeConfig.ReadQueueSize = 0
 
 	// flags from cassandra/config.go
 	flag.StringVar(&storeConfig.Addrs, "cassandra-addrs", "localhost", "cassandra host (may be given multiple times as comma-separated list)")
@@ -27,7 +25,7 @@ func main() {
 	flag.StringVar(&storeConfig.HostSelectionPolicy, "cassandra-host-selection-policy", "tokenaware,hostpool-epsilon-greedy", "")
 	flag.IntVar(&storeConfig.Timeout, "cassandra-timeout", 1000, "cassandra timeout in milliseconds")
 	flag.IntVar(&storeConfig.Retries, "cassandra-retries", 0, "how many times to retry a query before failing it")
-
+	flag.IntVar(&storeConfig.CqlProtocolVersion, "cql-protocol-version", 4, "cql protocol version to use")
 	flag.BoolVar(&storeConfig.DisableInitialHostLookup, "cassandra-disable-initial-host-lookup", false, "instruct the driver to not attempt to get host info from the system.peers table")
 	flag.BoolVar(&storeConfig.SSL, "cassandra-ssl", false, "enable SSL connection to cassandra")
 	flag.StringVar(&storeConfig.CaPath, "cassandra-ca-path", "/etc/metrictank/ca.pem", "cassandra CA certificate path when using SSL")

--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -81,7 +81,7 @@ type Server struct {
 
 func main() {
 	storeConfig := cassandraStore.NewStoreConfig()
-	// we dont use the cassandraStore's writeQueue, so we hard code this to 0.
+	// we don't use the cassandraStore's writeQueue, so we hard code this to 0.
 	storeConfig.WriteQueueSize = 0
 
 	// flags from cassandra/config.go, Cassandra
@@ -125,7 +125,7 @@ func main() {
 		cassFlags.PrintDefaults()
 		fmt.Println()
 		fmt.Println("EXAMPLES:")
-		fmt.Println("mt-whisper-importer-writer -cassandra-addrs=192.168.0.1 -cassandra-keyspace=mydata -exit-on-error=true -fake-avg-aggregates=true -http-endpoint=0.0.0.0:8080 -num-partitions=8 -partition-scheme=bySeries -ttls=8d,2y -uri-path=/chunks -verbose=true -window-factor=20 cass -hosts=192.168.0.1:9042 -keyspace=mydata")
+		fmt.Println("mt-whisper-importer-writer -cassandra-addrs=192.168.0.1 -cassandra-keyspace=mydata -exit-on-error=true -fake-avg-aggregates=true -http-endpoint=0.0.0.0:8080 -num-partitions=8 -partition-scheme=bySeries -ttls=8d,2y -uri-path=/chunks -verbose=true -cassandra-window-factor=20 cass -hosts=192.168.0.1:9042 -keyspace=mydata")
 	}
 
 	if len(os.Args) == 2 && (os.Args[1] == "-h" || os.Args[1] == "--help") {

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -25,56 +25,6 @@ warm-up-period = 1s
 # leave at 0 to disable.
 public-org = 0
 
-## metric data storage in cassandra ##
-
-# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# comma-separated list of hostnames to connect to
-cassandra-addrs = cassandra:9042
-# keyspace to use for storing the metric data table
-cassandra-keyspace = metrictank
-# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
-cassandra-consistency = one
-# how to select which hosts to query
-# roundrobin                : iterate all hosts, spreading queries evenly.
-# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
-# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
-# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
-# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
-# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
-cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
-# cassandra timeout in milliseconds
-cassandra-timeout = 4000
-# max number of concurrent reads to cassandra
-cassandra-read-concurrency = 500
-# max number of concurrent writes to cassandra
-cassandra-write-concurrency = 10
-# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
-cassandra-read-queue-size = 200000
-# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
-cassandra-write-queue-size = 100000
-# how many times to retry a query before failing it
-cassandra-retries = 0
-# CQL protocol version. cassandra 3.x needs v3 or 4.
-cql-protocol-version = 4
-# enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = false
-# File containing the needed schemas in case database needs initializing
-cassandra-schema-file = /etc/metrictank/schema-store-cassandra.toml
-# enable SSL connection to cassandra
-cassandra-ssl = false
-# cassandra CA certficate path when using SSL
-cassandra-ca-path = /etc/metrictank/ca.pem
-# host (hostname and server cert) verification when using SSL
-cassandra-host-verification = true
-# enable cassandra user authentication
-cassandra-auth = false
-# username for authentication
-cassandra-username = cassandra
-# password for authentication
-cassandra-password = cassandra
-# instruct the driver to not attempt to get host info from the system.peers table
-cassandra-disable-initial-host-lookup = false
-
 ## Profiling and logging ##
 
 # see https://golang.org/pkg/runtime/#SetBlockProfileRate
@@ -101,6 +51,57 @@ tracing-enabled = true
 tracing-addr = jaeger:6831
 # tracer/process-level tags to include, specified as comma-separated key:value pairs
 tracing-add-tags =
+
+## metric data storage in cassandra ##
+[cassandra]
+
+# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
+# comma-separated list of hostnames to connect to
+addrs = cassandra:9042
+# keyspace to use for storing the metric data table
+keyspace = metrictank
+# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
+consistency = one
+# how to select which hosts to query
+# roundrobin                : iterate all hosts, spreading queries evenly.
+# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
+# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
+# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
+# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
+# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
+host-selection-policy = tokenaware,hostpool-epsilon-greedy
+# cassandra timeout in milliseconds
+timeout = 4000
+# max number of concurrent reads to cassandra
+read-concurrency = 500
+# max number of concurrent writes to cassandra
+write-concurrency = 10
+# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
+read-queue-size = 200000
+# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
+write-queue-size = 100000
+# how many times to retry a query before failing it
+retries = 0
+# CQL protocol version. cassandra 3.x needs v3 or 4.
+cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+create-keyspace = true
+# File containing the needed schemas in case database needs initializing
+schema-file = /etc/metrictank/schema-store-cassandra.toml
+# enable SSL connection to cassandra
+ssl = false
+# cassandra CA certficate path when using SSL
+ca-path = /etc/metrictank/ca.pem
+# host (hostname and server cert) verification when using SSL
+host-verification = true
+# enable cassandra user authentication
+auth = false
+# username for authentication
+username = cassandra
+# password for authentication
+password = cassandra
+# instruct the driver to not attempt to get host info from the system.peers table
+disable-initial-host-lookup = false
 
 ## Retention settings ##
 [retention]

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -85,7 +85,7 @@ retries = 0
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this
-create-keyspace = true
+create-keyspace = false
 # File containing the needed schemas in case database needs initializing
 schema-file = /etc/metrictank/schema-store-cassandra.toml
 # enable SSL connection to cassandra

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -82,6 +82,10 @@ read-queue-size = 200000
 write-queue-size = 100000
 # how many times to retry a query before failing it
 retries = 0
+# size of compaction window relative to TTL
+window-factor = 20
+# if a read is older than this (in seconds), it will be omitted,  not executed
+omit-read-timeout = 60
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -25,56 +25,6 @@ warm-up-period = 1s
 # leave at 0 to disable.
 public-org = 0
 
-## metric data storage in cassandra ##
-
-# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# comma-separated list of hostnames to connect to
-cassandra-addrs = cassandra:9042
-# keyspace to use for storing the metric data table
-cassandra-keyspace = metrictank
-# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
-cassandra-consistency = one
-# how to select which hosts to query
-# roundrobin                : iterate all hosts, spreading queries evenly.
-# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
-# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
-# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
-# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
-# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
-cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
-# cassandra timeout in milliseconds
-cassandra-timeout = 4000
-# max number of concurrent reads to cassandra
-cassandra-read-concurrency = 500
-# max number of concurrent writes to cassandra
-cassandra-write-concurrency = 10
-# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
-cassandra-read-queue-size = 200000
-# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
-cassandra-write-queue-size = 100000
-# how many times to retry a query before failing it
-cassandra-retries = 0
-# CQL protocol version. cassandra 3.x needs v3 or 4.
-cql-protocol-version = 4
-# enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = false
-# File containing the needed schemas in case database needs initializing
-cassandra-schema-file = /etc/metrictank/schema-store-cassandra.toml
-# enable SSL connection to cassandra
-cassandra-ssl = false
-# cassandra CA certficate path when using SSL
-cassandra-ca-path = /etc/metrictank/ca.pem
-# host (hostname and server cert) verification when using SSL
-cassandra-host-verification = true
-# enable cassandra user authentication
-cassandra-auth = false
-# username for authentication
-cassandra-username = cassandra
-# password for authentication
-cassandra-password = cassandra
-# instruct the driver to not attempt to get host info from the system.peers table
-cassandra-disable-initial-host-lookup = false
-
 ## Profiling and logging ##
 
 # see https://golang.org/pkg/runtime/#SetBlockProfileRate
@@ -101,6 +51,61 @@ tracing-enabled = true
 tracing-addr = jaeger:6831
 # tracer/process-level tags to include, specified as comma-separated key:value pairs
 tracing-add-tags =
+
+## metric data storage in cassandra ##
+[cassandra]
+
+# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
+# comma-separated list of hostnames to connect to
+addrs = cassandra
+# keyspace to use for storing the metric data table
+keyspace = metrictank
+# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
+consistency = one
+# how to select which hosts to query
+# roundrobin                : iterate all hosts, spreading queries evenly.
+# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
+# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
+# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
+# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
+# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
+host-selection-policy = tokenaware,hostpool-epsilon-greedy
+# cassandra timeout in milliseconds
+timeout = 4000
+# max number of concurrent reads to cassandra
+read-concurrency = 500
+# max number of concurrent writes to cassandra
+write-concurrency = 10
+# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
+read-queue-size = 200000
+# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
+write-queue-size = 100000
+# how many times to retry a query before failing it
+retries = 0
+# size of compaction window relative to TTL
+window-factor = 20
+# if a read is older than this (in seconds), it will be omitted,  not executed
+omit-read-timeout = 60
+# CQL protocol version. cassandra 3.x needs v3 or 4.
+cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+create-keyspace = false
+# File containing the needed schemas in case database needs initializing
+schema-file = /etc/metrictank/schema-store-cassandra.toml
+# enable SSL connection to cassandra
+ssl = false
+# cassandra CA certficate path when using SSL
+ca-path = /etc/metrictank/ca.pem
+# host (hostname and server cert) verification when using SSL
+host-verification = true
+# enable cassandra user authentication
+auth = false
+# username for authentication
+username = cassandra
+# password for authentication
+password = cassandra
+# instruct the driver to not attempt to get host info from the system.peers table
+disable-initial-host-lookup = false
 
 ## Retention settings ##
 [retention]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -25,56 +25,6 @@ warm-up-period = 1h
 # leave at 0 to disable.
 public-org = 0
 
-## metric data storage in cassandra ##
-
-# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# comma-separated list of hostnames to connect to
-cassandra-addrs = cassandra:9042
-# keyspace to use for storing the metric data table
-cassandra-keyspace = metrictank
-# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
-cassandra-consistency = one
-# how to select which hosts to query
-# roundrobin                : iterate all hosts, spreading queries evenly.
-# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
-# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
-# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
-# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
-# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
-cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
-# cassandra timeout in milliseconds
-cassandra-timeout = 1000
-# max number of concurrent reads to cassandra
-cassandra-read-concurrency = 20
-# max number of concurrent writes to cassandra
-cassandra-write-concurrency = 10
-# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
-cassandra-read-queue-size = 200000
-# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
-cassandra-write-queue-size = 100000
-# how many times to retry a query before failing it
-cassandra-retries = 0
-# CQL protocol version. cassandra 3.x needs v3 or 4.
-cql-protocol-version = 4
-# enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = true
-# File containing the needed schemas in case database needs initializing
-cassandra-schema-file = /etc/metrictank/schema-store-cassandra.toml
-# enable SSL connection to cassandra
-cassandra-ssl = false
-# cassandra CA certficate path when using SSL
-cassandra-ca-path = /etc/metrictank/ca.pem
-# host (hostname and server cert) verification when using SSL
-cassandra-host-verification = true
-# enable cassandra user authentication
-cassandra-auth = false
-# username for authentication
-cassandra-username = cassandra
-# password for authentication
-cassandra-password = cassandra
-# instruct the driver to not attempt to get host info from the system.peers table
-cassandra-disable-initial-host-lookup = false
-
 ## Profiling and logging ##
 
 # see https://golang.org/pkg/runtime/#SetBlockProfileRate
@@ -101,6 +51,57 @@ tracing-enabled = false
 tracing-addr = localhost:6831
 # tracer/process-level tags to include, specified as comma-separated key:value pairs
 tracing-add-tags =
+
+## metric data storage in cassandra ##
+[cassandra]
+
+# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
+# comma-separated list of hostnames to connect to
+addrs = cassandra:9042
+# keyspace to use for storing the metric data table
+keyspace = metrictank
+# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
+consistency = one
+# how to select which hosts to query
+# roundrobin                : iterate all hosts, spreading queries evenly.
+# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
+# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
+# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
+# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
+# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
+host-selection-policy = tokenaware,hostpool-epsilon-greedy
+# cassandra timeout in milliseconds
+timeout = 1000
+# max number of concurrent reads to cassandra
+read-concurrency = 20
+# max number of concurrent writes to cassandra
+write-concurrency = 10
+# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
+read-queue-size = 200000
+# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
+write-queue-size = 100000
+# how many times to retry a query before failing it
+retries = 0
+# CQL protocol version. cassandra 3.x needs v3 or 4.
+cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+create-keyspace = true
+# File containing the needed schemas in case database needs initializing
+schema-file = /etc/metrictank/schema-store-cassandra.toml
+# enable SSL connection to cassandra
+ssl = false
+# cassandra CA certficate path when using SSL
+ca-path = /etc/metrictank/ca.pem
+# host (hostname and server cert) verification when using SSL
+host-verification = true
+# enable cassandra user authentication
+auth = false
+# username for authentication
+username = cassandra
+# password for authentication
+password = cassandra
+# instruct the driver to not attempt to get host info from the system.peers table
+disable-initial-host-lookup = false
 
 ## Retention settings ##
 [retention]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -82,6 +82,10 @@ read-queue-size = 200000
 write-queue-size = 100000
 # how many times to retry a query before failing it
 retries = 0
+# size of compaction window relative to TTL
+window-factor = 20
+# if a read is older than this (in seconds), it will be omitted,  not executed
+omit-read-timeout = 60
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,7 +86,7 @@ tracing-add-tags =
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 # comma-separated list of hostnames to connect to
-addrs =
+addrs = localhost
 # keyspace to use for storing the metric data table
 keyspace = metrictank
 # desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
@@ -111,6 +111,10 @@ read-queue-size = 200000
 write-queue-size = 100000
 # how many times to retry a query before failing it
 retries = 0
+# size of compaction window relative to TTL
+window-factor = 20
+# if a read is older than this (in seconds), it will be omitted,  not executed
+omit-read-timeout = 60
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,58 +54,6 @@ warm-up-period = 1h
 public-org = 0
 ```
 
-## metric data storage in cassandra ##
-
-```
-# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# comma-separated list of hostnames to connect to
-cassandra-addrs =
-# keyspace to use for storing the metric data table
-cassandra-keyspace = metrictank
-# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
-cassandra-consistency = one
-# how to select which hosts to query
-# roundrobin                : iterate all hosts, spreading queries evenly.
-# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
-# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
-# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
-# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
-# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
-cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
-# cassandra timeout in milliseconds
-cassandra-timeout = 1000
-# max number of concurrent reads to cassandra
-cassandra-read-concurrency = 20
-# max number of concurrent writes to cassandra
-cassandra-write-concurrency = 10
-# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
-cassandra-read-queue-size = 200000
-# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
-cassandra-write-queue-size = 100000
-# how many times to retry a query before failing it
-cassandra-retries = 0
-# CQL protocol version. cassandra 3.x needs v3 or 4.
-cql-protocol-version = 4
-# enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = true
-# File containing the needed schemas in case database needs initializing
-cassandra-schema-file = /etc/metrictank/schema-store-cassandra.toml
-# enable SSL connection to cassandra
-cassandra-ssl = false
-# cassandra CA certficate path when using SSL
-cassandra-ca-path = /etc/metrictank/ca.pem
-# host (hostname and server cert) verification when using SSL
-cassandra-host-verification = true
-# enable cassandra user authentication
-cassandra-auth = false
-# username for authentication
-cassandra-username = cassandra
-# password for authentication
-cassandra-password = cassandra
-# instruct the driver to not attempt to get host info from the system.peers table
-cassandra-disable-initial-host-lookup = false
-```
-
 ## Profiling and logging ##
 
 ```
@@ -130,6 +78,59 @@ tracing-enabled = false
 tracing-addr = localhost:6831
 # tracer/process-level tags to include, specified as comma-separated key:value pairs
 tracing-add-tags =
+```
+
+## metric data storage in cassandra ##
+
+```
+[cassandra]
+# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
+# comma-separated list of hostnames to connect to
+addrs =
+# keyspace to use for storing the metric data table
+keyspace = metrictank
+# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
+consistency = one
+# how to select which hosts to query
+# roundrobin                : iterate all hosts, spreading queries evenly.
+# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
+# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
+# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
+# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
+# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
+host-selection-policy = tokenaware,hostpool-epsilon-greedy
+# cassandra timeout in milliseconds
+timeout = 1000
+# max number of concurrent reads to cassandra
+read-concurrency = 20
+# max number of concurrent writes to cassandra
+write-concurrency = 10
+# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
+read-queue-size = 200000
+# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
+write-queue-size = 100000
+# how many times to retry a query before failing it
+retries = 0
+# CQL protocol version. cassandra 3.x needs v3 or 4.
+cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+create-keyspace = true
+# File containing the needed schemas in case database needs initializing
+schema-file = /etc/metrictank/schema-store-cassandra.toml
+# enable SSL connection to cassandra
+ssl = false
+# cassandra CA certficate path when using SSL
+ca-path = /etc/metrictank/ca.pem
+# host (hostname and server cert) verification when using SSL
+host-verification = true
+# enable cassandra user authentication
+auth = false
+# username for authentication
+username = cassandra
+# password for authentication
+password = cassandra
+# instruct the driver to not attempt to get host info from the system.peers table
+disable-initial-host-lookup = false
 ```
 
 ## Retention settings ##

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -277,8 +277,6 @@ Flags:
     	cassandra CA certificate path when using SSL (default "/etc/metrictank/ca.pem")
   -cassandra-consistency string
     	write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one (default "one")
-  -cassandra-create-keyspace
-    	enable the creation of the metrictank keyspace (default true)
   -cassandra-disable-initial-host-lookup
     	instruct the driver to not attempt to get host info from the system.peers table
   -cassandra-host-selection-policy string
@@ -291,16 +289,12 @@ Flags:
     	password for authentication (default "cassandra")
   -cassandra-retries int
     	how many times to retry a query before failing it
-  -cassandra-schema-file string
-    	File containing the needed schemas in case database needs initializing (default "/etc/metrictank/schema-store-cassandra.toml")
   -cassandra-ssl
     	enable SSL connection to cassandra
   -cassandra-timeout int
     	cassandra timeout in milliseconds (default 1000)
   -cassandra-username string
     	username for authentication (default "cassandra")
-  -cql-protocol-version int
-    	cql protocol version to use (default 4)
 ```
 
 
@@ -338,7 +332,7 @@ Flags:
   -cassandra-consistency string
     	write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one (default "one")
   -cassandra-create-keyspace
-    	enable the creation of the metrictank keyspace (default true)
+    	enable the creation of the mdata keyspace and tables, only one node needs this (default true)
   -cassandra-disable-initial-host-lookup
     	instruct the driver to not attempt to get host info from the system.peers table
   -cassandra-host-selection-policy string
@@ -346,7 +340,7 @@ Flags:
   -cassandra-host-verification
     	host (hostname and server cert) verification when using SSL (default true)
   -cassandra-keyspace string
-    	cassandra keyspace to use for storing the metric data table (default "raintank")
+    	cassandra keyspace to use for storing the metric data table (default "metrictank")
   -cassandra-omit-read-timeout int
     	if a read is older than this, it will directly be omitted without executing (default 60)
   -cassandra-password string
@@ -430,7 +424,7 @@ Flags:
   -version
     	print version string
   -window-factor int
-    	the window factor be used when creating the metric table schema (default 20)
+    	size of compaction window relative to TTL (default 20)
 Notes:
  * Using `*` as metric-selector may bring down your cassandra. Especially chunk-summary ignores from/to and queries all data.
    With great power comes great responsibility
@@ -564,27 +558,37 @@ global config flags:
   -cassandra-consistency string
     	write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one (default "one")
   -cassandra-create-keyspace
-    	enable the creation of the metrictank keyspace (default true)
+    	enable the creation of the mdata keyspace and tables, only one node needs this (default true)
+  -cassandra-disable-initial-host-lookup
+    	instruct the driver to not attempt to get host info from the system.peers table
   -cassandra-host-selection-policy string
     	 (default "tokenaware,hostpool-epsilon-greedy")
   -cassandra-host-verification
     	host (hostname and server cert) verification when using SSL (default true)
   -cassandra-keyspace string
-    	cassandra keyspace to use for storing the metric data table (default "raintank")
+    	cassandra keyspace to use for storing the metric data table (default "metrictank")
+  -cassandra-omit-read-timeout int
+    	if a read is older than this, it will directly be omitted without executing (default 60)
   -cassandra-password string
     	password for authentication (default "cassandra")
   -cassandra-read-concurrency int
     	max number of concurrent reads to cassandra. (default 20)
   -cassandra-read-queue-size int
-    	max number of outstanding reads before blocking. value doesn't matter much (default 100)
+    	max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel. (default 200000)
   -cassandra-retries int
     	how many times to retry a query before failing it
+  -cassandra-schema-file string
+    	File containing the needed schemas in case database needs initializing (default "/etc/metrictank/schema-store-cassandra.toml")
   -cassandra-ssl
     	enable SSL connection to cassandra
   -cassandra-timeout int
     	cassandra timeout in milliseconds (default 1000)
   -cassandra-username string
     	username for authentication (default "cassandra")
+  -cassandra-window-factor int
+    	size of compaction window relative to TTL (default 20)
+  -cassandra-write-concurrency int
+    	max number of concurrent writes to cassandra. (default 10)
   -cql-protocol-version int
     	cql protocol version to use (default 4)
   -exit-on-error
@@ -603,8 +607,6 @@ global config flags:
     	the URI on which we expect chunks to get posted (default "/chunks")
   -verbose
     	More detailed logging
-  -window-factor int
-    	the window factor be used when creating the metric table schema (default 20)
 
 idxtype: only 'cass' supported for now
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -295,6 +295,8 @@ Flags:
     	cassandra timeout in milliseconds (default 1000)
   -cassandra-username string
     	username for authentication (default "cassandra")
+  -cql-protocol-version int
+    	cql protocol version to use (default 4)
 ```
 
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -658,6 +658,6 @@ cass config flags:
     	Max number of metricDefs allowed to be unwritten to cassandra (default 100000)
 
 EXAMPLES:
-mt-whisper-importer-writer -cassandra-addrs=192.168.0.1 -cassandra-keyspace=mydata -exit-on-error=true -fake-avg-aggregates=true -http-endpoint=0.0.0.0:8080 -num-partitions=8 -partition-scheme=bySeries -ttls=8d,2y -uri-path=/chunks -verbose=true -window-factor=20 cass -hosts=192.168.0.1:9042 -keyspace=mydata
+mt-whisper-importer-writer -cassandra-addrs=192.168.0.1 -cassandra-keyspace=mydata -exit-on-error=true -fake-avg-aggregates=true -http-endpoint=0.0.0.0:8080 -num-partitions=8 -partition-scheme=bySeries -ttls=8d,2y -uri-path=/chunks -verbose=true -cassandra-window-factor=20 cass -hosts=192.168.0.1:9042 -keyspace=mydata
 ```
 

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -60,7 +60,7 @@ tracing-add-tags =
 
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 # comma-separated list of hostnames to connect to
-addrs =
+addrs = localhost
 # keyspace to use for storing the metric data table
 keyspace = metrictank
 # desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
@@ -85,6 +85,10 @@ read-queue-size = 200000
 write-queue-size = 100000
 # how many times to retry a query before failing it
 retries = 0
+# size of compaction window relative to TTL
+window-factor = 20
+# if a read is older than this (in seconds), it will be omitted,  not executed
+omit-read-timeout = 60
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -28,56 +28,6 @@ warm-up-period = 1h
 # leave at 0 to disable.
 public-org = 0
 
-## metric data storage in cassandra ##
-
-# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# comma-separated list of hostnames to connect to
-cassandra-addrs =
-# keyspace to use for storing the metric data table
-cassandra-keyspace = metrictank
-# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
-cassandra-consistency = one
-# how to select which hosts to query
-# roundrobin                : iterate all hosts, spreading queries evenly.
-# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
-# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
-# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
-# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
-# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
-cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
-# cassandra timeout in milliseconds
-cassandra-timeout = 1000
-# max number of concurrent reads to cassandra
-cassandra-read-concurrency = 20
-# max number of concurrent writes to cassandra
-cassandra-write-concurrency = 10
-# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
-cassandra-read-queue-size = 200000
-# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
-cassandra-write-queue-size = 100000
-# how many times to retry a query before failing it
-cassandra-retries = 0
-# CQL protocol version. cassandra 3.x needs v3 or 4.
-cql-protocol-version = 4
-# enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = true
-# File containing the needed schemas in case database needs initializing
-cassandra-schema-file = /etc/metrictank/schema-store-cassandra.toml
-# enable SSL connection to cassandra
-cassandra-ssl = false
-# cassandra CA certficate path when using SSL
-cassandra-ca-path = /etc/metrictank/ca.pem
-# host (hostname and server cert) verification when using SSL
-cassandra-host-verification = true
-# enable cassandra user authentication
-cassandra-auth = false
-# username for authentication
-cassandra-username = cassandra
-# password for authentication
-cassandra-password = cassandra
-# instruct the driver to not attempt to get host info from the system.peers table
-cassandra-disable-initial-host-lookup = false
-
 ## Profiling and logging ##
 
 # see https://golang.org/pkg/runtime/#SetBlockProfileRate
@@ -104,6 +54,57 @@ tracing-enabled = false
 tracing-addr = localhost:6831
 # tracer/process-level tags to include, specified as comma-separated key:value pairs
 tracing-add-tags =
+
+## metric data storage in cassandra ##
+[cassandra]
+
+# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
+# comma-separated list of hostnames to connect to
+addrs =
+# keyspace to use for storing the metric data table
+keyspace = metrictank
+# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
+consistency = one
+# how to select which hosts to query
+# roundrobin                : iterate all hosts, spreading queries evenly.
+# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
+# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
+# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
+# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
+# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
+host-selection-policy = tokenaware,hostpool-epsilon-greedy
+# cassandra timeout in milliseconds
+timeout = 1000
+# max number of concurrent reads to cassandra
+read-concurrency = 20
+# max number of concurrent writes to cassandra
+write-concurrency = 10
+# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
+read-queue-size = 200000
+# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
+write-queue-size = 100000
+# how many times to retry a query before failing it
+retries = 0
+# CQL protocol version. cassandra 3.x needs v3 or 4.
+cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+create-keyspace = true
+# File containing the needed schemas in case database needs initializing
+schema-file = /etc/metrictank/schema-store-cassandra.toml
+# enable SSL connection to cassandra
+ssl = false
+# cassandra CA certficate path when using SSL
+ca-path = /etc/metrictank/ca.pem
+# host (hostname and server cert) verification when using SSL
+host-verification = true
+# enable cassandra user authentication
+auth = false
+# username for authentication
+username = cassandra
+# password for authentication
+password = cassandra
+# instruct the driver to not attempt to get host info from the system.peers table
+disable-initial-host-lookup = false
 
 ## Retention settings ##
 [retention]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -25,56 +25,6 @@ warm-up-period = 1h
 # leave at 0 to disable.
 public-org = 0
 
-## metric data storage in cassandra ##
-
-# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# comma-separated list of hostnames to connect to
-cassandra-addrs = cassandra:9042
-# keyspace to use for storing the metric data table
-cassandra-keyspace = metrictank
-# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
-cassandra-consistency = one
-# how to select which hosts to query
-# roundrobin                : iterate all hosts, spreading queries evenly.
-# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
-# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
-# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
-# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
-# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
-cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
-# cassandra timeout in milliseconds
-cassandra-timeout = 10000
-# max number of concurrent reads to cassandra
-cassandra-read-concurrency = 20
-# max number of concurrent writes to cassandra
-cassandra-write-concurrency = 10
-# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
-cassandra-read-queue-size = 200000
-# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
-cassandra-write-queue-size = 100000
-# how many times to retry a query before failing it
-cassandra-retries = 0
-# CQL protocol version. cassandra 3.x needs v3 or 4.
-cql-protocol-version = 4
-# enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = true
-# File containing the needed schemas in case database needs initializing
-cassandra-schema-file = /etc/metrictank/schema-store-cassandra.toml
-# enable SSL connection to cassandra
-cassandra-ssl = false
-# cassandra CA certficate path when using SSL
-cassandra-ca-path = /etc/metrictank/ca.pem
-# host (hostname and server cert) verification when using SSL
-cassandra-host-verification = true
-# enable cassandra user authentication
-cassandra-auth = false
-# username for authentication
-cassandra-username = cassandra
-# password for authentication
-cassandra-password = cassandra
-# instruct the driver to not attempt to get host info from the system.peers table
-cassandra-disable-initial-host-lookup = false
-
 ## Profiling and logging ##
 
 # see https://golang.org/pkg/runtime/#SetBlockProfileRate
@@ -101,6 +51,57 @@ tracing-enabled = false
 tracing-addr = localhost:6831
 # tracer/process-level tags to include, specified as comma-separated key:value pairs
 tracing-add-tags =
+
+## metric data storage in cassandra ##
+[cassandra]
+
+# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
+# comma-separated list of hostnames to connect to
+addrs = cassandra:9042
+# keyspace to use for storing the metric data table
+keyspace = metrictank
+# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
+consistency = one
+# how to select which hosts to query
+# roundrobin                : iterate all hosts, spreading queries evenly.
+# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
+# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
+# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
+# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
+# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
+host-selection-policy = tokenaware,hostpool-epsilon-greedy
+# cassandra timeout in milliseconds
+timeout = 10000
+# max number of concurrent reads to cassandra
+read-concurrency = 20
+# max number of concurrent writes to cassandra
+write-concurrency = 10
+# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
+read-queue-size = 200000
+# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
+write-queue-size = 100000
+# how many times to retry a query before failing it
+retries = 0
+# CQL protocol version. cassandra 3.x needs v3 or 4.
+cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+create-keyspace = true
+# File containing the needed schemas in case database needs initializing
+schema-file = /etc/metrictank/schema-store-cassandra.toml
+# enable SSL connection to cassandra
+ssl = false
+# cassandra CA certficate path when using SSL
+ca-path = /etc/metrictank/ca.pem
+# host (hostname and server cert) verification when using SSL
+host-verification = true
+# enable cassandra user authentication
+auth = false
+# username for authentication
+username = cassandra
+# password for authentication
+password = cassandra
+# instruct the driver to not attempt to get host info from the system.peers table
+disable-initial-host-lookup = false
 
 ## Retention settings ##
 [retention]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -82,6 +82,10 @@ read-queue-size = 200000
 write-queue-size = 100000
 # how many times to retry a query before failing it
 retries = 0
+# size of compaction window relative to TTL
+window-factor = 20
+# if a read is older than this (in seconds), it will be omitted,  not executed
+omit-read-timeout = 60
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -57,7 +57,7 @@ tracing-add-tags =
 
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 # comma-separated list of hostnames to connect to
-addrs = localhost:9042
+addrs = localhost
 # keyspace to use for storing the metric data table
 keyspace = metrictank
 # desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
@@ -82,6 +82,10 @@ read-queue-size = 200000
 write-queue-size = 100000
 # how many times to retry a query before failing it
 retries = 0
+# size of compaction window relative to TTL
+window-factor = 20
+# if a read is older than this (in seconds), it will be omitted,  not executed
+omit-read-timeout = 60
 # CQL protocol version. cassandra 3.x needs v3 or 4.
 cql-protocol-version = 4
 # enable the creation of the mdata keyspace and tables, only one node needs this

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -25,56 +25,6 @@ warm-up-period = 1h
 # leave at 0 to disable.
 public-org = 0
 
-## metric data storage in cassandra ##
-
-# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# comma-separated list of hostnames to connect to
-cassandra-addrs = localhost:9042
-# keyspace to use for storing the metric data table
-cassandra-keyspace = metrictank
-# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
-cassandra-consistency = one
-# how to select which hosts to query
-# roundrobin                : iterate all hosts, spreading queries evenly.
-# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
-# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
-# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
-# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
-# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
-cassandra-host-selection-policy = tokenaware,hostpool-epsilon-greedy
-# cassandra timeout in milliseconds
-cassandra-timeout = 1000
-# max number of concurrent reads to cassandra
-cassandra-read-concurrency = 20
-# max number of concurrent writes to cassandra
-cassandra-write-concurrency = 10
-# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
-cassandra-read-queue-size = 200000
-# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
-cassandra-write-queue-size = 100000
-# how many times to retry a query before failing it
-cassandra-retries = 0
-# CQL protocol version. cassandra 3.x needs v3 or 4.
-cql-protocol-version = 4
-# enable the creation of the mdata keyspace and tables, only one node needs this
-cassandra-create-keyspace = true
-# File containing the needed schemas in case database needs initializing
-cassandra-schema-file = /etc/metrictank/schema-store-cassandra.toml
-# enable SSL connection to cassandra
-cassandra-ssl = false
-# cassandra CA certficate path when using SSL
-cassandra-ca-path = /etc/metrictank/ca.pem
-# host (hostname and server cert) verification when using SSL
-cassandra-host-verification = true
-# enable cassandra user authentication
-cassandra-auth = false
-# username for authentication
-cassandra-username = cassandra
-# password for authentication
-cassandra-password = cassandra
-# instruct the driver to not attempt to get host info from the system.peers table
-cassandra-disable-initial-host-lookup = false
-
 ## Profiling and logging ##
 
 # see https://golang.org/pkg/runtime/#SetBlockProfileRate
@@ -101,6 +51,57 @@ tracing-enabled = false
 tracing-addr = localhost:6831
 # tracer/process-level tags to include, specified as comma-separated key:value pairs
 tracing-add-tags =
+
+## metric data storage in cassandra ##
+[cassandra]
+
+# see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
+# comma-separated list of hostnames to connect to
+addrs = localhost:9042
+# keyspace to use for storing the metric data table
+keyspace = metrictank
+# desired write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
+consistency = one
+# how to select which hosts to query
+# roundrobin                : iterate all hosts, spreading queries evenly.
+# hostpool-simple           : basic pool that tracks which hosts are up and which are not.
+# hostpool-epsilon-greedy   : prefer best hosts, but regularly try other hosts to stay on top of all hosts.
+# tokenaware,roundrobin              : prefer host that has the needed data, fallback to roundrobin.
+# tokenaware,hostpool-simple         : prefer host that has the needed data, fallback to hostpool-simple.
+# tokenaware,hostpool-epsilon-greedy : prefer host that has the needed data, fallback to hostpool-epsilon-greedy.
+host-selection-policy = tokenaware,hostpool-epsilon-greedy
+# cassandra timeout in milliseconds
+timeout = 1000
+# max number of concurrent reads to cassandra
+read-concurrency = 20
+# max number of concurrent writes to cassandra
+write-concurrency = 10
+# max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel
+read-queue-size = 200000
+# write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have
+write-queue-size = 100000
+# how many times to retry a query before failing it
+retries = 0
+# CQL protocol version. cassandra 3.x needs v3 or 4.
+cql-protocol-version = 4
+# enable the creation of the mdata keyspace and tables, only one node needs this
+create-keyspace = true
+# File containing the needed schemas in case database needs initializing
+schema-file = /etc/metrictank/schema-store-cassandra.toml
+# enable SSL connection to cassandra
+ssl = false
+# cassandra CA certficate path when using SSL
+ca-path = /etc/metrictank/ca.pem
+# host (hostname and server cert) verification when using SSL
+host-verification = true
+# enable cassandra user authentication
+auth = false
+# username for authentication
+username = cassandra
+# password for authentication
+password = cassandra
+# instruct the driver to not attempt to get host info from the system.peers table
+disable-initial-host-lookup = false
 
 ## Retention settings ##
 [retention]

--- a/store/cassandra/config.go
+++ b/store/cassandra/config.go
@@ -74,7 +74,7 @@ func ConfigSetup() *flag.FlagSet {
 	cas.IntVar(&CliConfig.WriteQueueSize, "write-queue-size", CliConfig.WriteQueueSize, "write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have")
 	cas.IntVar(&CliConfig.Retries, "retries", CliConfig.Retries, "how many times to retry a query before failing it")
 	cas.IntVar(&CliConfig.WindowFactor, "window-factor", CliConfig.WindowFactor, "size of compaction window relative to TTL")
-	cas.IntVar(&CliConfig.OmitReadTimeout, "omit-read-timeout", CliConfig.OmitReadTimeout, "if a read is older than this, it will directly be omitted without executing")
+	cas.IntVar(&CliConfig.OmitReadTimeout, "omit-read-timeout", CliConfig.OmitReadTimeout, "if a read is older than this (in seconds), it will be omitted,  not executed")
 	cas.IntVar(&CliConfig.CqlProtocolVersion, "cql-protocol-version", CliConfig.CqlProtocolVersion, "cql protocol version to use")
 	cas.BoolVar(&CliConfig.CreateKeyspace, "create-keyspace", CliConfig.CreateKeyspace, "enable the creation of the mdata keyspace and tables, only one node needs this")
 	cas.BoolVar(&CliConfig.DisableInitialHostLookup, "disable-initial-host-lookup", CliConfig.DisableInitialHostLookup, "instruct the driver to not attempt to get host info from the system.peers table")

--- a/store/cassandra/config.go
+++ b/store/cassandra/config.go
@@ -1,0 +1,90 @@
+package cassandra
+
+import (
+	"flag"
+
+	"github.com/rakyll/globalconf"
+)
+
+type StoreConfig struct {
+	Addrs                    string
+	Keyspace                 string
+	Consistency              string
+	HostSelectionPolicy      string
+	Timeout                  int
+	ReadConcurrency          int
+	WriteConcurrency         int
+	ReadQueueSize            int
+	WriteQueueSize           int
+	Retries                  int
+	WindowFactor             int
+	OmitReadTimeout          int
+	CqlProtocolVersion       int
+	CreateKeyspace           bool
+	DisableInitialHostLookup bool
+	SSL                      bool
+	CaPath                   string
+	HostVerification         bool
+	Auth                     bool
+	Username                 string
+	Password                 string
+	SchemaFile               string
+}
+
+// return StoreConfig with default values set.
+func NewStoreConfig() *StoreConfig {
+	return &StoreConfig{
+		Addrs:                    "localhost",
+		Keyspace:                 "metrictank",
+		Consistency:              "one",
+		HostSelectionPolicy:      "tokenaware,hostpool-epsilon-greedy",
+		Timeout:                  1000,
+		ReadConcurrency:          20,
+		WriteConcurrency:         10,
+		ReadQueueSize:            200000,
+		WriteQueueSize:           100000,
+		Retries:                  0,
+		WindowFactor:             20,
+		OmitReadTimeout:          60,
+		CqlProtocolVersion:       4,
+		CreateKeyspace:           true,
+		DisableInitialHostLookup: false,
+		SSL:              false,
+		CaPath:           "/etc/metrictank/ca.pem",
+		HostVerification: true,
+		Auth:             false,
+		Username:         "cassandra",
+		Password:         "cassandra",
+		SchemaFile:       "/etc/metrictank/schema-store-cassandra.toml",
+	}
+}
+
+var CliConfig = NewStoreConfig()
+
+func ConfigSetup() *flag.FlagSet {
+	cas := flag.NewFlagSet("cassandra", flag.ExitOnError)
+	cas.StringVar(&CliConfig.Addrs, "addrs", CliConfig.Addrs, "cassandra host (may be given multiple times as comma-separated list)")
+	cas.StringVar(&CliConfig.Keyspace, "keyspace", CliConfig.Keyspace, "cassandra keyspace to use for storing the metric data table")
+	cas.StringVar(&CliConfig.Consistency, "consistency", CliConfig.Consistency, "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
+	cas.StringVar(&CliConfig.HostSelectionPolicy, "host-selection-policy", CliConfig.HostSelectionPolicy, "")
+	cas.IntVar(&CliConfig.Timeout, "timeout", CliConfig.Timeout, "cassandra timeout in milliseconds")
+	cas.IntVar(&CliConfig.ReadConcurrency, "read-concurrency", CliConfig.ReadConcurrency, "max number of concurrent reads to cassandra.")
+	cas.IntVar(&CliConfig.WriteConcurrency, "write-concurrency", CliConfig.WriteConcurrency, "max number of concurrent writes to cassandra.")
+	cas.IntVar(&CliConfig.ReadQueueSize, "read-queue-size", CliConfig.ReadQueueSize, "max number of outstanding reads before reads will be dropped. This is important if you run queries that result in many reads in parallel.")
+	cas.IntVar(&CliConfig.WriteQueueSize, "write-queue-size", CliConfig.WriteQueueSize, "write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have")
+	cas.IntVar(&CliConfig.Retries, "retries", CliConfig.Retries, "how many times to retry a query before failing it")
+	cas.IntVar(&CliConfig.WindowFactor, "window-factor", CliConfig.WindowFactor, "size of compaction window relative to TTL")
+	cas.IntVar(&CliConfig.OmitReadTimeout, "omit-read-timeout", CliConfig.OmitReadTimeout, "if a read is older than this, it will directly be omitted without executing")
+	cas.IntVar(&CliConfig.CqlProtocolVersion, "cql-protocol-version", CliConfig.CqlProtocolVersion, "cql protocol version to use")
+	cas.BoolVar(&CliConfig.CreateKeyspace, "create-keyspace", CliConfig.CreateKeyspace, "enable the creation of the mdata keyspace and tables, only one node needs this")
+	cas.BoolVar(&CliConfig.DisableInitialHostLookup, "disable-initial-host-lookup", CliConfig.DisableInitialHostLookup, "instruct the driver to not attempt to get host info from the system.peers table")
+	cas.BoolVar(&CliConfig.SSL, "ssl", CliConfig.SSL, "enable SSL connection to cassandra")
+	cas.StringVar(&CliConfig.CaPath, "ca-path", CliConfig.CaPath, "cassandra CA certificate path when using SSL")
+	cas.BoolVar(&CliConfig.HostVerification, "host-verification", CliConfig.HostVerification, "host (hostname and server cert) verification when using SSL")
+	cas.BoolVar(&CliConfig.Auth, "auth", CliConfig.Auth, "enable cassandra authentication")
+	cas.StringVar(&CliConfig.Username, "username", CliConfig.Username, "username for authentication")
+	cas.StringVar(&CliConfig.Password, "password", CliConfig.Password, "password for authentication")
+	cas.StringVar(&CliConfig.SchemaFile, "schema-file", CliConfig.SchemaFile, "File containing the needed schemas in case database needs initializing")
+	globalconf.Register("cassandra", cas)
+	return cas
+}


### PR DESCRIPTION
The cassandra.NewCassandraStore() had way too many variables being passed in.
The function has been updated to take a config struct instead.

The registering of the cassandraStore flag variables has also been moved out of main and into their own section in the config.
Previously, the config settings were in the global section of the config and prefixed with "cassandra-", now they are in their own "[cassandra]" section and the prefix has been removed.
All ENV variables previously used with the old config format will continue to work with the config format.
`ENV format MT_<section>_<name>`
old format : (section="", name=cassandra-addrs) : *MT_CASSANDRA_ADDRS=localhost*
new format : (section="cassandra", name=addrs) : *MT_CASSANDRA_ADDRS=localhost*