### PR TITLE
disable tracing for healthchecks

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -24,9 +24,10 @@ func (s *Server) RegisterRoutes() {
 	withOrg := middleware.RequireOrg()
 	cBody := middleware.CaptureBody
 	ready := middleware.NodeReady()
+	noTrace := middleware.DisableTracing
 
-	r.Get("/", s.appStatus)
-	r.Get("/node", s.getNodeStatus)
+	r.Get("/", noTrace, s.appStatus)
+	r.Get("/node", noTrace, s.getNodeStatus)
 	r.Post("/node", bind(models.NodeStatus{}), s.setNodeStatus)
 	r.Get("/priority", s.explainPriority)
 	r.Get("/debug/pprof/block", blockHandler)


### PR DESCRIPTION
I'm not sure what the best method to disable tracing on certain routes is. We could also just have a list of urls where tracing should be disabled, then we could compare the url against that list in `api/middleware/tracer.go`, but I think maintaining such a list is going to be ugly. 

We could also just not add the tracer middleware with `r.Use()` anymore, but add it in those routes that should have tracing enabled separately, but then we wouldn't have the tracer in all the middlewares that get executed before that one because then the tracer would be later in the list of middlewares.