### PR TITLE
Limit series from clusterByFind operation

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -320,13 +320,8 @@ func (s *Server) peerQuerySpeculative(ctx context.Context, data cluster.Traceabl
 		result[resp.peer.GetName()] = resp
 	}
 
-	select {
-	case err := <-errorChan:
-		return nil, err
-	default: // no error
-	}
-
-	return result, nil
+	err := <-errorChan
+	return result, err
 }
 
 // peerQuerySpeculativeChan takes a request and the path to request it on, then fans it out

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -337,10 +337,10 @@ func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Trac
 	resultChan := make(chan PeerResponse)
 	errorChan := make(chan error, 1)
 
-	defer close(errorChan)
-	defer close(resultChan)
-
 	go func() {
+		defer close(errorChan)
+		defer close(resultChan)
+
 		peerGroups, err := cluster.MembersForSpeculativeQuery()
 		if err != nil {
 			log.Error(3, "HTTP peerQuery unable to get peers, %s", err)

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -342,11 +342,11 @@ func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Trac
 
 		peerGroups, err := cluster.MembersForSpeculativeQuery()
 		if err != nil {
-			log.Error(3, "HTTP peerQuery unable to get peers, %s", err)
+			log.Errorf("HTTP peerQuery unable to get peers, %s", err.Error())
 			errorChan <- err
 			return
 		}
-		log.Debug("HTTP %s across %d instances", name, len(peerGroups)-1)
+		log.Debugf("HTTP %s across %d instances", name, len(peerGroups)-1)
 
 		reqCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -361,7 +361,7 @@ func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Trac
 		}, 1)
 
 		askPeer := func(shardGroup int32, peer cluster.Node) {
-			log.Debug("HTTP Render querying %s%s", peer.GetName(), path)
+			log.Debugf("HTTP Render querying %s%s", peer.GetName(), path)
 			buf, err := peer.Post(reqCtx, name, path, data)
 
 			select {
@@ -373,7 +373,7 @@ func (s *Server) peerQuerySpeculativeChan(ctx context.Context, data cluster.Trac
 
 			if err != nil {
 				cancel()
-				log.Error(4, "HTTP Render error querying %s%s: %q", peer.GetName(), path, err)
+				log.Errorf("HTTP Render error querying %s%s: %q", peer.GetName(), path, err)
 			}
 			responses <- struct {
 				shardGroup int32

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -303,7 +303,7 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 }
 
 // peerQuerySpeculative takes a request and the path to request it on, then fans it out
-// across the cluster. If any peer fails requests toother peers are aborted. If enough
+// across the cluster. If any peer fails requests to other peers are aborted. If enough
 // peers have been heard from (based on speculation-threshold configuration), and we
 // are missing the others, try to speculatively query each other member of each shard group.
 // ctx:          request context

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -303,10 +303,9 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 }
 
 // peerQuerySpeculative takes a request and the path to request it on, then fans it out
-// across the cluster, except to the local peer. If any peer fails requests to
-// other peers are aborted. If enough peers have been heard from (based on
-// speculation-threshold configuration), and we are missing the others, try to
-// speculatively query each other member of each shard group.
+// across the cluster. If any peer fails requests toother peers are aborted. If enough
+// peers have been heard from (based on speculation-threshold configuration), and we
+// are missing the others, try to speculatively query each other member of each shard group.
 // ctx:          request context
 // data:         request to be submitted
 // name:         name to be used in logging & tracing

--- a/api/config.go
+++ b/api/config.go
@@ -40,7 +40,7 @@ func ConfigSetup() {
 	apiCfg := flag.NewFlagSet("http", flag.ExitOnError)
 	apiCfg.IntVar(&maxPointsPerReqSoft, "max-points-per-req-soft", 1000000, "lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)")
 	apiCfg.IntVar(&maxPointsPerReqHard, "max-points-per-req-hard", 20000000, "limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)")
-	apiCfg.IntVar(&maxSeriesPerReq, "max-series-per-req", 200000, "limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)")
+	apiCfg.IntVar(&maxSeriesPerReq, "max-series-per-req", 250000, "limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)")
 	apiCfg.StringVar(&logMinDurStr, "log-min-dur", "5min", "only log incoming requests if their timerange is at least this duration. Use 0 to disable")
 
 	apiCfg.StringVar(&Addr, "listen", ":6060", "http listener address.")

--- a/api/config.go
+++ b/api/config.go
@@ -15,6 +15,7 @@ import (
 var (
 	maxPointsPerReqSoft int
 	maxPointsPerReqHard int
+	maxSeriesPerReq     int
 	logMinDurStr        string
 	logMinDur           uint32
 
@@ -39,6 +40,7 @@ func ConfigSetup() {
 	apiCfg := flag.NewFlagSet("http", flag.ExitOnError)
 	apiCfg.IntVar(&maxPointsPerReqSoft, "max-points-per-req-soft", 1000000, "lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)")
 	apiCfg.IntVar(&maxPointsPerReqHard, "max-points-per-req-hard", 20000000, "limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)")
+	apiCfg.IntVar(&maxSeriesPerReq, "max-series-per-req", 200000, "limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)")
 	apiCfg.StringVar(&logMinDurStr, "log-min-dur", "5min", "only log incoming requests if their timerange is at least this duration. Use 0 to disable")
 
 	apiCfg.StringVar(&Addr, "listen", ":6060", "http listener address.")

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -835,7 +835,9 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		// 0 disables the check, so only check if maxSeriesPerReq > 0
 		if maxSeriesPerReq > 0 && len(resp.Metrics)+len(allSeries) > maxSeries {
 			return nil,
-				response.NewError(413, fmt.Sprintf("Request exceeds max-series-per-req limit (%d). Reduce the number of targets or ask your admin to increase the limit.", maxSeriesPerReq))
+				response.NewError(
+					http.StatusRequestEntityTooLarge,
+					fmt.Sprintf("Request exceeds max-series-per-req limit (%d). Reduce the number of targets or ask your admin to increase the limit.", maxSeriesPerReq))
 		}
 
 		for _, series := range resp.Metrics {

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -607,7 +608,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 			for i, e := range exprs {
 				exprs[i] = strings.Trim(e, " '\"")
 			}
-			series, err = s.clusterFindByTag(ctx, orgId, exprs, int64(r.From))
+			series, err = s.clusterFindByTag(ctx, orgId, exprs, int64(r.From), maxSeriesPerReq-len(reqs))
 		} else {
 			series, err = s.findSeries(ctx, orgId, []string{r.Query}, int64(r.From))
 		}
@@ -798,7 +799,7 @@ func (s *Server) clusterTagDetails(ctx context.Context, orgId uint32, tag, filte
 
 func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.GraphiteTagFindSeries) {
 	reqCtx := ctx.Req.Context()
-	series, err := s.clusterFindByTag(reqCtx, ctx.OrgId, request.Expr, request.From)
+	series, err := s.clusterFindByTag(reqCtx, ctx.OrgId, request.Expr, request.From, maxSeriesPerReq)
 	if err != nil {
 		response.Write(ctx, response.WrapError(err))
 		return
@@ -818,28 +819,40 @@ func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.G
 	response.Write(ctx, response.NewJson(200, seriesNames, ""))
 }
 
-func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions []string, from int64) ([]Series, error) {
+func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions []string, from int64, maxSeries int) ([]Series, error) {
 	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions, From: from}
-	resps, err := s.peerQuerySpeculative(ctx, data, "clusterFindByTag", "/index/find_by_tag")
-	if err != nil {
-		return nil, err
-	}
+	responseChan := make(chan PeerResponse)
 
-	select {
-	case <-ctx.Done():
-		//request canceled
-		return nil, nil
-	default:
-	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var queryErr, err error
+	go func() {
+		queryErr = s.peerQuerySpeculativeChan(ctx, data, "clusterFindByTag", "/index/find_by_tag", responseChan)
+		wg.Done()
+	}()
 
 	var allSeries []Series
 
-	for _, r := range resps {
+	for r := range responseChan {
+		select {
+		case <-ctx.Done():
+			//request canceled
+			return nil, nil
+		default:
+		}
+
 		resp := models.IndexFindByTagResp{}
 		_, err = resp.UnmarshalMsg(r.buf)
 		if err != nil {
 			return nil, err
 		}
+
+		// 0 disables the check, so only check if maxSeriesPerReq > 0
+		if maxSeriesPerReq > 0 && len(resp.Metrics)+len(allSeries) > maxSeries {
+			return nil,
+				response.NewError(413, fmt.Sprintf("Request exceeds max-series-per-req limit (%d). Reduce the number of targets or ask your admin to increase the limit.", maxSeriesPerReq))
+		}
+
 		for _, series := range resp.Metrics {
 			allSeries = append(allSeries, Series{
 				Pattern: series.Path,
@@ -849,7 +862,8 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		}
 	}
 
-	return allSeries, nil
+	wg.Wait()
+	return allSeries, queryErr
 }
 
 func (s *Server) graphiteTags(ctx *middleware.Context, request models.GraphiteTags) {

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -847,13 +847,8 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		}
 	}
 
-	select {
-	case err := <-errorChan:
-		return nil, err
-	default: // no error
-	}
-
-	return allSeries, nil
+	err := <-errorChan
+	return allSeries, err
 }
 
 func (s *Server) graphiteTags(ctx *middleware.Context, request models.GraphiteTags) {

--- a/api/prometheus_querier.go
+++ b/api/prometheus_querier.go
@@ -64,7 +64,7 @@ func (q *querier) Select(matchers ...*labels.Matcher) (storage.SeriesSet, error)
 		}
 	}
 
-	series, err := q.clusterFindByTag(q.ctx, q.OrgID, expressions, 0)
+	series, err := q.clusterFindByTag(q.ctx, q.OrgID, expressions, 0, maxSeriesPerReq)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -202,7 +203,8 @@ func (n HTTPNode) GetName() string {
 func handleResp(rsp *http.Response) ([]byte, error) {
 	defer rsp.Body.Close()
 	if rsp.StatusCode != 200 {
-		ioutil.ReadAll(rsp.Body)
+		// Read in body so that the connection can be reused
+		io.Copy(ioutil.Discard, rsp.Body)
 		return nil, NewError(rsp.StatusCode, fmt.Errorf(rsp.Status))
 	}
 	return ioutil.ReadAll(rsp.Body)

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/docs/config.md
+++ b/docs/config.md
@@ -194,6 +194,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -156,6 +156,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -153,6 +153,8 @@ key-file = /etc/ssl/private/ssl-cert-snakeoil.key
 max-points-per-req-soft = 1000000
 # limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)
 max-points-per-req-hard = 20000000
+# limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)
+max-series-per-req = 250000
 # require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite


### PR DESCRIPTION
Fixes #968 and #1018 

Looking through the node::Post code, it seems like we could save quite a lot by marshaling directly from the response body into the msgp generated type. My C++ brain wants to use templates to accomplish it, so I'm not sure the cleanest method to use in go without generics. For that reason, I punted on that for now.