### PR TITLE
read from first chunks

### DIFF
--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -77,7 +77,7 @@ func (c *Checker) Verify(primary bool, from, to, first, last uint32) {
 	}
 	for pj = pi; c.points[pj].ts != last; pj++ {
 	}
-	c.t.Logf("verifying AggMetric.Get(%d,%d) =?= %d <= ts <= %d", from, to, first, last)
+	c.t.Logf("verifying AggMetric.Get(%d,%d) -> range is %d - %d ?", from, to, first, last)
 	index := pi - 1
 	for _, iter := range res.Iters {
 		for iter.Next() {
@@ -182,9 +182,7 @@ func TestAggMetric(t *testing.T) {
 	c.Add(200, 200)
 	c.Add(315, 315)
 	c.Verify(true, 100, 399, 101, 315)
-
-	// verify as secondary node. Data from the first chunk should not be returned.
-	c.Verify(false, 100, 399, 200, 315)
+	c.Verify(false, 100, 399, 101, 315)
 
 	// get subranges
 	c.Verify(true, 120, 299, 101, 200)

--- a/mdata/chunk/chunk.go
+++ b/mdata/chunk/chunk.go
@@ -15,20 +15,25 @@ type Chunk struct {
 	tsz.Series
 	LastTs    uint32 // last TS seen, not computed or anything
 	NumPoints uint32
+	First     bool
 	Closed    bool
 }
 
 func New(t0 uint32) *Chunk {
 	return &Chunk{
-		Series:    *tsz.New(t0),
-		LastTs:    0,
-		NumPoints: 0,
-		Closed:    false,
+		Series: *tsz.New(t0),
+	}
+}
+
+func NewFirst(t0 uint32) *Chunk {
+	return &Chunk{
+		Series: *tsz.New(t0),
+		First:  true,
 	}
 }
 
 func (c *Chunk) String() string {
-	return fmt.Sprintf("<chunk T0=%d, LastTs=%d, NumPoints=%d, Closed=%t>", c.T0, c.LastTs, c.NumPoints, c.Closed)
+	return fmt.Sprintf("<chunk T0=%d, LastTs=%d, NumPoints=%d, First=%t, Closed=%t>", c.T0, c.LastTs, c.NumPoints, c.First, c.Closed)
 
 }
 func (c *Chunk) Push(t uint32, v float64) error {

--- a/mdata/result.go
+++ b/mdata/result.go
@@ -8,5 +8,5 @@ import (
 type Result struct {
 	Points []schema.Point
 	Iters  []chunk.Iter
-	Oldest uint32
+	Oldest uint32 // timestamp of oldest point we have, to know when and when not we may need to query slower storage
 }


### PR DESCRIPTION
this is an old optimization (?) that has been with us
since a long time ago: #74
2029113406c9362e8891f49e8e7ca92d4425e163

here's how it caused data loss at read time:
- when only 1 chunk of data had been filled:
  the "update" of the field is a no-op
  because len(chunks) == 1, so oldPos goes back to 0
  (not sure if intentional or a bug) so reading the
  first chunk worked.
- once you have more than 1 chunk: update of oldPos works.
  we start hitting cassandra.
  depending on how long the chunk takes to get saved
  to cassandra, we will miss data at read time.
  also, our chunk cache does not cache absence of data,
  hitting cassandra harder during this period.
- once the chunk is saved to cassandra the problem disappears
- once the circular buffer recycles the first time (effectively
  removing the first chunk) this optimization no longer applies,
  but at that point we still hit cassandra just as before.

This problem is now solved. However, removing that code
enables another avenue for data loss at read time:
- when a read node starts (without data backfill)
- or a read node starts with data backfill, but the backfill
  doesn't have old data for the particular metric, IOW
  when the data only covers 1 chunk's worth
- a read node starts with data backfill, but since backfilling starts
  at arbitrary positions, the first chunk will miss some data in the
  beginning.

In all these cases, the first chunk is a partial chunk, whereas
a full version of the chunk is most likely already in cassandra.

To make sure this is not a problem, if the first chunk we used was
partial, we set oldest to the first timestamp, so that the rest
can be retrieved from cassandra.
Typically, this will cause the "same" chunk (but a full version)
to be retrieved from cassandra, which is then cached and seamlessly
merged via Fix()

fix #78 
fix #988 