### PR TITLE
account for the cap() of byte slices in ccache

### DIFF
--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -270,7 +270,7 @@ func (s *Server) insertChunks(table, id string, ttl uint32, itergens []chunk.Ite
 		success := false
 		attempts := 0
 		for !success {
-			err := s.Session.Query(query, rowKey, ig.Ts, cassandraStore.PrepareChunkData(ig.Span, ig.Bytes())).Exec()
+			err := s.Session.Query(query, rowKey, ig.Ts, cassandraStore.PrepareChunkData(ig.Span, ig.B)).Exec()
 			if err != nil {
 				if (attempts % 20) == 0 {
 					log.Warnf("CS: failed to save chunk to cassandra after %d attempts. %s", attempts+1, err)

--- a/mdata/cache/accnt/if.go
+++ b/mdata/cache/accnt/if.go
@@ -11,7 +11,7 @@ import (
 // in the future if they just implement this interface.
 type Accnt interface {
 	GetEvictQ() chan *EvictTarget
-	AddChunk(metric schema.AMKey, ts uint32, size uint64)
+	AddChunk(metric schema.AMKey, ts uint32, len, cap uint64)
 	AddChunks(metric schema.AMKey, chunks []chunk.IterGen)
 	HitChunk(metric schema.AMKey, ts uint32)
 	HitChunks(metric schema.AMKey, chunks []chunk.IterGen)

--- a/mdata/cache/accnt/stats.go
+++ b/mdata/cache/accnt/stats.go
@@ -33,4 +33,5 @@ var (
 
 	cacheSizeMax  = stats.NewGauge64("cache.size.max")
 	cacheSizeUsed = stats.NewGauge64("cache.size.used")
+	cacheCapUsed  = stats.NewGauge64("cache.cap.used")
 )

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -172,7 +172,7 @@ func (c *CCache) Add(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 		ccm.Add(prev, itergen)
 	}
 
-	c.accnt.AddChunk(metric, itergen.Ts, itergen.Size())
+	c.accnt.AddChunk(metric, itergen.Ts, uint64(len(itergen.B)), uint64(cap(itergen.B)))
 }
 
 func (c *CCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk.IterGen) {

--- a/mdata/chunk/itergen.go
+++ b/mdata/chunk/itergen.go
@@ -56,14 +56,6 @@ func (ig *IterGen) Get() (*Iter, error) {
 	return &Iter{it}, nil
 }
 
-func (ig *IterGen) Size() uint64 {
-	return uint64(len(ig.B))
-}
-
-func (ig IterGen) Bytes() []byte {
-	return ig.B
-}
-
 // end of itergen (exclusive)
 func (ig IterGen) EndTs() uint32 {
 	return ig.Ts + ig.Span


### PR DESCRIPTION
We want to know how much memory MT allocates for the cache, so we also need to keep track of the `cap()` of the data in the cache, instead of only tacking `len()`.

To get a really clear picture of how much memory is used for the chunk cache we'll need to add more metrics. Every time a chunk is added to the cache, there's some overhead for it in the data structure of the chunk cache itself, and also in the accounting for it. I think we should add two more metrics, one is keeping track of the overhead of the chunk cache data structure and another one keeps track of the overhead for the accounting itself.