### PR TITLE
Add cache overhead accounting

### DIFF
--- a/dashboards/main/metrictank.json
+++ b/dashboards/main/metrictank.json
@@ -3650,6 +3650,13 @@
           "pointradius": 1,
           "points": true,
           "yaxis": 2
+        },
+        {
+          "alias": "/(.*?)overhead/",
+          "lines": false,
+          "points": true,
+          "pointradius": 1,
+          "yaxis": 2
         }
       ],
       "spaceLength": 10,
@@ -3659,16 +3666,41 @@
         {
           "refId": "A",
           "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.max.gauge64), 'max')",
-          "textEditor": false
+          "textEditor": false,
+          "refCount": 1
         },
         {
           "refId": "B",
-          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64), 'used')"
+          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64), 'used')",
+          "refCount": 1
         },
         {
           "refId": "C",
           "target": "alias(divideSeries(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64),sumSeries(metrictank.stats.$environment.$instance.cache.size.max.gauge64)), 'utilisation')",
-          "textEditor": true
+          "textEditor": true,
+          "refCount": 1
+        },
+        {
+          "refId": "D",
+          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.chunk.gauge64), 'chunk overhead')",
+          "refCount": 1
+        },
+        {
+          "refId": "E",
+          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.flat.gauge64), 'flat overhead')",
+          "refCount": 1
+        },
+        {
+          "refId": "F",
+          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.lru.gauge64), 'lru overhead')",
+          "refCount": 1
+        },
+        {
+          "refId": "G",
+          "target": "alias(sum(#B, #D, #E, #F),'total used')",
+          "textEditor": true,
+          "refCount": 0,
+          "targetFull": "alias(sum(alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64), 'used'), alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.chunk.gauge64), 'chunk overhead'), alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.flat.gauge64), 'flat overhead'), alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.lru.gauge64), 'lru overhead')),'total overhead')"
         }
       ],
       "thresholds": [],

--- a/dashboards/main/metrictank.json
+++ b/dashboards/main/metrictank.json
@@ -3652,7 +3652,28 @@
           "yaxis": 2
         },
         {
-          "alias": "/(.*?)overhead/",
+          "alias": "chunk",
+          "lines": false,
+          "pointradius": 1,
+          "points": true,
+          "yaxis": 2
+        },
+        {
+          "alias": "total used",
+          "lines": false,
+          "points": true,
+          "pointradius": 1,
+          "yaxis": 2
+        },
+        {
+          "alias": "flat",
+          "lines": false,
+          "points": true,
+          "pointradius": 1,
+          "yaxis": 2
+        },
+        {
+          "alias": "lru",
           "lines": false,
           "points": true,
           "pointradius": 1,
@@ -3664,43 +3685,34 @@
       "steppedLine": false,
       "targets": [
         {
+          "refCount": 0,
           "refId": "A",
           "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.max.gauge64), 'max')",
-          "textEditor": false,
-          "refCount": 1
+          "textEditor": false
         },
         {
+          "refCount": -1,
           "refId": "B",
-          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64), 'used')",
-          "refCount": 1
+          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64), 'used')"
         },
         {
+          "refCount": 0,
           "refId": "C",
           "target": "alias(divideSeries(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64),sumSeries(metrictank.stats.$environment.$instance.cache.size.max.gauge64)), 'utilisation')",
-          "textEditor": true,
-          "refCount": 1
+          "textEditor": true
         },
         {
           "refId": "D",
-          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.chunk.gauge64), 'chunk overhead')",
-          "refCount": 1
+          "target": "groupByNodes(aliasByNode(metrictank.stats.$environment.$instance.cache.overhead.*.gauge64, 6), 'sum', 0)",
+          "refCount": -1,
+          "hide": false
         },
         {
-          "refId": "E",
-          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.flat.gauge64), 'flat overhead')",
-          "refCount": 1
-        },
-        {
-          "refId": "F",
-          "target": "alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.lru.gauge64), 'lru overhead')",
-          "refCount": 1
-        },
-        {
-          "refId": "G",
-          "target": "alias(sum(#B, #D, #E, #F),'total used')",
-          "textEditor": true,
           "refCount": 0,
-          "targetFull": "alias(sum(alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64), 'used'), alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.chunk.gauge64), 'chunk overhead'), alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.flat.gauge64), 'flat overhead'), alias(sumSeries(metrictank.stats.$environment.$instance.cache.overhead.lru.gauge64), 'lru overhead')),'total overhead')"
+          "refId": "E",
+          "target": "alias(sum(#B, #D),'total used')",
+          "textEditor": true,
+          "targetFull": "alias(sum(alias(sumSeries(metrictank.stats.$environment.$instance.cache.size.used.gauge64), 'used'), groupByNodes(aliasByNode(metrictank.stats.$environment.$instance.cache.overhead.*.gauge64, 6), 'sum', 0)),'total used')"
         }
       ],
       "thresholds": [],

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -52,6 +52,16 @@ how many metrics were hit fully (all needed chunks in cache)
 how many metrics were hit partially (some of the needed chunks in cache, but not all)
 * `cache.ops.metric.miss`:  
 how many metrics were missed fully (no needed chunks in cache)
+* `cache.overhead.chunk`:  
+an approximation of the overhead used to store chunks in the cache
+* `cache.overhead.flat`:  
+an approximation of the overhead used by flat accounting
+* `cache.overhead.lru`:  
+an approximation of the overhead used by the LRU
+* `cache.size.max`:  
+the maximum size of the cache (overhead does not count towards this limit)
+* `cache.size.used`:  
+how much of the cache is used (sum of the chunk data without overhead)
 * `cluster.decode_err.join`:  
 a counter of json unmarshal errors
 * `cluster.decode_err.update`:  

