### PR TITLE
refactor TimeLimiter

### DIFF
--- a/idx/memory/time_limit_test.go
+++ b/idx/memory/time_limit_test.go
@@ -69,3 +69,39 @@ func TestTimeLimiter(t *testing.T) {
 	time.AfterFunc(500*time.Millisecond, cancel)
 	shouldTakeAbout(t, tl.Wait, 500*time.Millisecond, 500, "window 3: work done: 130ms, canceling after 500ms - wait should be 500ms")
 }
+
+func BenchmarkTimeLimiterWaitNotLimited(b *testing.B) {
+	window := time.Second
+	limit := time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tl := NewTimeLimiter(ctx, window, limit)
+	for i := 0; i < b.N; i++ {
+		tl.Wait()
+	}
+}
+
+func BenchmarkTimeLimiterAddNotLimited(b *testing.B) {
+	window := time.Hour
+	limit := time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tl := NewTimeLimiter(ctx, window, limit)
+	for i := 0; i < b.N; i++ {
+		tl.Add(1)
+	}
+}
+
+func BenchmarkTimeLimiterAddLimited(b *testing.B) {
+	window := time.Hour
+	limit := time.Nanosecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tl := NewTimeLimiter(ctx, window, limit)
+	for i := 0; i < b.N; i++ {
+		tl.Add(1)
+	}
+}


### PR DESCRIPTION
Simplified the code to remove use of channels and just use locks
and a waitGroup

-- OLD code benchmark --
```
anthony:~/go/src/github.com/grafana/metrictank/idx/memory$ go test -v -race -run none -bench TimeLimiter -benchmem
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/idx/memory
BenchmarkTimeLimiterWaitNotLimited-4      500000              3245 ns/op              96 B/op          1 allocs/op
BenchmarkTimeLimiterAddNotLimited-4      1000000              1589 ns/op               0 B/op          0 allocs/op
BenchmarkTimeLimiterAddLimited-4         1000000              1552 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/grafana/metrictank/idx/memory        5.857s
```
-- NEW code benchmark --
```
anthony:~/go/src/github.com/grafana/metrictank/idx/memory$ go test -v -race -run none -bench TimeLimiter -benchmem
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/idx/memory
BenchmarkTimeLimiterWaitNotLimited-4    10000000               129 ns/op               0 B/op          0 allocs/op
BenchmarkTimeLimiterAddNotLimited-4      3000000               497 ns/op               0 B/op          0 allocs/op
BenchmarkTimeLimiterAddLimited-4         3000000               530 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/grafana/metrictank/idx/memory        6.574s
b6d0437
```