### PR TITLE
Find random corruptions

### DIFF
--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -212,9 +212,13 @@ func getRandomNumber(min, max int) int {
 // getRandomRange returns a range start-end so that
 // end >= start and both numbers drawn from [min, max)
 func getRandomRange(min, max int) (int, int) {
-	start := getRandomNumber(min, max)
-	end := getRandomNumber(start, max)
-	return start, end
+	number1 := getRandomNumber(min, max)
+	number2 := getRandomNumber(min, max)
+	if number1 > number2 {
+		return number2, number1
+	} else {
+		return number1, number2
+	}
 }
 
 func TestCorruptionCase2(t *testing.T) {
@@ -232,7 +236,7 @@ func TestCorruptionCase2(t *testing.T) {
 		// 0 = Add
 		// 1 = AddRange
 		// 2 = Del
-		// 2 = Del range (via multi del cals)
+		// 3 = Del range (via multi del cals)
 		action := getRandomNumber(0, 4)
 		switch action {
 		case 0:
@@ -255,8 +259,8 @@ func TestCorruptionCase2(t *testing.T) {
 			dels++
 		case 3:
 			from, to := getRandomRange(0, 100)
+			t.Logf("deleting range %d-%d", from, to)
 			for chunk := from; chunk < to; chunk++ {
-				t.Logf("deleting chunk %d", chunk)
 				ccm.Del(chunks[chunk].Ts) // note: chunk may not exist
 			}
 			opDelRange++

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -209,12 +209,11 @@ func getRandomNumber(min, max int) int {
 	return rand.Intn(max-min) + min
 }
 
+// getRandomRange returns a range start-end so that
+// end >= start and both numbers drawn from [min, max)
 func getRandomRange(min, max int) (int, int) {
 	start := getRandomNumber(min, max)
-	var end int
-	for end = min - 1; end < start; end = getRandomNumber(min, max) {
-	}
-
+	end := getRandomNumber(start, max)
 	return start, end
 }
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -221,6 +221,8 @@ func TestCorruptionCase2(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 	_, ccm := getCCM()
 	iterations := 100000
+
+	// 100 chunks, first t0=t10, last is t0=1000
 	chunks := generateChunks(t, 10, 100, 10)
 	adds, addRanges, dels := 0, 0, 0
 
@@ -243,7 +245,7 @@ func TestCorruptionCase2(t *testing.T) {
 		case 2:
 			chunk := getRandomNumber(0, 100)
 			t.Logf("deleting chunk %d", chunk)
-			ccm.Del(chunks[chunk].Ts)
+			ccm.Del(chunks[chunk].Ts) // note: chunk may not exist
 			dels++
 		}
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -221,7 +221,7 @@ func getRandomRange(min, max int) (int, int) {
 func TestCorruptionCase2(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 	_, ccm := getCCM()
-	iterations := 100000000
+	iterations := 100000
 	chunks := generateChunks(t, 10, 100, 10)
 	adds, addRanges, dels := 0, 0, 0
 

--- a/mdata/cache/ccache_metric_test.go
+++ b/mdata/cache/ccache_metric_test.go
@@ -233,17 +233,17 @@ func TestCorruptionCase2(t *testing.T) {
 		switch action {
 		case 0:
 			chunk := getRandomNumber(0, 100)
-			//fmt.Println(fmt.Sprintf("adding chunk %d", chunk))
+			t.Logf("adding chunk %d", chunk)
 			ccm.Add(0, chunks[chunk])
 			adds++
 		case 1:
 			from, to := getRandomRange(0, 100)
-			//fmt.Println(fmt.Sprintf("adding range %d-%d", from, to))
+			t.Logf("adding range %d-%d", from, to)
 			ccm.AddRange(0, chunks[from:to])
 			addRanges++
 		case 2:
 			chunk := getRandomNumber(0, 100)
-			//fmt.Println(fmt.Sprintf("deleting chunk %d", chunk))
+			t.Logf("deleting chunk %d", chunk)
 			ccm.Del(chunks[chunk].Ts)
 			dels++
 		}


### PR DESCRIPTION
*Not for merging*

Just wanted to show you that I believe that there are probably no ways left to corrupt the cache, as long as the first parameter of `Add()`/`AddRange()` (the previous ts) is not above `0` and wrong. 
This randomly adds/deletes stuff from the cache and then keeps checking if it can find a corruption.
I've run that a bunch of times, that's just from one run:

```
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ go test github.com/grafana/metrictank/mdata/cache -run TestCorruptionCase2 -test.v -c
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ time ./cache.test -test.run TestCorruptionCase2
adds: 33343523 addRanges: 33331415 dels:33325062
PASS

real	15m53.706s
user	16m11.340s
sys	0m3.484s

```