--- a/mdata/cache/accnt/flat_accnt.go
+++ b/mdata/cache/accnt/flat_accnt.go
@@ -254,11 +254,6 @@ func (a *FlatAccnt) eventLoop() {
 	}
 }
 
-// // totalUsed returns the sum of cacheSizeUsed, cacheOverheadChunk, cacheOverheadFlat, and cacheOverheadLru
-// func (a *FlatAccnt) totalUsed() uint64 {
-// 	return (cacheSizeUsed.Peek() + cacheOverheadChunk.Peek() + cacheOverheadFlat.Peek() + cacheOverheadLru.Peek())
-// }
-
 func (a *FlatAccnt) getTotal(res_chan chan uint64) {
 	res_chan <- cacheSizeUsed.Peek()
 }

--- a/mdata/cache/accnt/lru_test.go
+++ b/mdata/cache/accnt/lru_test.go
@@ -92,6 +92,7 @@ func TestLRUDelete(t *testing.T) {
 	}
 }
 
+// BenchmarkLRUGrowth is used to create comparisons of memory allocations as the LRU is optimized
 func BenchmarkLRUGrowth(b *testing.B) {
 	b.StopTimer()
 

--- a/mdata/cache/accnt/lru_test.go
+++ b/mdata/cache/accnt/lru_test.go
@@ -2,6 +2,8 @@ package accnt
 
 import (
 	"testing"
+
+	"github.com/grafana/metrictank/test"
 )
 
 func TestLRU(t *testing.T) {
@@ -88,4 +90,29 @@ func TestLRUDelete(t *testing.T) {
 	if len(lru.items) != expectedSize || lru.list.Len() != expectedSize {
 		t.Fatalf("Expected lru to contain %d items, but have %d / %d", expectedSize, len(lru.items), lru.list.Len())
 	}
+}
+
+func BenchmarkLRUGrowth(b *testing.B) {
+	b.StopTimer()
+
+	lru := NewLRU()
+
+	var targets []EvictTarget
+
+	amkey := test.GetAMKey(1)
+
+	// create our EvictTargets
+	for i := 0; i < (100 * 1024); i++ {
+		targets = append(targets, EvictTarget{
+			Metric: amkey,
+			Ts:     uint32(i)})
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		for _, target := range targets {
+			lru.touch(target)
+		}
+	}
+
 }

--- a/mdata/cache/accnt/stats.go
+++ b/mdata/cache/accnt/stats.go
@@ -33,6 +33,9 @@ var (
 
 	cacheSizeMax          = stats.NewGauge64("cache.size.max")
 	cacheSizeUsed         = stats.NewGauge64("cache.size.used")
+	cacheOverheadChunk    = stats.NewGauge64("cache.overhead.chunk")
+	cacheOverheadFlat     = stats.NewGauge64("cache.overhead.flat")
+	cacheOverheadLru      = stats.NewGauge64("cache.overhead.lru")
 	accntEventAddDuration = stats.NewLatencyHistogram15s32("cache.accounting.queue.add")
 	accntEventQueueUsed   = stats.NewRange32("cache.accounting.queue.size.used")
 	accntEventQueueMax    = stats.NewGauge64("cache.accounting.queue.size.max")

--- a/mdata/cache/accnt/stats.go
+++ b/mdata/cache/accnt/stats.go
@@ -31,11 +31,21 @@ var (
 	// metric cache.ops.chunk.evict is how many chunks were evicted from the cache
 	cacheChunkEvict = stats.NewCounter32("cache.ops.chunk.evict")
 
-	cacheSizeMax          = stats.NewGauge64("cache.size.max")
-	cacheSizeUsed         = stats.NewGauge64("cache.size.used")
-	cacheOverheadChunk    = stats.NewGauge64("cache.overhead.chunk")
-	cacheOverheadFlat     = stats.NewGauge64("cache.overhead.flat")
-	cacheOverheadLru      = stats.NewGauge64("cache.overhead.lru")
+	// metric cache.size.max is the maximum size of the cache (overhead does not count towards this limit)
+	cacheSizeMax = stats.NewGauge64("cache.size.max")
+
+	// metric cache.size.used is how much of the cache is used (sum of the chunk data without overhead)
+	cacheSizeUsed = stats.NewGauge64("cache.size.used")
+
+	// metric cache.overhead.chunk is an approximation of the overhead used to store chunks in the cache
+	cacheOverheadChunk = stats.NewGauge64("cache.overhead.chunk")
+
+	// metric cache.overhead.flat is an approximation of the overhead used by flat accounting
+	cacheOverheadFlat = stats.NewGauge64("cache.overhead.flat")
+
+	// metric cache.overhead.lru is an approximation of the overhead used by the LRU
+	cacheOverheadLru = stats.NewGauge64("cache.overhead.lru")
+
 	accntEventAddDuration = stats.NewLatencyHistogram15s32("cache.accounting.queue.add")
 	accntEventQueueUsed   = stats.NewRange32("cache.accounting.queue.size.used")
 	accntEventQueueMax    = stats.NewGauge64("cache.accounting.queue.size.max")


### PR DESCRIPTION
Prior to this change we were only counting the number of bytes
that the actual data occupied. However, there is a lot of overhead
in our cache system that also needs to be tracked. We were seeing
large differences in the total cache size used and and live heap
allocations.

These changes attempt to track most of the accounting overhead.
The numbers used to track overhead are estimates based on
data type sizes.

 * Added stats for Flat Acccounting, the LRU, and Chunks
 * Added benchmark for LRU allocations

Resolves: #1086
See also: #963