### PR TITLE
Block to submit accounting events

### DIFF
--- a/mdata/cache/accnt/flat_accnt.go
+++ b/mdata/cache/accnt/flat_accnt.go
@@ -2,10 +2,10 @@ package accnt
 
 import (
 	"sort"
+	"time"
 
 	"github.com/grafana/metrictank/mdata/chunk"
 	"github.com/raintank/schema"
-	"github.com/raintank/worldping-api/pkg/log"
 )
 
 const evictQSize = 1000
@@ -157,12 +157,9 @@ func (a *FlatAccnt) act(eType eventType, payload interface{}) {
 		pl:    payload,
 	}
 
-	select {
-	// we never want to block for accounting, rather just let it miss some events and print an error
-	case a.eventQ <- event:
-	default:
-		log.Error(3, "Failed to submit event to accounting, channel was blocked")
-	}
+	pre := time.Now()
+	a.eventQ <- event
+	AccntEventSubmission.Value(time.Now().Sub(pre))
 }
 
 func (a *FlatAccnt) eventLoop() {

--- a/mdata/cache/accnt/stats.go
+++ b/mdata/cache/accnt/stats.go
@@ -31,6 +31,7 @@ var (
 	// metric cache.ops.chunk.evict is how many chunks were evicted from the cache
 	cacheChunkEvict = stats.NewCounter32("cache.ops.chunk.evict")
 
-	cacheSizeMax  = stats.NewGauge64("cache.size.max")
-	cacheSizeUsed = stats.NewGauge64("cache.size.used")
+	cacheSizeMax         = stats.NewGauge64("cache.size.max")
+	cacheSizeUsed        = stats.NewGauge64("cache.size.used")
+	AccntEventSubmission = stats.NewLatencyHistogram15s32("cache.accounting.submission")
 )


### PR DESCRIPTION
This is the prevent a memory leak due to cached data that we didn't account for.

There is a risk that this will slow down queries processing time and/or ingest speed. That's why there is a metric to measure the time it takes to submit accounting events into the queue, it probably makes sense to have an alert on that metric in production because if it fills up and blocks then there will be user-impacting consequences.