### PR TITLE
Go1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/grafana/metrictank
     docker:
-      - image: circleci/golang:1.10.3
+      - image: circleci/golang:1.11
     steps:
       - checkout
       - run: scripts/build.sh
@@ -21,7 +21,7 @@ jobs:
   test:
     working_directory: /go/src/github.com/grafana/metrictank
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.11
     steps:
       - checkout
       - run: go test -v -race $(go list ./... | grep -v github.com/grafana/metrictank/stacktest)
@@ -29,7 +29,7 @@ jobs:
   qa:
     working_directory: /go/src/github.com/grafana/metrictank
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.11
     steps:
       - checkout
       - run: scripts/qa/gofmt.sh

--- a/store/cassandra/config.go
+++ b/store/cassandra/config.go
@@ -49,13 +49,13 @@ func NewStoreConfig() *StoreConfig {
 		CqlProtocolVersion:       4,
 		CreateKeyspace:           true,
 		DisableInitialHostLookup: false,
-		SSL:              false,
-		CaPath:           "/etc/metrictank/ca.pem",
-		HostVerification: true,
-		Auth:             false,
-		Username:         "cassandra",
-		Password:         "cassandra",
-		SchemaFile:       "/etc/metrictank/schema-store-cassandra.toml",
+		SSL:                      false,
+		CaPath:                   "/etc/metrictank/ca.pem",
+		HostVerification:         true,
+		Auth:                     false,
+		Username:                 "cassandra",
+		Password:                 "cassandra",
+		SchemaFile:               "/etc/metrictank/schema-store-cassandra.toml",
 	}
 }
 


### PR DESCRIPTION
note that for a smooth dev workflow, this means MT developers should also upgrade to go 1.11 on their system, due to the new gofmt change