### PR TITLE
Modify lag rate calculations

### DIFF
--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -347,7 +347,6 @@ func (k *KafkaMdm) trackStats(topic string, partition int32) {
 			return
 		case ts := <-ticker.C:
 			currentOffset := int64(kafkaStats.Offset.Peek())
-			k.lagMonitor.StoreOffset(partition, currentOffset, ts)
 			newest, err := k.tryGetOffset(topic, partition, sarama.OffsetNewest, 1, 0)
 			if err != nil {
 				log.Errorf("kafkamdm: %s", err.Error())
@@ -356,7 +355,7 @@ func (k *KafkaMdm) trackStats(topic string, partition int32) {
 			kafkaStats.LogSize.Set(int(newest))
 			lag := int(newest - currentOffset)
 			kafkaStats.Lag.Set(lag)
-			k.lagMonitor.StoreLag(partition, lag)
+			k.lagMonitor.StoreOffsets(partition, currentOffset, newest, ts)
 		}
 	}
 }

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -1,42 +1,57 @@
 package kafkamdm
 
 import (
+	"math"
 	"sync"
 	"time"
 )
+
+type offsetMeasurement struct {
+	readOffset, highWaterMark int64
+	ts                        time.Time
+}
 
 // lagLogger maintains a set of most recent lag measurements
 // and is able to provide the lowest value seen.
 type lagLogger struct {
 	pos          int
-	measurements []int
+	measurements []offsetMeasurement
 }
 
 func newLagLogger(size int) *lagLogger {
 	return &lagLogger{
 		pos:          0,
-		measurements: make([]int, 0, size),
+		measurements: make([]offsetMeasurement, 0, size),
 	}
 }
 
-// Store saves the current value, potentially overwriting an old value
+// Store saves the current offsets and timestamp, potentially overwriting an old value
 // if needed.
-// Note: negative values are ignored.  We rely on previous data - if any - in such case.
+// Note: negative values of highWaterMark - readOffset are ignored.  We rely on previous data - if any - in such case.
 // negative values can happen upon a rollover of the offset counter
