### PR TITLE
k8s: allow passing GO* variables as MT_GO*

### DIFF
--- a/scripts/k8s/entrypoint.sh
+++ b/scripts/k8s/entrypoint.sh
@@ -9,6 +9,12 @@ if ! mkdir -p $MT_PROFTRIGGER_PATH; then
 	exit 1
 fi
 
+# set any GO environment variables (which we allow to be passed in as MT_GO<foo>
+
+while read var val; do
+	export $var=$val
+done < <(env | sed -n '/^MT_GO/s/=/ /p' | sed 's/MT_//')
+
 # set offsets
 if [ x"$MT_KAFKA_MDM_IN_OFFSET" = "xauto" ]; then
   export MT_KAFKA_MDM_IN_OFFSET=$(/getOffset.py $MT_KAFKA_MDM_IN_TOPICS)


### PR DESCRIPTION
in particular, allows us to set MT_GOGC=xx without having to do any changes in hosted-metrics-api