### PR TITLE
fix logger again

### DIFF
--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -85,14 +85,6 @@ func init() {
 func main() {
 	startupTime = time.Now()
 
-	/***********************************
-		Initialize Logger
-	***********************************/
-	log.NewLogger(0, "console", fmt.Sprintf(`{"level": %d, "formatting":false}`, logLevel))
-
-	/***********************************
-		Initialize Configuration
-	***********************************/
 	flag.Parse()
 
 	// if the user just wants the version, give it and exit
@@ -111,7 +103,7 @@ func main() {
 		EnvPrefix: "MT_",
 	})
 	if err != nil {
-		log.Fatal(4, "error with configuration file: %s", err)
+		fmt.Fprintf(os.Stderr, "FATAL: configuration file error: %s", err)
 		os.Exit(1)
 	}
 	// load config for metric ingestors
@@ -144,8 +136,11 @@ func main() {
 	config.ParseAll()
 
 	/***********************************
-		Set logging levels
+		Set up Logger
 	***********************************/
+
+	log.NewLogger(0, "console", fmt.Sprintf(`{"level": %d, "formatting":false}`, logLevel))
+
 	mdata.LogLevel = logLevel
 	memory.LogLevel = logLevel
 	inKafkaMdm.LogLevel = logLevel

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -220,7 +220,7 @@ func (m *MemoryIdx) Update(point schema.MetricPoint, partition int32) (idx.Archi
 	if ok {
 		oldPart := existing.Partition
 		if LogLevel < 2 {
-			log.Debug("metricDef with id %v already in index", point.MKey)
+			log.Debug("memory-idx: metricDef with id %v already in index", point.MKey)
 		}
 
 		if existing.LastUpdate < int64(point.Time) {
@@ -246,7 +246,7 @@ func (m *MemoryIdx) AddOrUpdate(mkey schema.MKey, data *schema.MetricData, parti
 	existing, ok := m.defById[mkey]
 	if ok {
 		oldPart := existing.Partition
-		log.Debug("metricDef with id %s already in index.", mkey)
+		log.Debug("memory-idx: metricDef with id %s already in index.", mkey)
 		if existing.LastUpdate < int64(data.Time) {
 			existing.LastUpdate = int64(data.Time)
 		}


### PR DESCRIPTION
as of #823 / #825, the logger was created before flags were parsed
and the config (file and env vars) were loaded.
so the logger would always get the default value for the flag
and no way to change the level..
I tried creating the logger after flag parsing, and adjusting the log
level after config parsing, but couldn't the second step to work
properly.

Simplest solution is to just print to stderr directly the one time we
actually need it in between the two steps.

PS: I hate this logging library, but we'll get rid of it. see #624