-func (l *lagLogger) Store(lag int) {
+func (l *lagLogger) Store(readOffset, highWaterMark int64, ts time.Time) {
+	lag := highWaterMark - readOffset
 	if lag < 0 {
 		return
 	}
-	l.pos++
+
+	measurement := offsetMeasurement{
+		readOffset:    readOffset,
+		highWaterMark: highWaterMark,
+		ts:            ts,
+	}
 	if len(l.measurements) < cap(l.measurements) {
-		l.measurements = append(l.measurements, lag)
+		l.measurements = append(l.measurements, measurement)
+		l.pos = len(l.measurements) - 1
 		return
 	}
+
+	l.pos++
 
 	if l.pos >= cap(l.measurements) {
 		l.pos = 0
 	}
-	l.measurements[l.pos] = lag
+	l.measurements[l.pos] = measurement
 }
 
 // Min returns the lowest lag seen (0 or positive) or -1 if no lags reported yet
@@ -48,71 +63,45 @@ func (l *lagLogger) Min() int {
 	}
 	min := -1
 	for _, m := range l.measurements {
-		if min < 0 || m < min {
-			min = m
+		lag := int(m.highWaterMark - m.readOffset)
+		if min < 0 || lag < min {
+			min = lag
 		}
 	}
 	return min
 }
 
-type rateLogger struct {
-	lastOffset int64
-	lastTs     time.Time
-	rate       int64
-}
-
-func newRateLogger() *rateLogger {
-	return &rateLogger{}
-}
-
-// Store saves the current offset and updates the rate if it is confident
-// offset must be concrete values, not logical values like -2 (oldest) or -1 (newest)
-func (o *rateLogger) Store(offset int64, ts time.Time) {
-	if o.lastTs.IsZero() {
-		// first measurement
-		o.lastOffset = offset
-		o.lastTs = ts
-		return
-	}
-	duration := ts.Sub(o.lastTs)
-	if duration < time.Second && duration > 0 {
-		// too small difference. either due to clock adjustment or this method
-		// is called very frequently, e.g. due to a subsecond offset-commit-interval.
-		// We need to let more time pass to make an accurate calculation.
-		return
-	}
-	if duration <= 0 {
-		// current ts is <= last ts. This would only happen if clock went back in time
-		// in which case we can't reliably work out how
-		// long it has really been since we last took a measurement.
-		// but set a new baseline for next time
-		o.lastTs = ts
-		o.lastOffset = offset
-		return
-	}
-	metrics := offset - o.lastOffset
-	o.lastTs = ts
-	o.lastOffset = offset
-	if metrics < 0 {
-		// this is possible if our offset counter rolls over or is reset.
-		// If it was a rollover we could compute the rate, but it is safer
-		// to just keep using the last computed rate, and wait for the next
-		// measurement to compute a new rate based on the new baseline
-		return
-	}
-	// note the multiplication overflows if you have 9 billion metrics
-	// sice max int64 is 9 223 372 036 854 775 807 (not an issue in practice)
-	o.rate = (1e9 * metrics / int64(duration)) // metrics/ns -> metrics/s
-	return
-}
-
-// Rate returns the last reliable rate calculation
-// * generally, it's the last reported measurement
-// * occasionally, it's one report interval in the past (due to rollover)
-// * exceptionally, it's an old measurement (if you keep adjusting the system clock)
+// Rate returns an average rate calculation over the last N measurements (configured at construction)
 // after startup, reported rate may be 0 if we haven't been up long enough to determine it yet.
-func (o *rateLogger) Rate() int64 {
-	return o.rate
+func (l *lagLogger) Rate() int64 {
+	if len(l.measurements) < 2 {
+		return 0
+	}
+
+	latestLag := l.measurements[l.pos]
+	var earliestLag offsetMeasurement
+
+	if len(l.measurements) == cap(l.measurements) {
+		earliestLag = l.measurements[(l.pos+1)%len(l.measurements)]
+	} else {
+		earliestLag = l.measurements[0]
+	}
+
+	high, low := latestLag.highWaterMark, earliestLag.highWaterMark
+
+	// If there are no longer any incoming messages, use our read offsets to compute rate
+	if high == low {
+		high, low = latestLag.readOffset, earliestLag.readOffset
+	}
+	if high < low {
+		// Offset must have wrapped around...seems unlikely. Estimate growth using MaxInt64
+		high = math.MaxInt64
+	}
+
+	totalGrowth := high - low
+	totalDuration := latestLag.ts.UnixNano() - earliestLag.ts.UnixNano()
+
+	return totalGrowth / (totalDuration / time.Second.Nanoseconds())
 }
 
 // LagMonitor determines how upToDate this node is.
@@ -122,8 +111,7 @@ func (o *rateLogger) Rate() int64 {
 // We then combine this data into a score, see the Metric() method.
 type LagMonitor struct {
 	sync.Mutex
-	lag         map[int32]*lagLogger
-	rate        map[int32]*rateLogger
+	monitors    map[int32]*lagLogger
 	explanation Explanation
 }
 
@@ -141,12 +129,10 @@ type Status struct {
 
 func NewLagMonitor(size int, partitions []int32) *LagMonitor {
 	m := &LagMonitor{
-		lag:  make(map[int32]*lagLogger),
-		rate: make(map[int32]*rateLogger),
+		monitors: make(map[int32]*lagLogger),
 	}
 	for _, p := range partitions {
-		m.lag[p] = newLagLogger(size)
-		m.rate[p] = newRateLogger()
+		m.monitors[p] = newLagLogger(size)
 	}
 	return m
 }
@@ -154,9 +140,9 @@ func NewLagMonitor(size int, partitions []int32) *LagMonitor {
 // Metric computes the overall score of up-to-date-ness of this node,
 // as an estimated number of seconds behind kafka.
 // We first compute the score for each partition like so:
-// (minimum lag seen in last N measurements) / ingest rate.
+// (minimum lag seen in last N measurements) / input rate.
 // example:
-// lag (in messages/metrics)     ingest rate       --->    score (seconds behind)
+// lag (in messages/metrics)     input rate       --->    score (seconds behind)
 //                       10k       1k/second                 10
 //                       200       1k/second                  0 (less than 1s behind)
 //                         0               *                  0 (perfectly in sync)
@@ -176,10 +162,10 @@ func (l *LagMonitor) Metric() int {
 		Updated: time.Now(),
 	}
 	max := 0
-	for p, lag := range l.lag {
+	for p, lag := range l.monitors {
 		status := Status{
-			Lag:  lag.Min(),             // accurate lag, -1 if unknown
-			Rate: int(l.rate[p].Rate()), // accurate rate, or 0 if we're not sure
+			Lag:  lag.Min(),       // accurate lag, -1 if unknown
+			Rate: int(lag.Rate()), // accurate rate, or 0 if we're not sure
 		}
 		if status.Lag == -1 {
 			// if we have no lag measurements yet,
@@ -216,14 +202,8 @@ func (l *LagMonitor) Explain() interface{} {
 	}
 }
 
-func (l *LagMonitor) StoreLag(partition int32, val int) {
+func (l *LagMonitor) StoreOffsets(partition int32, readOffset, highWaterMark int64, ts time.Time) {
 	l.Lock()
-	l.lag[partition].Store(val)
-	l.Unlock()
-}
-
-func (l *LagMonitor) StoreOffset(partition int32, offset int64, ts time.Time) {
-	l.Lock()
-	l.rate[partition].Store(offset, ts)
+	l.monitors[partition].Store(readOffset, highWaterMark, ts)
 	l.Unlock()
 }

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -98,10 +98,10 @@ func (l *lagLogger) Rate() int64 {
 		high = math.MaxInt64
 	}
 
-	totalGrowth := high - low
-	totalDuration := latestLag.ts.UnixNano() - earliestLag.ts.UnixNano()
+	totalGrowth := float64(high - low)
+	totalDurationSec := float64(latestLag.ts.UnixNano()-earliestLag.ts.UnixNano()) / float64(time.Second.Nanoseconds())
 
-	return totalGrowth / (totalDuration / time.Second.Nanoseconds())
+	return int64(totalGrowth / totalDurationSec)
 }
 
 // LagMonitor determines how upToDate this node is.

--- a/input/kafkamdm/lag_monitor.go
+++ b/input/kafkamdm/lag_monitor.go
@@ -61,10 +61,10 @@ func (l *lagLogger) Min() int {
 	if len(l.measurements) == 0 {
 		return -1
 	}
-	min := -1
-	for _, m := range l.measurements {
+	min := int(l.measurements[0].highWaterMark - l.measurements[0].readOffset)
+	for _, m := range l.measurements[1:] {
 		lag := int(m.highWaterMark - m.readOffset)
-		if min < 0 || lag < min {
+		if lag < min {
 			min = lag
 		}
 	}

--- a/input/kafkamdm/lag_monitor_test.go
+++ b/input/kafkamdm/lag_monitor_test.go
@@ -7,113 +7,90 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+type OffsetAdjuster struct {
+	readOffset, highWaterMark int64
+	ts                        time.Time
+	lag                       *lagLogger
+}
+
+func (o *OffsetAdjuster) add(msgsProcessed, msgsAdded int64, secondsPassed int) {
+	o.ts = o.ts.Add(time.Second * time.Duration(secondsPassed))
+	o.readOffset += msgsProcessed
+	o.highWaterMark += msgsAdded
+	o.lag.Store(o.readOffset, o.highWaterMark, o.ts)
+}
+
 func TestLagLogger(t *testing.T) {
 	logger := newLagLogger(5)
-	now := time.Now()
 
 	Convey("with 0 measurements", t, func() {
 		So(logger.Min(), ShouldEqual, -1)
 	})
+
+	adjuster := OffsetAdjuster{
+		readOffset:    10 * 1000 * 1000,
+		highWaterMark: 10 * 1000 * 1000,
+		ts:            time.Now(),
+		lag:           logger,
+	}
 	Convey("with 1 measurements", t, func() {
-		logger.Store(0, 10, now.Add(time.Second*time.Duration(1)))
+		adjuster.add(0, 10, 1)
 		So(logger.Min(), ShouldEqual, 10)
 		So(logger.Rate(), ShouldEqual, 0)
 	})
 	Convey("with 2 measurements", t, func() {
-		logger.Store(10, 15, now.Add(time.Second*time.Duration(2)))
+		adjuster.add(10, 5, 1)
 		So(logger.Min(), ShouldEqual, 5)
 		So(logger.Rate(), ShouldEqual, 5)
 	})
 	Convey("with a negative measurement", t, func() {
-		logger.Store(10, 5, now.Add(time.Second*time.Duration(3)))
-
-		// Negative measuremnets are discarded, should be same as last time.
+		// Negative measurements are discarded, should be same as last time.
+		// Add directly to not mess with the adjusters offsets
+		logger.Store(adjuster.readOffset, adjuster.highWaterMark-100, adjuster.ts)
 		So(logger.Min(), ShouldEqual, 5)
 		So(logger.Rate(), ShouldEqual, 5)
 	})
 	Convey("with lots of measurements", t, func() {
+		// fall behind by 1 each step (we started behind by 5)
 		for i := 0; i < 100; i++ {
-			logger.Store(int64(10+i), int64(15+2*i), now.Add(time.Second*time.Duration(3+i)))
+			adjuster.add(19, 20, 1)
 		}
-		So(logger.Min(), ShouldEqual, 100)
-		So(logger.Rate(), ShouldEqual, 2)
+		So(logger.Min(), ShouldEqual, 101)
+		So(logger.Rate(), ShouldEqual, 20)
 	})
 }
 
-/*
-func TestRateLogger(t *testing.T) {
-	logger := newRateLogger()
-	now := time.Now()
-	Convey("with 0 measurements", t, func() {
-		So(logger.Rate(), ShouldEqual, 0)
-	})
-	Convey("after 1st measurements", t, func() {
-		logger.Store(10, now)
-		So(logger.Rate(), ShouldEqual, 0)
-	})
-	Convey("with 2nd measurements", t, func() {
-		logger.Store(15, now.Add(time.Second))
-		So(logger.Rate(), ShouldEqual, 5)
-	})
-	Convey("with old ts", t, func() {
-		logger.Store(25, now)
-		So(logger.Rate(), ShouldEqual, 5)
-	})
-	Convey("with less then 1per second", t, func() {
-		logger.Store(30, now.Add(time.Second*10))
-		So(logger.Rate(), ShouldEqual, 0)
-	})
-}
+func TestLagWithShortProcessingPause(t *testing.T) {
+	logger := newLagLogger(5)
 
-func TestRateLoggerSmallIncrements(t *testing.T) {
-	logger := newRateLogger()
-	now := time.Now()
-	Convey("after 1st measurements", t, func() {
-		logger.Store(10, now)
-		So(logger.Rate(), ShouldEqual, 0)
+	adjuster := OffsetAdjuster{
+		readOffset:    10 * 1000 * 1000,
+		highWaterMark: 10 * 1000 * 1000,
+		ts:            time.Now(),
+		lag:           logger,
+	}
+
+	// start with 50 lag
+	adjuster.highWaterMark += 50
+
+	// Simulate being almost in sync
+	for i := 0; i < 100; i++ {
+		adjuster.add(5000, 5000, 5)
+	}
+
+	Convey("should be almost in sync", t, func() {
+		So(logger.Min(), ShouldEqual, 50)
+		So(logger.Rate(), ShouldEqual, 1000)
 	})
-	Convey("with 2nd measurements", t, func() {
-		logger.Store(20, now.Add(200*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 0)
-	})
-	Convey("with 3rd measurements", t, func() {
-		logger.Store(30, now.Add(400*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 0)
-	})
-	Convey("with 4th measurements", t, func() {
-		logger.Store(40, now.Add(600*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 0)
-	})
-	Convey("with 5th measurements", t, func() {
-		logger.Store(50, now.Add(800*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 0)
-	})
-	Convey("with 6th measurements", t, func() {
-		logger.Store(60, now.Add(1000*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 60-10)
-	})
-	Convey("with 7th measurements", t, func() {
-		logger.Store(80, now.Add(1200*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 60-10)
-	})
-	Convey("with 8th measurements", t, func() {
-		logger.Store(100, now.Add(1400*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 60-10)
-	})
-	Convey("with 9th measurements", t, func() {
-		logger.Store(120, now.Add(1600*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 60-10)
-	})
-	Convey("with 10th measurements", t, func() {
-		logger.Store(140, now.Add(1800*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 60-10)
-	})
-	Convey("with 11th measurements", t, func() {
-		logger.Store(160, now.Add(2000*time.Millisecond))
-		So(logger.Rate(), ShouldEqual, 160-60)
+
+	// Short pause with no msgs processed
+	adjuster.add(0, 5*1000, 5)
+
+	Convey("Short pause should not cause large lag estimate", t, func() {
+		So(logger.Min(), ShouldEqual, 50)
+		So(logger.Rate(), ShouldEqual, 1000)
 	})
 }
-*/
 
 // TestLagMonitor tests LagMonitor priorities based on various scenarios.
 // the overall priority is obviously simply the max priority of any of the partitions,
@@ -182,13 +159,13 @@ func TestLagMonitor(t *testing.T) {
 				mon.StoreOffsets(part, int64(i), int64(2*i), now.Add(time.Second*time.Duration(i)))
 			}
 		}
-		So(mon.Metric(), ShouldEqual, 90)
+		So(mon.Metric(), ShouldEqual, 45)
 	})
 	Convey("metric should be worst partition", t, func() {
 		now := time.Now()
 		for part := range mon.monitors {
-			mon.StoreOffsets(part, int64(part), int64(2*part+10), now.Add(time.Second*time.Duration(part)))
+			mon.StoreOffsets(part, int64(part+200), int64(2*part+210), now.Add(time.Second*time.Duration(part+100)))
 		}
-		So(mon.Metric(), ShouldEqual, 13)
+		So(mon.Metric(), ShouldEqual, 6)
 	})
 }

--- a/input/kafkamdm/lag_monitor_test.go
+++ b/input/kafkamdm/lag_monitor_test.go
@@ -108,6 +108,12 @@ func TestLagMonitor(t *testing.T) {
 	Convey("with 0 measurements, priority should be 10k", t, func() {
 		So(mon.Metric(), ShouldEqual, 10000)
 		Reset(func() { mon = NewLagMonitor(2, []int32{0}) })
+		Convey("sub-second polling should work", func() {
+			mon.StoreOffsets(0, 1000, 1000, start)
+			ts := start.Add(time.Duration(float64(time.Second.Nanoseconds()) * float64(0.1)))
+			mon.StoreOffsets(0, 5000, 5000, ts)
+			So(mon.Metric(), ShouldEqual, 0)
+		})
 		Convey("with 100 measurements, not consuming and lag just growing", func() {
 			for i := 0; i < 100; i++ {
 				advance(i, int64(i), 0)


### PR DESCRIPTION
Related to #985 

We are seeing (as of yet undiagnosed) pauses of a few seconds in our read instances. When this happens, the lag jumps a bit and the priority jumped even more. The code harshly penalizes short pauses. This code uses a moving window to determine rate of kafka growth to estimate "seconds behind".