### PR TITLE
Expose AdvertiseAddr from the clustering configuration

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -21,6 +21,8 @@ var (
 	minAvailableShards int
 
 	swimUseConfig               = "default-lan"
+	swimAdvertiseAddrStr        string
+	swimAdvertiseAddr           *net.TCPAddr
 	swimBindAddrStr             string
 	swimBindAddr                *net.TCPAddr
 	swimTCPTimeout              time.Duration
@@ -57,6 +59,7 @@ func ConfigSetup() {
 	swimCfg := flag.NewFlagSet("swim", flag.ExitOnError)
 	swimCfg.StringVar(&swimUseConfig, "use-config", "manual", "config setting to use. If set to anything but manual, will override all other swim settings. Use manual|default-lan|default-local|default-wan. see https://godoc.org/github.com/hashicorp/memberlist#Config . Note all our swim settings correspond to default-lan")
 	swimCfg.StringVar(&swimBindAddrStr, "bind-addr", "0.0.0.0:7946", "binding TCP Address for UDP and TCP gossip")
+	swimCfg.StringVar(&swimAdvertiseAddrStr, "advertise-addr", "", "advertised TCP Address for UDP and TCP gossip NAT traversal")
 	swimCfg.DurationVar(&swimTCPTimeout, "tcp-timeout", 10*time.Second, "timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes")
 	swimCfg.IntVar(&swimIndirectChecks, "indirect-checks", 3, "number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails")
 	swimCfg.IntVar(&swimRetransmitMult, "retransmit-mult", 4, "multiplier for number of retransmissions for gossip messages. Retransmits = RetransmitMult * log(N+1)")
@@ -117,6 +120,15 @@ func ConfigProcess() {
 		swimBindAddr, err = net.ResolveTCPAddr("tcp", swimBindAddrStr)
 		if err != nil {
 			log.Fatal(4, "CLU Config: swim-bind-addr is not a valid TCP address: %s", err.Error())
+		}
+
+		if swimAdvertiseAddrStr != "" {
+			swimAdvertiseAddr, err = net.ResolveTCPAddr("tcp", swimAdvertiseAddrStr)
+			if err != nil {
+				log.Fatal(4, "CLU Config: swim-advertise-addr is not a valid TCP address: %s", err.Error())
+			}
+		} else {
+			swimAdvertiseAddr = swimBindAddr
 		}
 	}
 }

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -59,7 +59,7 @@ func ConfigSetup() {
 	swimCfg := flag.NewFlagSet("swim", flag.ExitOnError)
 	swimCfg.StringVar(&swimUseConfig, "use-config", "manual", "config setting to use. If set to anything but manual, will override all other swim settings. Use manual|default-lan|default-local|default-wan. see https://godoc.org/github.com/hashicorp/memberlist#Config . Note all our swim settings correspond to default-lan")
 	swimCfg.StringVar(&swimBindAddrStr, "bind-addr", "0.0.0.0:7946", "binding TCP Address for UDP and TCP gossip")
-	swimCfg.StringVar(&swimAdvertiseAddrStr, "advertise-addr", "", "advertised TCP Address for UDP and TCP gossip NAT traversal")
+	swimCfg.StringVar(&swimAdvertiseAddrStr, "advertise-addr", "", "advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)")
 	swimCfg.DurationVar(&swimTCPTimeout, "tcp-timeout", 10*time.Second, "timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes")
 	swimCfg.IntVar(&swimIndirectChecks, "indirect-checks", 3, "number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails")
 	swimCfg.IntVar(&swimRetransmitMult, "retransmit-mult", 4, "multiplier for number of retransmissions for gossip messages. Retransmits = RetransmitMult * log(N+1)")

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -83,7 +83,8 @@ func NewMemberlistManager(thisNode HTTPNode) *MemberlistManager {
 		mgr.cfg = memberlist.DefaultLANConfig() // use this as base so that the other settings have proper defaults
 		mgr.cfg.BindPort = swimBindAddr.Port
 		mgr.cfg.BindAddr = swimBindAddr.IP.String()
-		mgr.cfg.AdvertisePort = swimBindAddr.Port
+		mgr.cfg.AdvertisePort = swimAdvertiseAddr.Port
+		mgr.cfg.AdvertiseAddr = swimAdvertiseAddr.IP.String()
 		mgr.cfg.TCPTimeout = swimTCPTimeout
 		mgr.cfg.IndirectChecks = swimIndirectChecks
 		mgr.cfg.RetransmitMult = swimRetransmitMult

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -251,6 +251,9 @@ http-timeout = 60s
 use-config = manual
 # binding TCP Address for UDP and TCP gossip (full ip/dns:port combo unlike memberlist.Config)
 bind-addr = 0.0.0.0:7946
+# advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)
+# Useful for traversing NAT such as from inside docker
+advertise-addr =
 # timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes
 tcp-timeout = 10s
 # number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -251,6 +251,9 @@ http-timeout = 60s
 use-config = manual
 # binding TCP Address for UDP and TCP gossip (full ip/dns:port combo unlike memberlist.Config)
 bind-addr = 0.0.0.0:7946
+# advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)
+# Useful for traversing NAT such as from inside docker
+advertise-addr =
 # timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes
 tcp-timeout = 10s
 # number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -251,6 +251,9 @@ http-timeout = 60s
 use-config = manual
 # binding TCP Address for UDP and TCP gossip (full ip/dns:port combo unlike memberlist.Config)
 bind-addr = 0.0.0.0:7946
+# advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)
+# Useful for traversing NAT such as from inside docker
+advertise-addr =
 # timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes
 tcp-timeout = 10s
 # number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails

--- a/docs/config.md
+++ b/docs/config.md
@@ -306,6 +306,9 @@ http-timeout = 60s
 use-config = manual
 # binding TCP Address for UDP and TCP gossip (full ip/dns:port combo unlike memberlist.Config)
 bind-addr = 0.0.0.0:7946
+# advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)
+# Useful for traversing NAT such as from inside docker
+advertise-addr =
 # timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes
 tcp-timeout = 10s
 # number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -254,6 +254,9 @@ http-timeout = 60s
 use-config = manual
 # binding TCP Address for UDP and TCP gossip (full ip/dns:port combo unlike memberlist.Config)
 bind-addr = 0.0.0.0:7946
+# advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)
+# Useful for traversing NAT such as from inside docker
+advertise-addr =
 # timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes
 tcp-timeout = 10s
 # number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -251,6 +251,9 @@ http-timeout = 60s
 use-config = manual
 # binding TCP Address for UDP and TCP gossip (full ip/dns:port combo unlike memberlist.Config)
 bind-addr = 0.0.0.0:7946
+# advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)
+# Useful for traversing NAT such as from inside docker
+advertise-addr =
 # timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes
 tcp-timeout = 10s
 # number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -251,6 +251,9 @@ http-timeout = 60s
 use-config = manual
 # binding TCP Address for UDP and TCP gossip (full ip/dns:port combo unlike memberlist.Config)
 bind-addr = 0.0.0.0:7946
+# advertised TCP address for UDP and TCP gossip (full ip/dns:port combo, or empty to use bind-addr)
+# Useful for traversing NAT such as from inside docker
+advertise-addr =
 # timeout for establishing a stream connection with peers for a full state sync, and for stream reads and writes
 tcp-timeout = 10s
 # number of nodes that will be asked to perform an indirect probe of a node in the case a direct probe fails


### PR DESCRIPTION
This exposes the raft advertise IP/port settings in the metrictank configuration file so that metrictank instances that are behind a NAT (such as when ports are exposed from a docker container). If a custom advertisement address is not provided, it falls back to using the bind IP/port (previous behavior).