### PR TITLE
Fix advertise address bug in cluster config

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -124,10 +124,8 @@ func ConfigProcess() {
 		if swimAdvertiseAddrStr != "" {
 			swimAdvertiseAddr, err = net.ResolveTCPAddr("tcp", swimAdvertiseAddrStr)
 			if err != nil {
-				log.Fatal(4, "CLU Config: swim-advertise-addr is not a valid TCP address: %s", err.Error())
+				log.Fatalf("CLU Config: swim-advertise-addr is not a valid TCP address: %s", err.Error())
 			}
-		} else {
-			swimAdvertiseAddr = swimBindAddr
 		}
 	}
 }

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -83,8 +83,12 @@ func NewMemberlistManager(thisNode HTTPNode) *MemberlistManager {
 		mgr.cfg = memberlist.DefaultLANConfig() // use this as base so that the other settings have proper defaults
 		mgr.cfg.BindPort = swimBindAddr.Port
 		mgr.cfg.BindAddr = swimBindAddr.IP.String()
-		mgr.cfg.AdvertisePort = swimAdvertiseAddr.Port
-		mgr.cfg.AdvertiseAddr = swimAdvertiseAddr.IP.String()
+		if swimAdvertiseAddr == nil {
+			mgr.cfg.AdvertisePort = swimBindAddr.Port
+		} else {
+			mgr.cfg.AdvertisePort = swimAdvertiseAddr.Port
+			mgr.cfg.AdvertiseAddr = swimAdvertiseAddr.IP.String()
+		}
 		mgr.cfg.TCPTimeout = swimTCPTimeout
 		mgr.cfg.IndirectChecks = swimIndirectChecks
 		mgr.cfg.RetransmitMult = swimRetransmitMult


### PR DESCRIPTION
Fixes bug introduced in #1089 which was causing metrictank to send out it's IP Address as `0.0.0.0`

Resolves: #1096
See also: #1089