### PR TITLE
endpoint for analyzing priority calculation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,6 +49,7 @@ type Server struct {
 	Cache           cache.Cache
 	shutdown        chan struct{}
 	Tracer          opentracing.Tracer
+	prioritySetters []PrioritySetter
 }
 
 func (s *Server) BindMetricIndex(i idx.MetricIndex) {
@@ -71,6 +72,14 @@ func (s *Server) BindTracer(tracer opentracing.Tracer) {
 
 func (s *Server) BindPromQueryEngine() {
 	s.PromQueryEngine = promql.NewEngine(s, nil)
+}
+
+type PrioritySetter interface {
+	ExplainPriority() interface{}
+}
+
+func (s *Server) BindPrioritySetter(p PrioritySetter) {
+	s.prioritySetters = append(s.prioritySetters, p)
 }
 
 func NewServer() (*Server, error) {

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -18,6 +18,14 @@ import (
 
 var NotFoundErr = errors.New("not found")
 
+func (s *Server) explainPriority(ctx *middleware.Context) {
+	var data []interface{}
+	for _, p := range s.prioritySetters {
+		data = append(data, p.ExplainPriority())
+	}
+	response.Write(ctx, response.NewJson(200, data, ""))
+}
+
 func (s *Server) getNodeStatus(ctx *middleware.Context) {
 	response.Write(ctx, response.NewJson(200, cluster.Manager.ThisNode(), ""))
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -27,6 +27,7 @@ func (s *Server) RegisterRoutes() {
 	r.Get("/", s.appStatus)
 	r.Get("/node", s.getNodeStatus)
 	r.Post("/node", bind(models.NodeStatus{}), s.setNodeStatus)
+	r.Get("/priority", s.explainPriority)
 	r.Get("/debug/pprof/block", blockHandler)
 	r.Get("/debug/pprof/mutex", mutexHandler)
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -160,6 +160,46 @@ Sets the primary status to this node to true or false.
 curl --data primary=true "http://localhost:6060/node"
 ```
 
+## Analyze instance priority
+
+```
+GET /priority
+```
+
+Gets all enabled plugins to declare how they compute their
+priority scores.
+
+#### Example
+
+```bash
+curl -s http://localhost:6060/priority | jsonpp
+[
+    "carbon-in: priority=0 (always in sync)",
+    {
+        "Title": "kafka-mdm:",
+        "Explanation": {
+            "Explanation": {
+                "Status": {
+                    "0": {
+                        "Lag": 1,
+                        "Rate": 26494,
+                        "Priority": 0
+                    },
+                    "1": {
+                        "Lag": 2,
+                        "Rate": 24989,
+                        "Priority": 0
+                    }
+                },
+                "Priority": 0,
+                "Updated": "2018-06-06T11:56:24.399840121Z"
+            },
+            "Now": "2018-06-06T11:56:25.016645631Z"
+        }
+    }
+]
+```
+
 ## Misc
 
 ### Tspec

--- a/input/carbon/carbon.go
+++ b/input/carbon/carbon.go
@@ -126,6 +126,10 @@ func (c *Carbon) MaintainPriority() {
 	cluster.Manager.SetPriority(0)
 }
 
+func (c *Carbon) ExplainPriority() interface{} {
+	return "carbon-in: priority=0 (always in sync)"
+}
+
 func (c *Carbon) accept() {
 	for {
 		conn, err := c.listener.AcceptTCP()

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -399,3 +399,13 @@ func (k *KafkaMdm) MaintainPriority() {
 		}
 	}()
 }
+
+func (k *KafkaMdm) ExplainPriority() interface{} {
+	return struct {
+		Title       string
+		Explanation interface{}
+	}{
+		"kafka-mdm:",
+		k.lagMonitor.Explain(),
+	}
+}

--- a/input/plugin.go
+++ b/input/plugin.go
@@ -9,5 +9,6 @@ type Plugin interface {
 	// Note that upon fatal close, metrictank will call Stop() on all plugins, also the one that triggered it.
 	Start(handler Handler, fatal chan struct{}) error
 	MaintainPriority()
+	ExplainPriority() interface{}
 	Stop() // Should block until shutdown is complete.
 }

--- a/input/prometheus/prometheus.go
+++ b/input/prometheus/prometheus.go
@@ -55,6 +55,10 @@ func (p *prometheusWriteHandler) MaintainPriority() {
 	cluster.Manager.SetPriority(0)
 }
 
+func (p *prometheusWriteHandler) ExplainPriority() interface{} {
+	return "prometheus-in: priority=0 (always in sync)"
+}
+
 func (p *prometheusWriteHandler) Stop() {
 	log.Info("prometheus-in: shutting down")
 }

--- a/metrictank.go
+++ b/metrictank.go
@@ -421,6 +421,7 @@ func main() {
 			return
 		}
 		plugin.MaintainPriority()
+		apiServer.BindPrioritySetter(plugin)
 	}
 
 	// metric cluster.self.promotion_wait is how long a candidate (secondary node) has to wait until it can become a primary


### PR DESCRIPTION
we sometimes see instances coming online and after replaying their
backlog, not being able to become ready.
Or sometimes we want to analyze the priority calculation