### PR TITLE
no need for $(go list ./... | grep -v /vendor/) ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 default:
 	$(MAKE) all
 test:
-	CGO_ENABLED=1 go test -v -race $(shell go list ./... | grep -v /vendor/ | grep -v stacktest)
+	CGO_ENABLED=1 go test -v -race $(shell go list ./... | grep -v stacktest)
 check:
 	$(MAKE) test
 bin:

--- a/scripts/qa/go-generate.sh
+++ b/scripts/qa/go-generate.sh
@@ -18,7 +18,7 @@ fi
 
 go get -u golang.org/x/tools/cmd/stringer github.com/tinylib/msgp
 
-go generate $(go list ./... | grep -v /vendor/)
+go generate ./...
 out=$(git status --short)
 [ -z "$out" ] && echo "all good" && exit 0
 
@@ -31,5 +31,5 @@ git --no-pager diff
 
 echo "You should probably run:"
 echo "go get -u golang.org/x/tools/cmd/stringer github.com/tinylib/msgp"
-echo 'go generate $(go list ./... | grep -v /vendor/)'
+echo 'go generate ./...'
 exit 2


### PR DESCRIPTION
..for tools that use new loader. e.g. not gocyclo