### PR TITLE
chunk cache perf fixes: AddRange + batched accounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 default:
 	$(MAKE) all
 test:
-	CGO_ENABLED=1 go test -v -race $(shell go list ./... | grep -v /vendor/ | grep -v chaos)
+	CGO_ENABLED=1 go test -v -race $(shell go list ./... | grep -v /vendor/ | grep -v stacktest)
 check:
 	$(MAKE) test
 bin:

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -362,7 +362,7 @@ func (a *AggMetric) pushToCache(c *chunk.Chunk) {
 		return
 	}
 	// push into cache
-	go a.cachePusher.CacheIfHot(
+	go a.cachePusher.AddIfHot(
 		a.Key,
 		0,
 		*chunk.NewBareIterGen(

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -126,7 +126,7 @@ func testMetricPersistOptionalPrimary(t *testing.T, primary bool) {
 	calledCb := make(chan bool)
 
 	mockCache := cache.MockCache{}
-	mockCache.CacheIfHotCb = func() { calledCb <- true }
+	mockCache.AddIfHotCb = func() { calledCb <- true }
 
 	numChunks, chunkAddCount, chunkSpan := uint32(5), uint32(10), uint32(300)
 	ret := []conf.Retention{conf.NewRetentionMT(1, 1, chunkSpan, numChunks, true)}

--- a/mdata/cache/accnt/flat_accnt.go
+++ b/mdata/cache/accnt/flat_accnt.go
@@ -137,6 +137,9 @@ func (a *FlatAccnt) HitChunk(metric schema.AMKey, ts uint32) {
 	a.act(evnt_hit_chnk, &HitPayload{metric, ts})
 }
 func (a *FlatAccnt) HitChunks(metric schema.AMKey, chunks []chunk.IterGen) {
+	if len(chunks) == 0 {
+		return
+	}
 	a.act(evnt_hit_chnks, &HitsPayload{metric, chunks})
 }
 

--- a/mdata/cache/accnt/flat_accnt.go
+++ b/mdata/cache/accnt/flat_accnt.go
@@ -3,6 +3,7 @@ package accnt
 import (
 	"sort"
 
+	"github.com/grafana/metrictank/mdata/chunk"
 	"github.com/raintank/worldping-api/pkg/log"
 	"gopkg.in/raintank/schema.v1"
 )
@@ -47,18 +48,23 @@ type FlatAccntMet struct {
 	chunks map[uint32]uint64
 }
 
-// event types to be used in FlatAccntEvent
-const evnt_hit_chnk uint8 = 4
-const evnt_add_chnk uint8 = 5
-const evnt_del_met uint8 = 6
-const evnt_get_total uint8 = 7
-const evnt_stop uint8 = 100
-const evnt_reset uint8 = 101
-
 type FlatAccntEvent struct {
-	t  uint8       // event type
-	pl interface{} // payload
+	eType eventType
+	pl    interface{} // payload
 }
+
+type eventType uint8
+
+const (
+	evnt_hit_chnk eventType = iota
+	evnt_hit_chnks
+	evnt_add_chnk
+	evnt_add_chnks
+	evnt_del_met
+	evnt_get_total
+	evnt_stop
+	evnt_reset
+)
 
 // payload to be sent with an add event
 type AddPayload struct {
@@ -67,10 +73,22 @@ type AddPayload struct {
 	size   uint64
 }
 
+// payload to be sent with an add event
+type AddsPayload struct {
+	metric schema.AMKey
+	chunks []chunk.IterGen
+}
+
 // payload to be sent with a hit event
 type HitPayload struct {
 	metric schema.AMKey
 	ts     uint32
+}
+
+// payload to be sent with a hits event
+type HitsPayload struct {
+	metric schema.AMKey
+	chunks []chunk.IterGen
 }
 
 // payload to be sent with del metric event
@@ -111,8 +129,15 @@ func (a *FlatAccnt) AddChunk(metric schema.AMKey, ts uint32, size uint64) {
 	a.act(evnt_add_chnk, &AddPayload{metric, ts, size})
 }
 
+func (a *FlatAccnt) AddChunks(metric schema.AMKey, chunks []chunk.IterGen) {
+	a.act(evnt_add_chnks, &AddsPayload{metric, chunks})
+}
+
 func (a *FlatAccnt) HitChunk(metric schema.AMKey, ts uint32) {
 	a.act(evnt_hit_chnk, &HitPayload{metric, ts})
+}
+func (a *FlatAccnt) HitChunks(metric schema.AMKey, chunks []chunk.IterGen) {
+	a.act(evnt_hit_chnks, &HitsPayload{metric, chunks})
 }
 
 func (a *FlatAccnt) Stop() {
@@ -123,10 +148,10 @@ func (a *FlatAccnt) Reset() {
 	a.act(evnt_reset, nil)
 }
 
-func (a *FlatAccnt) act(t uint8, payload interface{}) {
+func (a *FlatAccnt) act(eType eventType, payload interface{}) {
 	event := FlatAccntEvent{
-		t:  t,
-		pl: payload,
+		eType: eType,
+		pl:    payload,
 	}
 
 	select {
@@ -141,7 +166,7 @@ func (a *FlatAccnt) eventLoop() {
 	for {
 		select {
 		case event := <-a.eventQ:
-			switch event.t {
+			switch event.eType {
 			case evnt_add_chnk:
 				payload := event.pl.(*AddPayload)
 				a.add(payload.metric, payload.ts, payload.size)
@@ -152,6 +177,18 @@ func (a *FlatAccnt) eventLoop() {
 						Ts:     payload.ts,
 					},
 				)
+			case evnt_add_chnks:
+				payload := event.pl.(*AddsPayload)
+				a.addRange(payload.metric, payload.chunks)
+				cacheChunkAdd.Add(len(payload.chunks))
+				for _, chunk := range payload.chunks {
+					a.lru.touch(
+						EvictTarget{
+							Metric: payload.metric,
+							Ts:     chunk.Ts,
+						},
+					)
+				}
 			case evnt_hit_chnk:
 				payload := event.pl.(*HitPayload)
 				a.lru.touch(
@@ -160,6 +197,16 @@ func (a *FlatAccnt) eventLoop() {
 						Ts:     payload.ts,
 					},
 				)
+			case evnt_hit_chnks:
+				payload := event.pl.(*HitsPayload)
+				for _, chunk := range payload.chunks {
+					a.lru.touch(
+						EvictTarget{
+							Metric: payload.metric,
+							Ts:     chunk.Ts,
+						},
+					)
+				}
 			case evnt_del_met:
 				payload := event.pl.(*DelMetPayload)
 				a.delMet(payload.metric)
@@ -226,6 +273,35 @@ func (a *FlatAccnt) add(metric schema.AMKey, ts uint32, size uint64) {
 	met.chunks[ts] = size
 	met.total = met.total + size
 	cacheSizeUsed.AddUint64(size)
+}
+
+func (a *FlatAccnt) addRange(metric schema.AMKey, chunks []chunk.IterGen) {
+	var met *FlatAccntMet
+	var ok bool
+
+	if met, ok = a.metrics[metric]; !ok {
+		met = &FlatAccntMet{
+			total:  0,
+			chunks: make(map[uint32]uint64),
+		}
+		a.metrics[metric] = met
+		cacheMetricAdd.Inc()
+	}
+
+	var sizeDiff uint64
+
+	for _, chunk := range chunks {
+		if _, ok = met.chunks[chunk.Ts]; ok {
+			// we already have that chunk
+			continue
+		}
+		size := chunk.Size()
+		sizeDiff += size
+		met.chunks[chunk.Ts] = size
+	}
+
+	met.total = met.total + sizeDiff
+	cacheSizeUsed.AddUint64(sizeDiff)
 }
 
 func (a *FlatAccnt) evict() {

--- a/mdata/cache/accnt/if.go
+++ b/mdata/cache/accnt/if.go
@@ -1,6 +1,9 @@
 package accnt
 
-import "gopkg.in/raintank/schema.v1"
+import (
+	"github.com/grafana/metrictank/mdata/chunk"
+	"gopkg.in/raintank/schema.v1"
+)
 
 // Accnt represents an instance of cache accounting.
 // Currently there is only one implementation called `FlatAccnt`,
@@ -9,7 +12,9 @@ import "gopkg.in/raintank/schema.v1"
 type Accnt interface {
 	GetEvictQ() chan *EvictTarget
 	AddChunk(metric schema.AMKey, ts uint32, size uint64)
+	AddChunks(metric schema.AMKey, chunks []chunk.IterGen)
 	HitChunk(metric schema.AMKey, ts uint32)
+	HitChunks(metric schema.AMKey, chunks []chunk.IterGen)
 	DelMetric(metric schema.AMKey)
 	Stop()
 	Reset()

--- a/mdata/cache/accnt/lru.go
+++ b/mdata/cache/accnt/lru.go
@@ -5,8 +5,8 @@ import (
 )
 
 type LRU struct {
-	list  *list.List
-	items map[interface{}]*list.Element
+	list  *list.List                    // the actual queue in which we move items around to represent their used time
+	items map[interface{}]*list.Element // to find entries within the LRU so we can move them to the front
 }
 
 func NewLRU() *LRU {

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -31,6 +31,12 @@ func (mc *MockCache) Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen
 	mc.AddCount++
 }
 
+func (mc *MockCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen) {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.AddCount += len(itergens)
+}
+
 func (mc *MockCache) CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -11,8 +11,8 @@ import (
 type MockCache struct {
 	sync.Mutex
 	AddCount          int
-	CacheIfHotCount   int
-	CacheIfHotCb      func()
+	AddIfHotCount     int
+	AddIfHotCb        func()
 	StopCount         int
 	SearchCount       int
 	DelMetricArchives int
@@ -37,12 +37,12 @@ func (mc *MockCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk
 	mc.AddCount += len(itergens)
 }
 
-func (mc *MockCache) CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
+func (mc *MockCache) AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()
-	mc.CacheIfHotCount++
-	if mc.CacheIfHotCb != nil {
-		mc.CacheIfHotCb()
+	mc.AddIfHotCount++
+	if mc.AddIfHotCb != nil {
+		mc.AddIfHotCb()
 	}
 }
 

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -202,9 +202,7 @@ func (c *CCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk.Ite
 		ccm.AddRange(prev, itergens)
 	}
 
-	for _, itergen := range itergens {
-		c.accnt.AddChunk(metric, itergen.Ts, itergen.Size())
-	}
+	c.accnt.AddChunks(metric, itergens)
 }
 
 func (cc *CCache) Reset() (int, int) {
@@ -293,12 +291,8 @@ func (c *CCache) Search(ctx context.Context, metric schema.AMKey, from, until ui
 
 		accnt.CacheChunkHit.Add(len(res.Start) + len(res.End))
 		go func() {
-			for _, hit := range res.Start {
-				c.accnt.HitChunk(metric, hit.Ts)
-			}
-			for _, hit := range res.End {
-				c.accnt.HitChunk(metric, hit.Ts)
-			}
+			c.accnt.HitChunks(metric, res.Start)
+			c.accnt.HitChunks(metric, res.End)
 		}()
 
 		if res.Complete {

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -116,7 +116,7 @@ func (c *CCache) DelMetric(rawMetric schema.MKey) (int, int) {
 }
 
 // adds the given chunk to the cache, but only if the metric is sufficiently hot
-func (c *CCache) CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
+func (c *CCache) AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	if c == nil {
 		return
 	}

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -154,8 +154,8 @@ func (c *CCache) Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 
 	ccm, ok := c.metricCache[metric]
 	if !ok {
-		ccm = NewCCacheMetric()
-		ccm.Init(metric.MKey, prev, itergen)
+		ccm = NewCCacheMetric(metric.MKey)
+		ccm.Add(prev, itergen)
 		c.metricCache[metric] = ccm
 
 		// if we do not have this raw key yet, create the entry with the association
@@ -184,11 +184,8 @@ func (c *CCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk.Ite
 
 	ccm, ok := c.metricCache[metric]
 	if !ok {
-		ccm = NewCCacheMetric()
-		ccm.Init(metric.MKey, prev, itergens[0])
-		if len(itergens) > 1 {
-			ccm.AddRange(itergens[0].Ts, itergens[1:])
-		}
+		ccm = NewCCacheMetric(metric.MKey)
+		ccm.AddRange(prev, itergens)
 		c.metricCache[metric] = ccm
 
 		// if we do not have this raw key yet, create the entry with the association

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -26,15 +26,11 @@ type CCacheMetric struct {
 }
 
 // NewCCacheMetric creates a CCacheMetric
-func NewCCacheMetric() *CCacheMetric {
+func NewCCacheMetric(mkey schema.MKey) *CCacheMetric {
 	return &CCacheMetric{
+		MKey:   mkey,
 		chunks: make(map[uint32]*CCacheChunk),
 	}
-}
-
-func (mc *CCacheMetric) Init(MKey schema.MKey, prev uint32, itergen chunk.IterGen) {
-	mc.Add(prev, itergen)
-	mc.MKey = MKey
 }
 
 // Del deletes chunks for the given timestamp

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -128,8 +128,8 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 
 	// handle the 2nd until the last-but-one
 	for i := 1; i < len(itergens)-1; i++ {
-		itergen := itergens[i]
-		ts := itergen.Ts
+		itergen = itergens[i]
+		ts = itergen.Ts
 		// add chunk if we don't have it yet (most likely)
 		if _, ok := mc.chunks[ts]; !ok {
 			chunks = append(chunks, CCacheChunk{

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -122,6 +122,8 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 		})
 		mc.chunks[ts] = &chunks[len(chunks)-1]
 		mc.keys = append(mc.keys, ts)
+	} else {
+		mc.chunks[ts].Next = itergens[1].Ts
 	}
 
 	prev = ts
@@ -130,17 +132,16 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 	for i := 1; i < len(itergens)-1; i++ {
 		itergen = itergens[i]
 		ts = itergen.Ts
-		// add chunk if we don't have it yet (most likely)
-		if _, ok := mc.chunks[ts]; !ok {
-			chunks = append(chunks, CCacheChunk{
-				Ts:    ts,
-				Prev:  prev,
-				Next:  itergens[i+1].Ts,
-				Itgen: itergen,
-			})
-			mc.chunks[ts] = &chunks[len(chunks)-1]
-			mc.keys = append(mc.keys, ts)
-		}
+		// add chunk, potentially overwriting pre-existing chunk (unlikely)
+		chunks = append(chunks, CCacheChunk{
+			Ts:    ts,
+			Prev:  prev,
+			Next:  itergens[i+1].Ts,
+			Itgen: itergen,
+		})
+		mc.chunks[ts] = &chunks[len(chunks)-1]
+		mc.keys = append(mc.keys, ts)
+
 		prev = ts
 	}
 

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -69,6 +69,70 @@ func (mc *CCacheMetric) Del(ts uint32) int {
 	return len(mc.chunks)
 }
 
+// AddRange adds a range (sequence) of chunks.
+// Note the following requirements:
+// the sequence should be in ascending timestamp order
+// the sequence should be complete (no gaps)
+func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
+	if len(itergens) == 0 {
+		return
+	}
+
+	mc.Lock()
+	defer mc.Unlock()
+
+	ts := itergens[0].Ts
+
+	// if previous chunk has not been passed we try to be smart and figure it out.
+	// this is common in a scenario where a metric continuously gets queried
+	// for a range that starts less than one chunkspan before now().
+	if prev == 0 {
+		res, ok := mc.seekDesc(ts - 1)
+		if ok {
+			prev = res
+		}
+	}
+
+	for _, itergen := range itergens {
+		ts = itergen.Ts
+
+		if _, ok := mc.chunks[ts]; ok {
+			// chunk is already present. no need to error on that, just ignore it
+			continue
+		}
+
+		mc.chunks[ts] = &CCacheChunk{
+			Ts:    ts,
+			Prev:  0,
+			Next:  0,
+			Itgen: itergen,
+		}
+
+		// if the previous chunk is cached, link in both directions
+		if _, ok := mc.chunks[prev]; ok {
+			mc.chunks[prev].Next = ts
+			mc.chunks[ts].Prev = prev
+		}
+		prev = ts
+	}
+
+	nextTs := mc.nextTs(ts)
+
+	// if nextTs() can't figure out the end date it returns ts
+	if nextTs > ts {
+		// if the next chunk is cached, link in both directions
+		if _, ok := mc.chunks[nextTs]; ok {
+			mc.chunks[nextTs].Prev = ts
+			mc.chunks[ts].Next = nextTs
+		}
+	}
+
+	// regenerate the list of sorted keys after adding a chunk
+	mc.generateKeys()
+
+	return
+}
+
 func (mc *CCacheMetric) Add(prev uint32, itergen chunk.IterGen) {
 	ts := itergen.Ts
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -21,8 +21,7 @@ func generateChunks(b testing.TB, startAt, count, step uint32) []chunk.IterGen {
 
 func getCCM() (schema.AMKey, *CCacheMetric) {
 	amkey, _ := schema.AMKeyFromString("1.12345678901234567890123456789012")
-	ccm := NewCCacheMetric()
-	ccm.MKey = amkey.MKey
+	ccm := NewCCacheMetric(amkey.MKey)
 	return amkey, ccm
 }
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -1,0 +1,190 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/grafana/metrictank/mdata/chunk"
+	"github.com/grafana/metrictank/test"
+	"gopkg.in/raintank/schema.v1"
+)
+
+func generateChunks(b testing.TB, startAt, count, step uint32) []chunk.IterGen {
+	res := make([]chunk.IterGen, 0, count)
+
+	values := make([]uint32, step)
+	for t0 := startAt; t0 < startAt+(step*uint32(count)); t0 += step {
+		c := getItgen(b, values, t0, true)
+		res = append(res, c)
+	}
+	return res
+}
+
+func getCCM() (schema.AMKey, *CCacheMetric) {
+	amkey, _ := schema.AMKeyFromString("1.12345678901234567890123456789012")
+	ccm := NewCCacheMetric()
+	ccm.MKey = amkey.MKey
+	return amkey, ccm
+}
+
+// TestAddAsc tests adding ascending timestamp chunks individually
+func TestAddAsc(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		prev := uint32(1)
+		for _, chunk := range chunks {
+			ccm.Add(prev, chunk)
+			prev = chunk.Ts
+		}
+	})
+}
+
+// TestAddDesc1 tests adding chunks that are all descending
+func TestAddDesc1(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		for i := len(chunks) - 1; i >= 0; i-- {
+			ccm.Add(0, chunks[i])
+		}
+	})
+}
+
+// TestAddDesc4 tests adding chunks that are globally descending
+// but in groups 4 are ascending
+func TestAddDesc4(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		ccm.Add(0, chunks[2])
+		ccm.Add(0, chunks[3])
+		ccm.Add(0, chunks[4])
+		ccm.Add(0, chunks[5])
+		ccm.Add(0, chunks[0])
+		ccm.Add(0, chunks[1])
+	})
+}
+
+// TestAddRange tests adding a contiguous range at once
+func TestAddRange(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		prev := uint32(10)
+		ccm.AddRange(prev, chunks)
+	})
+}
+
+// TestAddRangeDesc4 benchmarks adding chunks that are globally descending
+// but in groups of 4 are ascending. those groups are added via 1 AddRange.
+func TestAddRangeDesc4(t *testing.T) {
+	testRun(t, func(ccm *CCacheMetric) {
+		chunks := generateChunks(t, 10, 6, 10)
+		ccm.AddRange(0, chunks[2:6])
+		ccm.AddRange(0, chunks[0:2])
+	})
+}
+
+// test executes the run function
+// run should generate chunks and add them to the CCacheMetric however it likes,
+// but in a way so that the result will be as expected
+func testRun(t *testing.T, run func(*CCacheMetric)) {
+	amkey, ccm := getCCM()
+
+	run(ccm)
+
+	res := CCSearchResult{}
+	ccm.Search(test.NewContext(), amkey, &res, 25, 45)
+	if res.Complete != true {
+		t.Fatalf("Expected result to be complete, but it was not")
+	}
+
+	if res.Start[0].Ts != 20 {
+		t.Fatalf("Expected result to start at 20, but had %d", res.Start[0].Ts)
+	}
+
+	if res.Start[len(res.Start)-1].Ts != 40 {
+		t.Fatalf("Expected result to start at 40, but had %d", res.Start[len(res.Start)-1].Ts)
+	}
+}
+
+// BenchmarkAddAsc benchmarks adding ascending timestamp chunks individually
+func BenchmarkAddAsc(b *testing.B) {
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	prev := uint32(1)
+	b.ResetTimer()
+	for _, chunk := range chunks {
+		ccm.Add(prev, chunk)
+		prev = chunk.Ts
+	}
+}
+
+// BenchmarkAddDesc1 benchmarks adding chunks that are all descending
+func BenchmarkAddDesc1(b *testing.B) {
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 1; i >= 0; i-- {
+		ccm.Add(0, chunks[i])
+	}
+}
+
+// BenchmarkAddDesc4 benchmarks adding chunks that are globally descending
+// but in groups 4 are ascending
+func BenchmarkAddDesc4(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 4)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 4; i >= 0; i -= 4 {
+		ccm.Add(0, chunks[i])
+		ccm.Add(0, chunks[i+1])
+		ccm.Add(0, chunks[i+2])
+		ccm.Add(0, chunks[i+3])
+	}
+}
+
+// BenchmarkAddDesc64 benchmarks adding chunks that are globally descending
+// but in groups 64 are ascending
+func BenchmarkAddDesc64(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 64)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 64; i >= 0; i -= 64 {
+		for offset := 0; offset < 64; offset += 1 {
+			ccm.Add(0, chunks[i+offset])
+		}
+	}
+
+}
+
+// BenchmarkAddRangeAsc benchmarks adding a contiguous range at once
+func BenchmarkAddRangeAsc(b *testing.B) {
+	_, ccm := getCCM()
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	prev := uint32(1)
+	b.ResetTimer()
+	ccm.AddRange(prev, chunks)
+}
+
+// BenchmarkAddRangeDesc4 benchmarks adding chunks that are globally descending
+// but in groups 4 are ascending. those groups are added via 1 AddRange.
+func BenchmarkAddRangeDesc4(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 4)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 4; i >= 0; i -= 4 {
+		ccm.AddRange(0, chunks[i:i+4])
+	}
+}
+
+// BenchmarkAddRangeDesc64 benchmarks adding chunks that are globally descending
+// but in groups 64 are ascending. those groups are added via 1 AddRange.
+func BenchmarkAddRangeDesc64(b *testing.B) {
+	_, ccm := getCCM()
+	b.N = b.N - (b.N % 64)
+	chunks := generateChunks(b, 10, uint32(b.N), 10)
+	b.ResetTimer()
+	for i := len(chunks) - 64; i >= 0; i -= 64 {
+		ccm.AddRange(0, chunks[i:i+64])
+	}
+}

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -11,14 +11,16 @@ import (
 )
 
 // getItgen returns an IterGen which holds a chunk which has directly encoded all values
+// it assumes the data has step=1, deriving the span as len(values)
 func getItgen(t testing.TB, values []uint32, ts uint32, spanaware bool) chunk.IterGen {
 	var b []byte
 	buf := new(bytes.Buffer)
 	if spanaware {
 		binary.Write(buf, binary.LittleEndian, uint8(chunk.FormatStandardGoTszWithSpan))
-		spanCode, ok := chunk.RevChunkSpans[uint32(len(values))]
+		span := uint32(len(values))
+		spanCode, ok := chunk.RevChunkSpans[span]
 		if !ok {
-			t.Fatalf("invalid chunk span provided (%d)", len(values))
+			t.Fatalf("invalid chunk span provided (%d)", span)
 		}
 		binary.Write(buf, binary.LittleEndian, spanCode)
 	} else {

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // getItgen returns an IterGen which holds a chunk which has directly encoded all values
-func getItgen(t *testing.T, values []uint32, ts uint32, spanaware bool) chunk.IterGen {
+func getItgen(t testing.TB, values []uint32, ts uint32, spanaware bool) chunk.IterGen {
 	var b []byte
 	buf := new(bytes.Buffer)
 	if spanaware {

--- a/mdata/cache/ccache_test.go
+++ b/mdata/cache/ccache_test.go
@@ -68,7 +68,7 @@ func TestAddIfHotWithoutPrevTsOnHotMetric(t *testing.T) {
 	cc.Add(metric, 0, itgen1)
 	cc.Add(metric, 1000, itgen2)
 
-	cc.CacheIfHot(metric, 0, itgen3)
+	cc.AddIfHot(metric, 0, itgen3)
 
 	mc := cc.metricCache[metric]
 
@@ -101,7 +101,7 @@ func TestAddIfHotWithoutPrevTsOnColdMetric(t *testing.T) {
 
 	cc.Add(metric, 0, itgen1)
 
-	cc.CacheIfHot(metric, 0, itgen3)
+	cc.AddIfHot(metric, 0, itgen3)
 
 	mc := cc.metricCache[metric]
 
@@ -128,7 +128,7 @@ func TestAddIfHotWithPrevTsOnHotMetric(t *testing.T) {
 	cc.Add(metric, 0, itgen1)
 	cc.Add(metric, 1000, itgen2)
 
-	cc.CacheIfHot(metric, 1005, itgen3)
+	cc.AddIfHot(metric, 1005, itgen3)
 
 	mc := cc.metricCache[metric]
 
@@ -161,7 +161,7 @@ func TestAddIfHotWithPrevTsOnColdMetric(t *testing.T) {
 
 	cc.Add(metric, 0, itgen1)
 
-	cc.CacheIfHot(metric, 1005, itgen3)
+	cc.AddIfHot(metric, 1005, itgen3)
 
 	mc := cc.metricCache[metric]
 

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -9,8 +9,8 @@ import (
 
 type Cache interface {
 	Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
+	AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 	AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen)
-	CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 	Stop()
 	Search(ctx context.Context, metric schema.AMKey, from, until uint32) (*CCSearchResult, error)
 	DelMetric(rawMetric schema.MKey) (int, int)
@@ -18,7 +18,7 @@ type Cache interface {
 }
 
 type CachePusher interface {
-	CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
+	AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 }
 
 type CCSearchResult struct {

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -9,6 +9,7 @@ import (
 
 type Cache interface {
 	Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
+	AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen)
 	CacheIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 	Stop()
 	Search(ctx context.Context, metric schema.AMKey, from, until uint32) (*CCSearchResult, error)


### PR DESCRIPTION
replaces #940

going from the old Add implementation to the new AddRange implementation
```
benchcmp pre.txt post7.txt
benchmark                   old ns/op     new ns/op     delta
BenchmarkAddAsc             1223930       1111          -99.91%
BenchmarkAddDesc1           1449968       707682        -51.19%
BenchmarkAddDesc4           1450317       708973        -51.12%
BenchmarkAddDesc64          1446361       705477        -51.22%
BenchmarkAddRangeAsc        1124          406           -63.88%
BenchmarkAddRangeDesc4      362446        196523        -45.78%
BenchmarkAddRangeDesc64     278462        157809        -43.33%

benchmark                   old allocs     new allocs     delta
BenchmarkAddAsc             5              3              -40.00%
BenchmarkAddDesc1           7              6              -14.29%
BenchmarkAddDesc4           9              8              -11.11%
BenchmarkAddDesc64          9              8              -11.11%
BenchmarkAddRangeAsc        1              0              -100.00%
BenchmarkAddRangeDesc4      2              1              -50.00%
BenchmarkAddRangeDesc64     1              0              -100.00%

benchmark                   old bytes     new bytes     delta
BenchmarkAddAsc             21684         145           -99.33%
BenchmarkAddDesc1           21720         191           -99.12%
BenchmarkAddDesc4           21729         199           -99.08%
BenchmarkAddDesc64          21701         202           -99.07%
BenchmarkAddRangeAsc        118           123           +4.24%
BenchmarkAddRangeDesc4      5503          132           -97.60%
BenchmarkAddRangeDesc64     3276          115           -96.49%
```