### PR TITLE
log response sizes for all response types

### DIFF
--- a/api/response/fast_json_test.go
+++ b/api/response/fast_json_test.go
@@ -33,9 +33,11 @@ func BenchmarkHttpRespFastJsonEmptySeries(b *testing.B) {
 	var resp *FastJson
 	for n := 0; n < b.N; n++ {
 		resp = NewFastJson(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespFastJsonEmptySeriesNeedsEscaping(b *testing.B) {
@@ -49,9 +51,11 @@ func BenchmarkHttpRespFastJsonEmptySeriesNeedsEscaping(b *testing.B) {
 	var resp *FastJson
 	for n := 0; n < b.N; n++ {
 		resp = NewFastJson(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespFastJsonIntegers(b *testing.B) {
@@ -73,9 +77,11 @@ func BenchmarkHttpRespFastJsonIntegers(b *testing.B) {
 	var resp *FastJson
 	for n := 0; n < b.N; n++ {
 		resp = NewFastJson(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 func BenchmarkHttpRespFastJsonFloats(b *testing.B) {
 	points := make([]schema.Point, 1000, 1000)
@@ -96,9 +102,11 @@ func BenchmarkHttpRespFastJsonFloats(b *testing.B) {
 	var resp *FastJson
 	for n := 0; n < b.N; n++ {
 		resp = NewFastJson(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 func BenchmarkHttpRespFastJsonNulls(b *testing.B) {
 	points := make([]schema.Point, 1000, 1000)
@@ -119,9 +127,11 @@ func BenchmarkHttpRespFastJsonNulls(b *testing.B) {
 	var resp *FastJson
 	for n := 0; n < b.N; n++ {
 		resp = NewFastJson(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespFastJson1MMetricNames(b *testing.B) {
@@ -133,9 +143,11 @@ func BenchmarkHttpRespFastJson1MMetricNames(b *testing.B) {
 	var resp *FastJson
 	for n := 0; n < b.N; n++ {
 		resp = NewFastJson(200, models.MetricNames(series))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespFastJson1MMetricNamesNeedEscaping(b *testing.B) {
@@ -147,7 +159,9 @@ func BenchmarkHttpRespFastJson1MMetricNamesNeedEscaping(b *testing.B) {
 	var resp *FastJson
 	for n := 0; n < b.N; n++ {
 		resp = NewFastJson(200, models.MetricNames(series))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }

--- a/api/response/init_test.go
+++ b/api/response/init_test.go
@@ -1,0 +1,3 @@
+package response
+
+var size int

--- a/api/response/json_test.go
+++ b/api/response/json_test.go
@@ -33,9 +33,11 @@ func BenchmarkHttpRespJsonEmptySeries(b *testing.B) {
 	var resp *Json
 	for n := 0; n < b.N; n++ {
 		resp = NewJson(200, models.SeriesByTarget(data), "")
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespJsonEmptySeriesNeedsEscaping(b *testing.B) {
@@ -49,9 +51,11 @@ func BenchmarkHttpRespJsonEmptySeriesNeedsEscaping(b *testing.B) {
 	var resp *Json
 	for n := 0; n < b.N; n++ {
 		resp = NewJson(200, models.SeriesByTarget(data), "")
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespJsonIntegers(b *testing.B) {
@@ -73,9 +77,11 @@ func BenchmarkHttpRespJsonIntegers(b *testing.B) {
 	var resp *Json
 	for n := 0; n < b.N; n++ {
 		resp = NewJson(200, models.SeriesByTarget(data), "")
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespJsonFloats(b *testing.B) {
@@ -97,9 +103,11 @@ func BenchmarkHttpRespJsonFloats(b *testing.B) {
 	var resp *Json
 	for n := 0; n < b.N; n++ {
 		resp = NewJson(200, models.SeriesByTarget(data), "")
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespJsonNulls(b *testing.B) {
@@ -121,9 +129,11 @@ func BenchmarkHttpRespJsonNulls(b *testing.B) {
 	var resp *Json
 	for n := 0; n < b.N; n++ {
 		resp = NewJson(200, models.SeriesByTarget(data), "")
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespJson1MMetricNames(b *testing.B) {
@@ -136,9 +146,11 @@ func BenchmarkHttpRespJson1MMetricNames(b *testing.B) {
 	var resp *Json
 	for n := 0; n < b.N; n++ {
 		resp = NewJson(200, models.MetricNames(series), "")
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespJson1MMetricNamesNeedEscaping(b *testing.B) {
@@ -150,7 +162,9 @@ func BenchmarkHttpRespJson1MMetricNamesNeedEscaping(b *testing.B) {
 	var resp *Json
 	for n := 0; n < b.N; n++ {
 		resp = NewJson(200, models.MetricNames(series), "")
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }

--- a/api/response/msgp_test.go
+++ b/api/response/msgp_test.go
@@ -19,9 +19,11 @@ func BenchmarkHttpRespMsgpEmptySeries(b *testing.B) {
 	var resp *Msgp
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgp(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpEmptySeriesNeedsEscaping(b *testing.B) {
@@ -35,9 +37,11 @@ func BenchmarkHttpRespMsgpEmptySeriesNeedsEscaping(b *testing.B) {
 	var resp *Msgp
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgp(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpIntegers(b *testing.B) {
@@ -59,9 +63,11 @@ func BenchmarkHttpRespMsgpIntegers(b *testing.B) {
 	var resp *Msgp
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgp(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpFloats(b *testing.B) {
@@ -83,9 +89,11 @@ func BenchmarkHttpRespMsgpFloats(b *testing.B) {
 	var resp *Msgp
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgp(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpNulls(b *testing.B) {
@@ -107,7 +115,9 @@ func BenchmarkHttpRespMsgpNulls(b *testing.B) {
 	var resp *Msgp
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgp(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }

--- a/api/response/msgpack_test.go
+++ b/api/response/msgpack_test.go
@@ -19,9 +19,11 @@ func BenchmarkHttpRespMsgpackEmptySeries(b *testing.B) {
 	var resp *Msgpack
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgpack(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpackEmptySeriesNeedsEscaping(b *testing.B) {
@@ -35,9 +37,11 @@ func BenchmarkHttpRespMsgpackEmptySeriesNeedsEscaping(b *testing.B) {
 	var resp *Msgpack
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgpack(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpackIntegers(b *testing.B) {
@@ -59,9 +63,11 @@ func BenchmarkHttpRespMsgpackIntegers(b *testing.B) {
 	var resp *Msgpack
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgpack(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpackFloats(b *testing.B) {
@@ -83,9 +89,11 @@ func BenchmarkHttpRespMsgpackFloats(b *testing.B) {
 	var resp *Msgpack
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgpack(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespMsgpackNulls(b *testing.B) {
@@ -107,7 +115,9 @@ func BenchmarkHttpRespMsgpackNulls(b *testing.B) {
 	var resp *Msgpack
 	for n := 0; n < b.N; n++ {
 		resp = NewMsgpack(200, models.SeriesByTarget(data))
-		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }

--- a/api/response/pickle_test.go
+++ b/api/response/pickle_test.go
@@ -20,8 +20,11 @@ func BenchmarkHttpRespPickleEmptySeries(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp = NewPickle(200, models.SeriesByTarget(data))
 		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespPickleEmptySeriesNeedsEscaping(b *testing.B) {
@@ -36,8 +39,11 @@ func BenchmarkHttpRespPickleEmptySeriesNeedsEscaping(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp = NewPickle(200, models.SeriesByTarget(data))
 		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespPickleIntegers(b *testing.B) {
@@ -60,8 +66,11 @@ func BenchmarkHttpRespPickleIntegers(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp = NewPickle(200, models.SeriesByTarget(data))
 		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespPickleFloats(b *testing.B) {
@@ -84,8 +93,11 @@ func BenchmarkHttpRespPickleFloats(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp = NewPickle(200, models.SeriesByTarget(data))
 		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }
 
 func BenchmarkHttpRespPickleNulls(b *testing.B) {
@@ -108,6 +120,9 @@ func BenchmarkHttpRespPickleNulls(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp = NewPickle(200, models.SeriesByTarget(data))
 		resp.Body()
+		body, _ := resp.Body()
+		size = len(body)
 		resp.Close()
 	}
+	b.Log("body size", size)
 }


### PR DESCRIPTION
FWIW on my system:
```
~/g/s/g/g/m/a/response ❯❯❯ go test -bench . -v | uniq
=== RUN   TestFastJson
--- PASS: TestFastJson (0.00s)
=== RUN   TestJson
--- PASS: TestJson (0.00s)
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/api/response
BenchmarkHttpRespFastJsonEmptySeries-8                 	 5000000	       324 ns/op
--- BENCH: BenchmarkHttpRespFastJsonEmptySeries-8
	fast_json_test.go:40: body size 46
BenchmarkHttpRespFastJsonEmptySeriesNeedsEscaping-8    	 5000000	       317 ns/op
--- BENCH: BenchmarkHttpRespFastJsonEmptySeriesNeedsEscaping-8
	fast_json_test.go:58: body size 47
BenchmarkHttpRespFastJsonIntegers-8                    	   20000	     92478 ns/op	 129.76 MB/s
--- BENCH: BenchmarkHttpRespFastJsonIntegers-8
	fast_json_test.go:84: body size 20958
BenchmarkHttpRespFastJsonFloats-8                      	   10000	    175096 ns/op	  68.53 MB/s
--- BENCH: BenchmarkHttpRespFastJsonFloats-8
	fast_json_test.go:109: body size 21724
BenchmarkHttpRespFastJsonNulls-8                       	   50000	     25468 ns/op	 471.16 MB/s
--- BENCH: BenchmarkHttpRespFastJsonNulls-8
	fast_json_test.go:134: body size 18069
BenchmarkHttpRespFastJson1MMetricNames-8               	       1	1326531906 ns/op
--- BENCH: BenchmarkHttpRespFastJson1MMetricNames-8
	fast_json_test.go:150: body size 53888891
BenchmarkHttpRespFastJson1MMetricNamesNeedEscaping-8   	       1	1353419432 ns/op
--- BENCH: BenchmarkHttpRespFastJson1MMetricNamesNeedEscaping-8
	fast_json_test.go:166: body size 56888891
BenchmarkHttpRespJsonEmptySeries-8                     	 1000000	      1255 ns/op
--- BENCH: BenchmarkHttpRespJsonEmptySeries-8
	json_test.go:40: body size 46
BenchmarkHttpRespJsonEmptySeriesNeedsEscaping-8        	 1000000	      1261 ns/op
--- BENCH: BenchmarkHttpRespJsonEmptySeriesNeedsEscaping-8
	json_test.go:58: body size 47
BenchmarkHttpRespJsonIntegers-8                        	    5000	    304243 ns/op	  39.44 MB/s
--- BENCH: BenchmarkHttpRespJsonIntegers-8
	json_test.go:84: body size 20958
BenchmarkHttpRespJsonFloats-8                          	    3000	    376562 ns/op	  31.87 MB/s
--- BENCH: BenchmarkHttpRespJsonFloats-8
	json_test.go:110: body size 21724
BenchmarkHttpRespJsonNulls-8                           	   10000	    196471 ns/op	  61.08 MB/s
--- BENCH: BenchmarkHttpRespJsonNulls-8
	json_test.go:136: body size 18069
BenchmarkHttpRespJson1MMetricNames-8                   	       1	1562120836 ns/op
--- BENCH: BenchmarkHttpRespJson1MMetricNames-8
	json_test.go:153: body size 53888891
BenchmarkHttpRespJson1MMetricNamesNeedEscaping-8       	       1	1700054557 ns/op
--- BENCH: BenchmarkHttpRespJson1MMetricNamesNeedEscaping-8
	json_test.go:169: body size 56888891
BenchmarkHttpRespMsgpEmptySeries-8                     	 5000000	       281 ns/op
--- BENCH: BenchmarkHttpRespMsgpEmptySeries-8
	msgp_test.go:26: body size 109
BenchmarkHttpRespMsgpEmptySeriesNeedsEscaping-8        	 5000000	       272 ns/op
--- BENCH: BenchmarkHttpRespMsgpEmptySeriesNeedsEscaping-8
	msgp_test.go:44: body size 109
BenchmarkHttpRespMsgpIntegers-8                        	  100000	     22003 ns/op	 545.38 MB/s
--- BENCH: BenchmarkHttpRespMsgpIntegers-8
	msgp_test.go:70: body size 22139
BenchmarkHttpRespMsgpFloats-8                          	  100000	     21800 ns/op	 550.44 MB/s
--- BENCH: BenchmarkHttpRespMsgpFloats-8
	msgp_test.go:96: body size 22137
BenchmarkHttpRespMsgpNulls-8                           	  100000	     22615 ns/op	 530.61 MB/s
--- BENCH: BenchmarkHttpRespMsgpNulls-8
	msgp_test.go:122: body size 22136
BenchmarkHttpRespMsgpackEmptySeries-8                  	 5000000	       300 ns/op
--- BENCH: BenchmarkHttpRespMsgpackEmptySeries-8
	msgpack_test.go:26: body size 109
BenchmarkHttpRespMsgpackEmptySeriesNeedsEscaping-8     	 5000000	       295 ns/op
--- BENCH: BenchmarkHttpRespMsgpackEmptySeriesNeedsEscaping-8
	msgpack_test.go:44: body size 109
BenchmarkHttpRespMsgpackIntegers-8                     	  100000	     22468 ns/op	 534.09 MB/s
--- BENCH: BenchmarkHttpRespMsgpackIntegers-8
	msgpack_test.go:70: body size 22139
BenchmarkHttpRespMsgpackFloats-8                       	  100000	     21934 ns/op	 547.09 MB/s
--- BENCH: BenchmarkHttpRespMsgpackFloats-8
	msgpack_test.go:96: body size 22137
BenchmarkHttpRespMsgpackNulls-8                        	  100000	     21903 ns/op	 547.86 MB/s
--- BENCH: BenchmarkHttpRespMsgpackNulls-8
	msgpack_test.go:122: body size 22136
BenchmarkHttpRespPickleEmptySeries-8                   	  300000	      5260 ns/op
--- BENCH: BenchmarkHttpRespPickleEmptySeries-8
	pickle_test.go:27: body size 178
BenchmarkHttpRespPickleEmptySeriesNeedsEscaping-8      	  300000	      5145 ns/op
--- BENCH: BenchmarkHttpRespPickleEmptySeriesNeedsEscaping-8
	pickle_test.go:46: body size 178
BenchmarkHttpRespPickleIntegers-8                      	   10000	    219496 ns/op	  54.67 MB/s
--- BENCH: BenchmarkHttpRespPickleIntegers-8
	pickle_test.go:73: body size 18232
BenchmarkHttpRespPickleFloats-8                        	   10000	    215799 ns/op	  55.61 MB/s
--- BENCH: BenchmarkHttpRespPickleFloats-8
	pickle_test.go:100: body size 18228
BenchmarkHttpRespPickleNulls-8                         	   10000	    131757 ns/op	  91.08 MB/s
--- BENCH: BenchmarkHttpRespPickleNulls-8
	pickle_test.go:127: body size 2226
PASS
ok  	github.com/grafana/metrictank/api/response	54.632s
```