### PR TITLE
Speculative queries

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -304,8 +304,9 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 
 // peerQuerySpeculative takes a request and the path to request it on, then fans it out
 // across the cluster, except to the local peer. If any peer fails requests to
-// other peers are aborted. If 95% of peers have been heard from, and we are missing
-// the others, try to speculatively query ANOTHER member of the shard group.
+// other peers are aborted. If enough peers have been heard from (based on
+// speculation-threshold configuration), and we are missing the others, try to
+// speculatively query other members of the shard group.
 // ctx:          request context
 // data:         request to be submitted
 // name:         name to be used in logging & tracing

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -22,10 +22,10 @@ var NotFoundErr = errors.New("not found")
 
 var (
 
-	// metric api.cluster.speculative.requests is how many peer queries resulted in speculation
+	// metric api.cluster.speculative.attempts is how many peer queries resulted in speculation
 	speculativeAttempts = stats.NewCounter32("api.cluster.speculative.attempts")
 
-	// metric api.cluster.speculative.requests is how many peer queries were improved due to speculation
+	// metric api.cluster.speculative.wins is how many peer queries were improved due to speculation
 	speculativeWins = stats.NewCounter32("api.cluster.speculative.wins")
 
 	// metric api.cluster.speculative.requests is how many speculative http requests made to peers

--- a/api/config.go
+++ b/api/config.go
@@ -29,6 +29,7 @@ var (
 
 	getTargetsConcurrency int
 	tagdbDefaultLimit     uint
+	speculationThreshold  float64
 
 	graphiteProxy *httputil.ReverseProxy
 	timeZone      *time.Location
@@ -50,6 +51,7 @@ func ConfigSetup() {
 	apiCfg.StringVar(&timeZoneStr, "time-zone", "local", "timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone")
 	apiCfg.IntVar(&getTargetsConcurrency, "get-targets-concurrency", 20, "maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.")
 	apiCfg.UintVar(&tagdbDefaultLimit, "tagdb-default-limit", 100, "default limit for tagdb query results, can be overridden with query parameter \"limit\"")
+	apiCfg.Float64Var(&speculationThreshold, "speculation-threshold", 1, "ratio of peer responses after which speculation is used. Set to 1 to disable.")
 	globalconf.Register("http", apiCfg)
 }
 

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -380,6 +380,7 @@ func (c *MemberlistManager) SetPrimary(p bool) {
 
 // set the partitions that this node is handling.
 func (c *MemberlistManager) SetPartitions(part []int32) {
+	sort.Slice(part, func(i, j int) bool { return part[i] < part[j] })
 	c.Lock()
 	node := c.members[c.nodeName]
 	node.Partitions = part
@@ -495,6 +496,7 @@ func (m *SingleNodeManager) Join(peers []string) (int, error) {
 
 // set the partitions that this node is handling.
 func (m *SingleNodeManager) SetPartitions(part []int32) {
+	sort.Slice(part, func(i, j int) bool { return part[i] < part[j] })
 	m.Lock()
 	defer m.Unlock()
 	m.node.Partitions = part

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"sort"
 	"time"
 )
 
@@ -84,6 +85,8 @@ func (c *MockClusterManager) GetPartitions() []int32 {
 }
 
 func (c *MockClusterManager) SetPartitions(partitions []int32) {
+	sort.Slice(partitions, func(i, j int) bool { return partitions[i] < partitions[j] })
+
 	c.partitions = partitions
 }
 

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -165,6 +165,8 @@ time-zone = local
 get-targets-concurrency = 20
 # default limit for tagdb query results, can be overridden with query parameter "limit"
 tagdb-default-limit = 100
+# ratio of peer responses after which speculation is used. Set to 1 to disable.
+speculation-threshold = 1
 
 ## metric data inputs ##
 

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -165,6 +165,8 @@ time-zone = local
 get-targets-concurrency = 20
 # default limit for tagdb query results, can be overridden with query parameter "limit"
 tagdb-default-limit = 100
+# ratio of peer responses after which speculation is used. Set to 1 to disable.
+speculation-threshold = 1
 
 ## metric data inputs ##
 

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -165,6 +165,8 @@ time-zone = local
 get-targets-concurrency = 20
 # default limit for tagdb query results, can be overridden with query parameter "limit"
 tagdb-default-limit = 100
+# ratio of peer responses after which speculation is used. Set to 1 to disable.
+speculation-threshold = 1
 
 ## metric data inputs ##
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -206,6 +206,8 @@ time-zone = local
 get-targets-concurrency = 20
 # default limit for tagdb query results, can be overridden with query parameter "limit"
 tagdb-default-limit = 100
+# ratio of peer responses after which speculation is used. Set to 1 to disable.
+speculation-threshold = 1
 ```
 
 ## metric data inputs ##

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -168,6 +168,8 @@ time-zone = local
 get-targets-concurrency = 20
 # default limit for tagdb query results, can be overridden with query parameter "limit"
 tagdb-default-limit = 100
+# ratio of peer responses after which speculation is used. Set to 1 to disable.
+speculation-threshold = 1
 
 ## metric data inputs ##
 

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -165,6 +165,8 @@ time-zone = local
 get-targets-concurrency = 20
 # default limit for tagdb query results, can be overridden with query parameter "limit"
 tagdb-default-limit = 100
+# ratio of peer responses after which speculation is used. Set to 1 to disable.
+speculation-threshold = 1
 
 ## metric data inputs ##
 

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -165,6 +165,8 @@ time-zone = local
 get-targets-concurrency = 20
 # default limit for tagdb query results, can be overridden with query parameter "limit"
 tagdb-default-limit = 100
+# ratio of peer responses after which speculation is used. Set to 1 to disable.
+speculation-threshold = 1
 
 ## metric data inputs ##
 

--- a/stacktest/tests/end2end_carbon/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon/end2end_carbon_test.go
@@ -64,7 +64,6 @@ func TestStartup(t *testing.T) {
 	matchers := []track.Matcher{
 		{Str: "metrictank.*metricIndex initialized.*starting data consumption$"},
 		{Str: "metrictank.*carbon-in: listening on.*2003"},
-		{Str: "grafana.*HTTP Server Listen.*:3000"},
 	}
 	select {
 	case <-tracker.Match(matchers):


### PR DESCRIPTION
For #954 

I made speculation configurable, but one thing will still change even with speculation disabled: Local requests are now via HTTP rather than a special case. This is good and bad (good: happens in parallel with peer requests and tracing just works, bad: a bit of overhead)

TODO:
- [ ] Figure out partitions / shard group problem
- [x] Some functions (e.g. `findSeries`) don't use `peerQuery`; fix that
- [x] Try to more efficiently pre-allocate memory for initial results
- [x] Documentation

