### PR TITLE
[WIP] Add method to cache many chunks at once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 default:
 	$(MAKE) all
 test:
-	CGO_ENABLED=1 go test -v -race $(shell go list ./... | grep -v /vendor/ | grep -v chaos)
+	CGO_ENABLED=1 go test -v -race $(shell go list ./... | grep -v /vendor/ | grep -v stacktest)
 check:
 	$(MAKE) test
 bin:

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -359,7 +359,7 @@ func (a *AggMetric) addAggregators(ts uint32, val float64) {
 
 func (a *AggMetric) pushToCache(c *chunk.Chunk) {
 	// push into cache
-	go a.cachePusher.CacheIfHot(
+	go a.cachePusher.AddIfHot(
 		a.Key,
 		0,
 		*chunk.NewBareIterGen(

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -126,7 +126,7 @@ func testMetricPersistOptionalPrimary(t *testing.T, primary bool) {
 	calledCb := make(chan bool)
 
 	mockCache := cache.MockCache{}
-	mockCache.CacheIfHotCb = func() { calledCb <- true }
+	mockCache.AddIfHotCb = func() { calledCb <- true }
 
 	numChunks, chunkAddCount, chunkSpan := uint32(5), uint32(10), uint32(300)
 	ret := []conf.Retention{conf.NewRetentionMT(1, 1, chunkSpan, numChunks, true)}

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -31,6 +31,12 @@ func (mc *MockCache) Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen
 	mc.AddCount++
 }
 
+func (mc *MockCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen) {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.AddCount += len(itergens)
+}
+
 func (mc *MockCache) CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -11,8 +11,8 @@ import (
 type MockCache struct {
 	sync.Mutex
 	AddCount          int
-	CacheIfHotCount   int
-	CacheIfHotCb      func()
+	AddIfHotCount     int
+	AddIfHotCb        func()
 	StopCount         int
 	SearchCount       int
 	DelMetricArchives int
@@ -37,12 +37,12 @@ func (mc *MockCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk
 	mc.AddCount += len(itergens)
 }
 
-func (mc *MockCache) CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
+func (mc *MockCache) AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()
-	mc.CacheIfHotCount++
-	if mc.CacheIfHotCb != nil {
-		mc.CacheIfHotCb()
+	mc.AddIfHotCount++
+	if mc.AddIfHotCb != nil {
+		mc.AddIfHotCb()
 	}
 }
 

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -104,7 +104,7 @@ func (c *CCache) DelMetric(rawMetric schema.MKey) (int, int) {
 }
 
 // adds the given chunk to the cache, but only if the metric is sufficiently hot
-func (c *CCache) CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
+func (c *CCache) AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	c.RLock()
 
 	var met *CCacheMetric

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -136,8 +136,8 @@ func (c *CCache) Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 
 	ccm, ok := c.metricCache[metric]
 	if !ok {
-		ccm = NewCCacheMetric()
-		ccm.Init(metric.MKey, prev, itergen)
+		ccm = NewCCacheMetric(metric.MKey)
+		ccm.Add(prev, itergen)
 		c.metricCache[metric] = ccm
 
 		// if we do not have this raw key yet, create the entry with the association
@@ -166,11 +166,8 @@ func (c *CCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk.Ite
 
 	ccm, ok := c.metricCache[metric]
 	if !ok {
-		ccm = NewCCacheMetric()
-		ccm.Init(metric.MKey, prev, itergens[0])
-		if len(itergens) > 1 {
-			ccm.AddRange(itergens[0].Ts, itergens[1:])
-		}
+		ccm = NewCCacheMetric(metric.MKey)
+		ccm.AddRange(prev, itergens)
 		c.metricCache[metric] = ccm
 
 		// if we do not have this raw key yet, create the entry with the association

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -157,6 +157,41 @@ func (c *CCache) Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	c.accnt.AddChunk(metric, itergen.Ts, itergen.Size())
 }
 
+func (c *CCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen) {
+	if len(itergens) == 0 {
+		return
+	}
+	c.Lock()
+	defer c.Unlock()
+
+	ccm, ok := c.metricCache[metric]
+	if !ok {
+		ccm = NewCCacheMetric()
+		ccm.Init(metric.MKey, prev, itergens[0])
+		if len(itergens) > 1 {
+			ccm.AddRange(itergens[0].Ts, itergens[1:])
+		}
+		c.metricCache[metric] = ccm
+
+		// if we do not have this raw key yet, create the entry with the association
+		ccms, ok := c.metricRawKeys[metric.MKey]
+		if !ok {
+			c.metricRawKeys[metric.MKey] = map[schema.Archive]struct{}{
+				metric.Archive: {},
+			}
+		} else {
+			// otherwise, make sure the association exists
+			ccms[metric.Archive] = struct{}{}
+		}
+	} else {
+		ccm.AddRange(prev, itergens)
+	}
+
+	for _, itergen := range itergens {
+		c.accnt.AddChunk(metric, itergen.Ts, itergen.Size())
+	}
+}
+
 func (cc *CCache) Reset() (int, int) {
 	cc.Lock()
 	cc.accnt.Reset()

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -69,7 +69,11 @@ func (mc *CCacheMetric) Del(ts uint32) int {
 	return len(mc.chunks)
 }
 
-func (mc *CCacheMetric) AddSlice(prev uint32, itergens []chunk.IterGen) {
+// AddRange adds a range (sequence) of chunks.
+// Note the following requirements:
+// the sequence should be in ascending timestamp order
+// the sequence should be complete (no gaps)
+func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 	if len(itergens) == 0 {
 		return
 	}

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -26,15 +26,11 @@ type CCacheMetric struct {
 }
 
 // NewCCacheMetric creates a CCacheMetric
-func NewCCacheMetric() *CCacheMetric {
+func NewCCacheMetric(mkey schema.MKey) *CCacheMetric {
 	return &CCacheMetric{
+		MKey:   mkey,
 		chunks: make(map[uint32]*CCacheChunk),
 	}
-}
-
-func (mc *CCacheMetric) Init(MKey schema.MKey, prev uint32, itergen chunk.IterGen) {
-	mc.Add(prev, itergen)
-	mc.MKey = MKey
 }
 
 // Del deletes chunks for the given timestamp

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -128,8 +128,8 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 
 	// handle the 2nd until the last-but-one
 	for i := 1; i < len(itergens)-1; i++ {
-		itergen := itergens[i]
-		ts := itergen.Ts
+		itergen = itergens[i]
+		ts = itergen.Ts
 		// add chunk if we don't have it yet (most likely)
 		if _, ok := mc.chunks[ts]; !ok {
 			chunks = append(chunks, CCacheChunk{

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -122,6 +122,8 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 		})
 		mc.chunks[ts] = &chunks[len(chunks)-1]
 		mc.keys = append(mc.keys, ts)
+	} else {
+		mc.chunks[ts].Next = itergens[1].Ts
 	}
 
 	prev = ts
@@ -130,17 +132,16 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 	for i := 1; i < len(itergens)-1; i++ {
 		itergen = itergens[i]
 		ts = itergen.Ts
-		// add chunk if we don't have it yet (most likely)
-		if _, ok := mc.chunks[ts]; !ok {
-			chunks = append(chunks, CCacheChunk{
-				Ts:    ts,
-				Prev:  prev,
-				Next:  itergens[i+1].Ts,
-				Itgen: itergen,
-			})
-			mc.chunks[ts] = &chunks[len(chunks)-1]
-			mc.keys = append(mc.keys, ts)
-		}
+		// add chunk, potentially overwriting pre-existing chunk (unlikely)
+		chunks = append(chunks, CCacheChunk{
+			Ts:    ts,
+			Prev:  prev,
+			Next:  itergens[i+1].Ts,
+			Itgen: itergen,
+		})
+		mc.chunks[ts] = &chunks[len(chunks)-1]
+		mc.keys = append(mc.keys, ts)
+
 		prev = ts
 	}
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -4,32 +4,34 @@ import (
 	"testing"
 
 	"github.com/grafana/metrictank/mdata/chunk"
+	"github.com/grafana/metrictank/test"
 	"gopkg.in/raintank/schema.v1"
 )
 
-func generateChunks(b *testing.B) []chunk.IterGen {
-	res := make([]chunk.IterGen, 0, b.N)
+func generateChunks(b testing.TB, startAt, count, step int) []chunk.IterGen {
+	res := make([]chunk.IterGen, 0, count)
 
+	values := make([]uint32, step)
 	// the metric is initialized with the first chunk at ts 1,
 	// so the generated slice should start at ts 2
-	for i := uint32(2); i < uint32(b.N+2); i++ {
-		c := getItgen(b, []uint32{1}, i, true)
+	for i := startAt; i < (step*count)+startAt; i += step {
+		c := getItgen(b, values, uint32(i), true)
 		res = append(res, c)
 	}
 	return res
 }
 
-func initMetric(b *testing.B) *CCacheMetric {
+func initMetric(b testing.TB) (schema.MKey, *CCacheMetric) {
 	ccm := NewCCacheMetric()
 	mkey, _ := schema.MKeyFromString("1.12345678901234567890123456789012")
 	c := getItgen(b, []uint32{1}, uint32(1), true)
 	ccm.Init(mkey, 0, c)
-	return ccm
+	return mkey, ccm
 }
 
 func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
-	ccm := initMetric(b)
-	chunks := generateChunks(b)
+	_, ccm := initMetric(b)
+	chunks := generateChunks(b, 2, b.N, 1)
 	prev := uint32(1)
 	b.ResetTimer()
 	for _, chunk := range chunks {
@@ -39,9 +41,56 @@ func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
 }
 
 func BenchmarkAddingManyChunksAtOnce(b *testing.B) {
-	ccm := initMetric(b)
-	chunks := generateChunks(b)
+	_, ccm := initMetric(b)
+	chunks := generateChunks(b, 2, b.N, 1)
 	prev := uint32(1)
 	b.ResetTimer()
 	ccm.AddSlice(prev, chunks)
+}
+
+func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
+	mkey, ccm := initMetric(t)
+	amkey := schema.AMKey{MKey: mkey, Archive: 0}
+	chunks := generateChunks(t, 10, 100, 10)
+	prev := uint32(10)
+	for _, chunk := range chunks {
+		ccm.Add(prev, chunk)
+		prev = chunk.Ts
+	}
+
+	res := CCSearchResult{}
+	ccm.Search(test.NewContext(), amkey, &res, 25, 45)
+	if res.Complete != true {
+		t.Fatalf("Expected result to be complete, but it was not")
+	}
+
+	if res.Start[0].Ts != 20 {
+		t.Fatalf("Expected result to start at 20, but had %d", res.Start[0].Ts)
+	}
+
+	if res.Start[len(res.Start)-1].Ts != 40 {
+		t.Fatalf("Expected result to start at 40, but had %d", res.Start[len(res.Start)-1].Ts)
+	}
+}
+
+func TestAddingChunksAtOnceAndQueryingThem(t *testing.T) {
+	mkey, ccm := initMetric(t)
+	amkey := schema.AMKey{MKey: mkey, Archive: 0}
+	chunks := generateChunks(t, 10, 100, 10)
+	prev := uint32(10)
+	ccm.AddSlice(prev, chunks)
+
+	res := CCSearchResult{}
+	ccm.Search(test.NewContext(), amkey, &res, 25, 45)
+	if res.Complete != true {
+		t.Fatalf("Expected result to be complete, but it was not")
+	}
+
+	if res.Start[0].Ts != 20 {
+		t.Fatalf("Expected result to start at 20, but had %d", res.Start[0].Ts)
+	}
+
+	if res.Start[len(res.Start)-1].Ts != 40 {
+		t.Fatalf("Expected result to start at 40, but had %d", res.Start[len(res.Start)-1].Ts)
+	}
 }

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/grafana/metrictank/mdata/chunk"
+	"gopkg.in/raintank/schema.v1"
+)
+
+func generateChunks(b *testing.B) []chunk.IterGen {
+	res := make([]chunk.IterGen, 0, b.N)
+
+	// the metric is initialized with the first chunk at ts 1,
+	// so the generated slice should start at ts 2
+	for i := uint32(2); i < uint32(b.N+2); i++ {
+		c := getItgen(b, []uint32{1}, i, true)
+		res = append(res, c)
+	}
+	return res
+}
+
+func initMetric(b *testing.B) *CCacheMetric {
+	ccm := NewCCacheMetric()
+	mkey, _ := schema.MKeyFromString("1.12345678901234567890123456789012")
+	c := getItgen(b, []uint32{1}, uint32(1), true)
+	ccm.Init(mkey, 0, c)
+	return ccm
+}
+
+func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
+	ccm := initMetric(b)
+	chunks := generateChunks(b)
+	prev := uint32(1)
+	b.ResetTimer()
+	for _, chunk := range chunks {
+		ccm.Add(prev, chunk)
+		prev = chunk.Ts
+	}
+}
+
+func BenchmarkAddingManyChunksAtOnce(b *testing.B) {
+	ccm := initMetric(b)
+	chunks := generateChunks(b)
+	prev := uint32(1)
+	b.ResetTimer()
+	ccm.AddSlice(prev, chunks)
+}

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -8,30 +8,29 @@ import (
 	"gopkg.in/raintank/schema.v1"
 )
 
-func generateChunks(b testing.TB, startAt, count, step int) []chunk.IterGen {
+func generateChunks(b testing.TB, startAt, count, step uint32) []chunk.IterGen {
 	res := make([]chunk.IterGen, 0, count)
 
 	values := make([]uint32, step)
-	// the metric is initialized with the first chunk at ts 1,
-	// so the generated slice should start at ts 2
-	for i := startAt; i < (step*count)+startAt; i += step {
-		c := getItgen(b, values, uint32(i), true)
+	for t0 := startAt; t0 < startAt+(step*uint32(count)); t0 += step {
+		c := getItgen(b, values, t0, true)
 		res = append(res, c)
 	}
 	return res
 }
 
-func initMetric(b testing.TB) (schema.MKey, *CCacheMetric) {
+func initMetric(b testing.TB, start, step uint32) (schema.MKey, *CCacheMetric) {
 	ccm := NewCCacheMetric()
 	mkey, _ := schema.MKeyFromString("1.12345678901234567890123456789012")
-	c := getItgen(b, []uint32{1}, uint32(1), true)
+	values := make([]uint32, step)
+	c := getItgen(b, values, start, true)
 	ccm.Init(mkey, 0, c)
 	return mkey, ccm
 }
 
 func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
-	_, ccm := initMetric(b)
-	chunks := generateChunks(b, 2, b.N, 1)
+	_, ccm := initMetric(b, 10, 10)
+	chunks := generateChunks(b, 20, uint32(b.N), 10)
 	prev := uint32(1)
 	b.ResetTimer()
 	for _, chunk := range chunks {
@@ -41,17 +40,17 @@ func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
 }
 
 func BenchmarkAddingManyChunksAtOnce(b *testing.B) {
-	_, ccm := initMetric(b)
-	chunks := generateChunks(b, 2, b.N, 1)
+	_, ccm := initMetric(b, 10, 10)
+	chunks := generateChunks(b, 20, uint32(b.N), 10)
 	prev := uint32(1)
 	b.ResetTimer()
 	ccm.AddSlice(prev, chunks)
 }
 
 func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
-	mkey, ccm := initMetric(t)
+	mkey, ccm := initMetric(t, 10, 10)
 	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 10, 100, 10)
+	chunks := generateChunks(t, 20, 100, 10)
 	prev := uint32(10)
 	for _, chunk := range chunks {
 		ccm.Add(prev, chunk)
@@ -72,11 +71,10 @@ func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
 		t.Fatalf("Expected result to start at 40, but had %d", res.Start[len(res.Start)-1].Ts)
 	}
 }
-
 func TestAddingChunksAtOnceAndQueryingThem(t *testing.T) {
-	mkey, ccm := initMetric(t)
+	mkey, ccm := initMetric(t, 10, 10)
 	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 10, 100, 10)
+	chunks := generateChunks(t, 20, 100, 10)
 	prev := uint32(10)
 	ccm.AddSlice(prev, chunks)
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -19,18 +19,15 @@ func generateChunks(b testing.TB, startAt, count, step uint32) []chunk.IterGen {
 	return res
 }
 
-func initMetric(b testing.TB, start, step uint32) (schema.MKey, *CCacheMetric) {
-	ccm := NewCCacheMetric()
+func getCCM() (schema.MKey, *CCacheMetric) {
 	mkey, _ := schema.MKeyFromString("1.12345678901234567890123456789012")
-	values := make([]uint32, step)
-	c := getItgen(b, values, start, true)
-	ccm.Init(mkey, 0, c)
+	ccm := NewCCacheMetric(mkey)
 	return mkey, ccm
 }
 
 func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
-	_, ccm := initMetric(b, 10, 10)
-	chunks := generateChunks(b, 20, uint32(b.N), 10)
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
 	prev := uint32(1)
 	b.ResetTimer()
 	for _, chunk := range chunks {
@@ -40,18 +37,18 @@ func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
 }
 
 func BenchmarkAddingManyChunksAtOnce(b *testing.B) {
-	_, ccm := initMetric(b, 10, 10)
-	chunks := generateChunks(b, 20, uint32(b.N), 10)
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
 	prev := uint32(1)
 	b.ResetTimer()
 	ccm.AddRange(prev, chunks)
 }
 
 func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
-	mkey, ccm := initMetric(t, 10, 10)
+	mkey, ccm := getCCM()
 	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 20, 5, 10)
-	prev := uint32(10)
+	chunks := generateChunks(t, 10, 6, 10)
+	prev := uint32(1)
 	for _, chunk := range chunks {
 		ccm.Add(prev, chunk)
 		prev = chunk.Ts
@@ -72,9 +69,9 @@ func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
 	}
 }
 func TestAddingChunksAtOnceAndQueryingThem(t *testing.T) {
-	mkey, ccm := initMetric(t, 10, 10)
+	mkey, ccm := getCCM()
 	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 20, 5, 10)
+	chunks := generateChunks(t, 10, 6, 10)
 	prev := uint32(10)
 	ccm.AddRange(prev, chunks)
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -19,40 +19,74 @@ func generateChunks(b testing.TB, startAt, count, step uint32) []chunk.IterGen {
 	return res
 }
 
-func getCCM() (schema.MKey, *CCacheMetric) {
-	mkey, _ := schema.MKeyFromString("1.12345678901234567890123456789012")
-	ccm := NewCCacheMetric(mkey)
-	return mkey, ccm
+func getCCM() (schema.AMKey, *CCacheMetric) {
+	amkey, _ := schema.AMKeyFromString("1.12345678901234567890123456789012")
+	ccm := NewCCacheMetric(amkey.MKey)
+	return amkey, ccm
 }
 
-func BenchmarkAddingManyChunksOneByOne(b *testing.B) {
-	_, ccm := getCCM()
-	chunks := generateChunks(b, 10, uint32(b.N), 10)
-	prev := uint32(1)
-	b.ResetTimer()
-	for _, chunk := range chunks {
-		ccm.Add(prev, chunk)
-		prev = chunk.Ts
-	}
+// TestAddAsc tests adding ascending timestamp chunks individually
+func TestAddAsc(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		prev := uint32(1)
+		for _, chunk := range chunks {
+			ccm.Add(prev, chunk)
+			prev = chunk.Ts
+		}
+	})
 }
 
-func BenchmarkAddingManyChunksAtOnce(b *testing.B) {
-	_, ccm := getCCM()
-	chunks := generateChunks(b, 10, uint32(b.N), 10)
-	prev := uint32(1)
-	b.ResetTimer()
-	ccm.AddRange(prev, chunks)
+// TestAddDesc1 tests adding chunks that are all descending
+func TestAddDesc1(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		for i := len(chunks) - 1; i >= 0; i-- {
+			ccm.Add(0, chunks[i])
+		}
+	})
 }
 
-func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
-	mkey, ccm := getCCM()
-	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 10, 6, 10)
-	prev := uint32(1)
-	for _, chunk := range chunks {
-		ccm.Add(prev, chunk)
-		prev = chunk.Ts
-	}
+// TestAddDesc4 tests adding chunks that are globally descending
+// but in groups 4 are ascending
+func TestAddDesc4(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		ccm.Add(0, chunks[2])
+		ccm.Add(0, chunks[3])
+		ccm.Add(0, chunks[4])
+		ccm.Add(0, chunks[5])
+		ccm.Add(0, chunks[0])
+		ccm.Add(0, chunks[1])
+	})
+}
+
+// TestAddRange tests adding a contiguous range at once
+func TestAddRange(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		prev := uint32(10)
+		ccm.AddRange(prev, chunks)
+	})
+}
+
+// TestAddRangeDesc4 benchmarks adding chunks that are globally descending
+// but in groups of 4 are ascending. those groups are added via 1 AddRange.
+func TestAddRangeDesc4(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		ccm.AddRange(0, chunks[2:6])
+		ccm.AddRange(0, chunks[0:2])
+	})
+}
+
+// test executes the run function
+// run should generate chunks and add them to the CCacheMetric however it likes,
+// but in a way so that the result will be as expected
+func testRun(t *testing.T, run func(*CCacheMetric)) {
+	amkey, ccm := getCCM()
+
+	run(ccm)
 
 	res := CCSearchResult{}
 	ccm.Search(test.NewContext(), amkey, &res, 25, 45)
@@ -68,24 +102,88 @@ func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
 		t.Fatalf("Expected result to start at 40, but had %d", res.Start[len(res.Start)-1].Ts)
 	}
 }
-func TestAddingChunksAtOnceAndQueryingThem(t *testing.T) {
-	mkey, ccm := getCCM()
-	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 10, 6, 10)
-	prev := uint32(10)
+
+// BenchmarkAddAsc benchmarks adding ascending timestamp chunks individually
+func BenchmarkAddAsc(b *testing.B) {
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	prev := uint32(1)
+	b.ResetTimer()
+	for _, chunk := range chunks {
+		ccm.Add(prev, chunk)
+		prev = chunk.Ts
+	}
+}
+
+// BenchmarkAddDesc1 benchmarks adding chunks that are all descending
+func BenchmarkAddDesc1(b *testing.B) {
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 1; i >= 0; i-- {
+		ccm.Add(0, chunks[i])
+	}
+}
+
+// BenchmarkAddDesc4 benchmarks adding chunks that are globally descending
+// but in groups 4 are ascending
+func BenchmarkAddDesc4(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 4)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 4; i >= 0; i -= 4 {
+		ccm.Add(0, chunks[i])
+		ccm.Add(0, chunks[i+1])
+		ccm.Add(0, chunks[i+2])
+		ccm.Add(0, chunks[i+3])
+	}
+}
+
+// BenchmarkAddDesc64 benchmarks adding chunks that are globally descending
+// but in groups 64 are ascending
+func BenchmarkAddDesc64(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 64)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 64; i >= 0; i -= 64 {
+		for offset := 0; offset < 64; offset += 1 {
+			ccm.Add(0, chunks[i+offset])
+		}
+	}
+
+}
+
+// BenchmarkAddRangeAsc benchmarks adding a contiguous range at once
+func BenchmarkAddRangeAsc(b *testing.B) {
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	prev := uint32(1)
+	b.ResetTimer()
 	ccm.AddRange(prev, chunks)
+}
 
-	res := CCSearchResult{}
-	ccm.Search(test.NewContext(), amkey, &res, 25, 45)
-	if res.Complete != true {
-		t.Fatalf("Expected result to be complete, but it was not")
+// BenchmarkAddRangeDesc4 benchmarks adding chunks that are globally descending
+// but in groups 4 are ascending. those groups are added via 1 AddRange.
+func BenchmarkAddRangeDesc4(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 4)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 4; i >= 0; i -= 4 {
+		ccm.AddRange(0, chunks[i:i+4])
 	}
+}
 
-	if res.Start[0].Ts != 20 {
-		t.Fatalf("Expected result to start at 20, but had %d", res.Start[0].Ts)
-	}
-
-	if res.Start[len(res.Start)-1].Ts != 40 {
-		t.Fatalf("Expected result to start at 40, but had %d", res.Start[len(res.Start)-1].Ts)
+// BenchmarkAddRangeDesc64 benchmarks adding chunks that are globally descending
+// but in groups 64 are ascending. those groups are added via 1 AddRange.
+func BenchmarkAddRangeDesc64(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 64)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 64; i >= 0; i -= 64 {
+		ccm.AddRange(0, chunks[i:i+64])
 	}
 }

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -50,7 +50,7 @@ func BenchmarkAddingManyChunksAtOnce(b *testing.B) {
 func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
 	mkey, ccm := initMetric(t, 10, 10)
 	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 20, 100, 10)
+	chunks := generateChunks(t, 20, 5, 10)
 	prev := uint32(10)
 	for _, chunk := range chunks {
 		ccm.Add(prev, chunk)
@@ -74,7 +74,7 @@ func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
 func TestAddingChunksAtOnceAndQueryingThem(t *testing.T) {
 	mkey, ccm := initMetric(t, 10, 10)
 	amkey := schema.AMKey{MKey: mkey, Archive: 0}
-	chunks := generateChunks(t, 20, 100, 10)
+	chunks := generateChunks(t, 20, 5, 10)
 	prev := uint32(10)
 	ccm.AddRange(prev, chunks)
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -44,7 +44,7 @@ func BenchmarkAddingManyChunksAtOnce(b *testing.B) {
 	chunks := generateChunks(b, 20, uint32(b.N), 10)
 	prev := uint32(1)
 	b.ResetTimer()
-	ccm.AddSlice(prev, chunks)
+	ccm.AddRange(prev, chunks)
 }
 
 func TestAddingChunksOneByOneAndQueryingThem(t *testing.T) {
@@ -76,7 +76,7 @@ func TestAddingChunksAtOnceAndQueryingThem(t *testing.T) {
 	amkey := schema.AMKey{MKey: mkey, Archive: 0}
 	chunks := generateChunks(t, 20, 100, 10)
 	prev := uint32(10)
-	ccm.AddSlice(prev, chunks)
+	ccm.AddRange(prev, chunks)
 
 	res := CCSearchResult{}
 	ccm.Search(test.NewContext(), amkey, &res, 25, 45)

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -11,14 +11,16 @@ import (
 )
 
 // getItgen returns an IterGen which holds a chunk which has directly encoded all values
+// it assumes the data has step=1, deriving the span as len(values)
 func getItgen(t testing.TB, values []uint32, ts uint32, spanaware bool) chunk.IterGen {
 	var b []byte
 	buf := new(bytes.Buffer)
 	if spanaware {
 		binary.Write(buf, binary.LittleEndian, uint8(chunk.FormatStandardGoTszWithSpan))
-		spanCode, ok := chunk.RevChunkSpans[uint32(len(values))]
+		span := uint32(len(values))
+		spanCode, ok := chunk.RevChunkSpans[span]
 		if !ok {
-			t.Fatalf("invalid chunk span provided (%d)", len(values))
+			t.Fatalf("invalid chunk span provided (%d)", span)
 		}
 		binary.Write(buf, binary.LittleEndian, spanCode)
 	} else {

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // getItgen returns an IterGen which holds a chunk which has directly encoded all values
-func getItgen(t *testing.T, values []uint32, ts uint32, spanaware bool) chunk.IterGen {
+func getItgen(t testing.TB, values []uint32, ts uint32, spanaware bool) chunk.IterGen {
 	var b []byte
 	buf := new(bytes.Buffer)
 	if spanaware {

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -68,7 +68,7 @@ func TestAddIfHotWithoutPrevTsOnHotMetric(t *testing.T) {
 	cc.Add(metric, 0, itgen1)
 	cc.Add(metric, 1000, itgen2)
 
-	cc.CacheIfHot(metric, 0, itgen3)
+	cc.AddIfHot(metric, 0, itgen3)
 
 	mc := cc.metricCache[metric]
 
@@ -101,7 +101,7 @@ func TestAddIfHotWithoutPrevTsOnColdMetric(t *testing.T) {
 
 	cc.Add(metric, 0, itgen1)
 
-	cc.CacheIfHot(metric, 0, itgen3)
+	cc.AddIfHot(metric, 0, itgen3)
 
 	mc := cc.metricCache[metric]
 
@@ -128,7 +128,7 @@ func TestAddIfHotWithPrevTsOnHotMetric(t *testing.T) {
 	cc.Add(metric, 0, itgen1)
 	cc.Add(metric, 1000, itgen2)
 
-	cc.CacheIfHot(metric, 1005, itgen3)
+	cc.AddIfHot(metric, 1005, itgen3)
 
 	mc := cc.metricCache[metric]
 
@@ -161,7 +161,7 @@ func TestAddIfHotWithPrevTsOnColdMetric(t *testing.T) {
 
 	cc.Add(metric, 0, itgen1)
 
-	cc.CacheIfHot(metric, 1005, itgen3)
+	cc.AddIfHot(metric, 1005, itgen3)
 
 	mc := cc.metricCache[metric]
 

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -9,8 +9,8 @@ import (
 
 type Cache interface {
 	Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
+	AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 	AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen)
-	CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 	Stop()
 	Search(ctx context.Context, metric schema.AMKey, from, until uint32) (*CCSearchResult, error)
 	DelMetric(rawMetric schema.MKey) (int, int)
@@ -18,7 +18,7 @@ type Cache interface {
 }
 
 type CachePusher interface {
-	CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
+	AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 }
 
 type CCSearchResult struct {

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -9,6 +9,7 @@ import (
 
 type Cache interface {
 	Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
+	AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen)
 	CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 	Stop()
 	Search(ctx context.Context, metric schema.AMKey, from, until uint32) (*CCSearchResult, error)


### PR DESCRIPTION
@Dieterbe Looks like quite a major difference, although I still need to verify that the result is really the same and I'm not creating any corruption:

```
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ go test github.com/grafana/metrictank/mdata/cache  -bench BenchmarkAddingManyChunks
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/mdata/cache
BenchmarkAddingManyChunksOneByOne-8   	   10000	    816636 ns/op
BenchmarkAddingManyChunksAtOnce-8     	 2000000	       671 ns/op
PASS
ok  	github.com/grafana/metrictank/mdata/cache	11.255s
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ 
```

Will also deduplicate the `Add()` and `AddSlice()` methods, currently there's a lot of duplication between these two