### PR TITLE
Ignore chunk cache on corruption

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -551,6 +551,7 @@ func (s *Server) getSeriesCachedStore(ctx *requestContext, until uint32) ([]chun
 		if cacheRes.From != cacheRes.Until {
 			storeIterGens, err := s.BackendStore.Search(ctx.ctx, ctx.AMKey, ctx.Req.TTL, cacheRes.From, cacheRes.Until)
 			if err != nil {
+				log.Warn("Failed to retrieve data for key = %s", ctx.AMKey.String())
 				return iters, err
 			}
 			// check to see if the request has been canceled, if so abort now.

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -112,7 +112,7 @@ func (mc *CCacheMetric) AddRange(prev uint32, itergens []chunk.IterGen) {
 		}
 
 		// if the previous chunk is cached, link it
-		if (ts - prev) != (itergens[1].Ts - ts) {
+		if prev != 0 && (ts-prev) != (itergens[1].Ts-ts) {
 			log.Warn("CCacheMetric AddRange: Bad prev begin used: key = %s, prev = %d, itergens[0].Ts = %d, itergens[1].Ts = %d",
 				mc.MKey.String(), prev, itergens[0].Ts, itergens[1].Ts)
 			prev = 0

--- a/mdata/cache/ccache_metric.go
+++ b/mdata/cache/ccache_metric.go
@@ -401,15 +401,23 @@ func (mc *CCacheMetric) Search(ctx context.Context, metric schema.AMKey, res *CC
 	}
 
 	if !res.Complete && res.From > res.Until {
-		log.Debug("CCacheMetric Search: Found from > until (%d/%d), printing chunks\n", res.From, res.Until)
-		mc.debugMetric()
+		log.Warn("CCacheMetric Search: Found from > until (%d/%d), printing chunks\n", res.From, res.Until)
+		log.Warn("Bad res = %v", *res)
+		mc.debugMetric(from, until)
+		res.Complete = false
+		res.Start = res.Start[:0]
+		res.End = res.End[:0]
+		res.From = from
+		res.Until = until
 	}
 }
 
-func (mc *CCacheMetric) debugMetric() {
-	log.Debug("CCacheMetric debugMetric: --- debugging metric ---\n")
+func (mc *CCacheMetric) debugMetric(from, until uint32) {
+	log.Warn("CCacheMetric debugMetric: --- debugging metric between %d and %d ---\n", from, until)
 	for _, key := range mc.keys {
-		log.Debug("CCacheMetric debugMetric: ts %d; prev %d; next %d\n", key, mc.chunks[key].Prev, mc.chunks[key].Next)
+		if key >= from && key <= until {
+			log.Warn("CCacheMetric debugMetric: ts %d; prev %d; next %d\n", key, mc.chunks[key].Prev, mc.chunks[key].Next)
+		}
 	}
-	log.Debug("CCacheMetric debugMetric: ------------------------\n")
+	log.Warn("CCacheMetric debugMetric: ------------------------\n")
 }


### PR DESCRIPTION
This is just some minor workaround code that prevents chunk cache corruption from failing requests. It also lets the request "self-heal" as the chunks are added to the cache again when retrieved from cassandra. We've been running it for about a month and it has silenced query failures due to chunk cache corruption.

I also added in some logging when it occurs.

See #967 for details