### PR TITLE
Fix parsing duration and durationVar in cass idx

### DIFF
--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -316,7 +316,7 @@ func main() {
 		}
 		metricIndex = memory.New()
 	}
-	if cassandra.Enabled {
+	if cassandra.CasIdxConfig.Enabled {
 		if metricIndex != nil {
 			log.Fatal("Only 1 metricIndex handler can be enabled.")
 		}

--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -142,7 +142,7 @@ func main() {
 
 	globalFlags.Parse(os.Args[1:cassI])
 	cassFlags.Parse(os.Args[cassI+1 : len(os.Args)-1])
-	cassandra.Enabled = true
+	cassandra.CasIdxConfig.Enabled = true
 
 	var show func(d schema.MetricDefinition)
 

--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -155,7 +155,7 @@ func main() {
 
 	globalFlags.Parse(os.Args[1:cassI])
 	cassFlags.Parse(os.Args[cassI+1 : len(os.Args)])
-	cassandra.Enabled = true
+	cassandra.CasIdxConfig.Enabled = true
 
 	if *verbose {
 		log.SetLevel(log.DebugLevel)

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -346,7 +346,7 @@ num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
 #automatically clear series from the index if they have not been seen for this much time.
-max-stale = 0
+max-stale = 0s
 #Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -346,7 +346,7 @@ num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
 #automatically clear series from the index if they have not been seen for this much time.
-max-stale = 0
+max-stale = 0s
 #Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -346,7 +346,7 @@ num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
 #automatically clear series from the index if they have not been seen for this much time.
-max-stale = 0
+max-stale = 0s
 #Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.

--- a/docs/config.md
+++ b/docs/config.md
@@ -408,7 +408,7 @@ num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
 #automatically clear series from the index if they have not been seen for this much time.
-max-stale = 0
+max-stale = 0s
 #Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -110,26 +110,26 @@ cass config flags:
     	comma separated list of cassandra addresses in host:port form (default "localhost:9042")
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
-  -max-stale duration
-    	clear series from the index if they have not been seen for this much time.
+  -max-stale string
+    	clear series from the index if they have not been seen for this much time. (default "0s")
   -num-conns int
     	number of concurrent connections to cassandra (default 10)
   -password string
     	password for authentication (default "cassandra")
   -protocol-version int
     	cql protocol version to use (default 4)
-  -prune-interval duration
-    	Interval at which the index should be checked for stale series. (default 3h0m0s)
+  -prune-interval string
+    	Interval at which the index should be checked for stale series. (default "3h")
   -schema-file string
     	File containing the needed schemas in case database needs initializing (default "/etc/metrictank/schema-idx-cassandra.toml")
   -ssl
     	enable SSL connection to cassandra
-  -timeout duration
-    	cassandra request timeout (default 1s)
+  -timeout string
+    	cassandra request timeout (default "1s")
   -update-cassandra-index
     	synchronize index changes to cassandra. not all your nodes need to do this. (default true)
-  -update-interval duration
-    	frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates (default 3h0m0s)
+  -update-interval string
+    	frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates (default "3h")
   -username string
     	username for authentication (default "cassandra")
   -write-queue-size int
@@ -663,26 +663,26 @@ cass config flags:
     	comma separated list of cassandra addresses in host:port form (default "localhost:9042")
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
-  -max-stale duration
-    	clear series from the index if they have not been seen for this much time.
+  -max-stale string
+    	clear series from the index if they have not been seen for this much time. (default "0s")
   -num-conns int
     	number of concurrent connections to cassandra (default 10)
   -password string
     	password for authentication (default "cassandra")
   -protocol-version int
     	cql protocol version to use (default 4)
-  -prune-interval duration
-    	Interval at which the index should be checked for stale series. (default 3h0m0s)
+  -prune-interval string
+    	Interval at which the index should be checked for stale series. (default "3h")
   -schema-file string
     	File containing the needed schemas in case database needs initializing (default "/etc/metrictank/schema-idx-cassandra.toml")
   -ssl
     	enable SSL connection to cassandra
-  -timeout duration
-    	cassandra request timeout (default 1s)
+  -timeout string
+    	cassandra request timeout (default "1s")
   -update-cassandra-index
     	synchronize index changes to cassandra. not all your nodes need to do this. (default true)
-  -update-interval duration
-    	frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates (default 3h0m0s)
+  -update-interval string
+    	frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates (default "3h")
   -username string
     	username for authentication (default "cassandra")
   -write-queue-size int

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -61,14 +61,17 @@ func (i *testIterator) Close() error {
 }
 
 func init() {
+	CasIdxConfig = NewCasIdxConfig()
 	CasIdxConfig.keyspace = "metrictank"
 	CasIdxConfig.hosts = ""
 	CasIdxConfig.consistency = "one"
 	CasIdxConfig.timeout = 1
+	timeout = time.Second
 	CasIdxConfig.numConns = 1
 	CasIdxConfig.writeQueueSize = 1000
 	CasIdxConfig.protoVer = 4
 	CasIdxConfig.updateCassIdx = false
+	updateInterval = time.Hour
 
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 }
@@ -174,15 +177,19 @@ func TestAddToWriteQueue(t *testing.T) {
 	originalUpdateCassIdx := CasIdxConfig.updateCassIdx
 	originalUpdateInterval := CasIdxConfig.updateInterval
 	originalWriteQSize := CasIdxConfig.writeQueueSize
+	originalUpdateIntervalDur := updateInterval
 
 	defer func() {
 		CasIdxConfig.updateCassIdx = originalUpdateCassIdx
+		updateCassIdx = originalUpdateCassIdx
 		CasIdxConfig.updateInterval = originalUpdateInterval
 		CasIdxConfig.writeQueueSize = originalWriteQSize
+		updateInterval = originalUpdateIntervalDur
 	}()
 
 	CasIdxConfig.updateCassIdx = true
-	CasIdxConfig.updateInterval = 10
+	updateCassIdx = true
+	updateInterval = 10
 	CasIdxConfig.writeQueueSize = 5
 	ix := New()
 	initForTests(ix)
@@ -419,10 +426,12 @@ func BenchmarkIndexing(b *testing.B) {
 	CasIdxConfig.hosts = "localhost:9042"
 	CasIdxConfig.consistency = "one"
 	CasIdxConfig.timeout = 1
+	timeout = time.Second
 	CasIdxConfig.numConns = 10
 	CasIdxConfig.writeQueueSize = 10
 	CasIdxConfig.protoVer = 4
 	CasIdxConfig.updateInterval = 3600
+	updateInterval = time.Hour
 	CasIdxConfig.updateCassIdx = true
 	ix := New()
 	tmpSession, err := ix.cluster.CreateSession()
@@ -467,10 +476,12 @@ func BenchmarkLoad(b *testing.B) {
 	CasIdxConfig.hosts = "localhost:9042"
 	CasIdxConfig.consistency = "one"
 	CasIdxConfig.timeout = 1
+	timeout = time.Second
 	CasIdxConfig.numConns = 10
 	CasIdxConfig.writeQueueSize = 10
 	CasIdxConfig.protoVer = 4
 	CasIdxConfig.updateInterval = 3600
+	updateInterval = time.Hour
 	CasIdxConfig.updateCassIdx = true
 	ix := New()
 
@@ -500,10 +511,12 @@ func BenchmarkIndexingWithUpdates(b *testing.B) {
 	CasIdxConfig.hosts = "localhost:9042"
 	CasIdxConfig.consistency = "one"
 	CasIdxConfig.timeout = 1
+	timeout = time.Second
 	CasIdxConfig.numConns = 10
 	CasIdxConfig.writeQueueSize = 10
 	CasIdxConfig.protoVer = 4
 	CasIdxConfig.updateInterval = 3600
+	updateInterval = time.Hour
 	CasIdxConfig.updateCassIdx = true
 	ix := New()
 	tmpSession, err := ix.cluster.CreateSession()

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -61,14 +61,14 @@ func (i *testIterator) Close() error {
 }
 
 func init() {
-	keyspace = "metrictank"
-	hosts = ""
-	consistency = "one"
-	timeout = time.Second
-	numConns = 1
-	writeQueueSize = 1000
-	protoVer = 4
-	updateCassIdx = false
+	CasIdxConfig.keyspace = "metrictank"
+	CasIdxConfig.hosts = ""
+	CasIdxConfig.consistency = "one"
+	CasIdxConfig.timeout = 1
+	CasIdxConfig.numConns = 1
+	CasIdxConfig.writeQueueSize = 1000
+	CasIdxConfig.protoVer = 4
+	CasIdxConfig.updateCassIdx = false
 
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 }
@@ -171,19 +171,19 @@ func TestGetAddKey(t *testing.T) {
 }
 
 func TestAddToWriteQueue(t *testing.T) {
-	originalUpdateCassIdx := updateCassIdx
-	originalUpdateInterval := updateInterval
-	originalWriteQSize := writeQueueSize
+	originalUpdateCassIdx := CasIdxConfig.updateCassIdx
+	originalUpdateInterval := CasIdxConfig.updateInterval
+	originalWriteQSize := CasIdxConfig.writeQueueSize
 
 	defer func() {
-		updateCassIdx = originalUpdateCassIdx
-		updateInterval = originalUpdateInterval
-		writeQueueSize = originalWriteQSize
+		CasIdxConfig.updateCassIdx = originalUpdateCassIdx
+		CasIdxConfig.updateInterval = originalUpdateInterval
+		CasIdxConfig.writeQueueSize = originalWriteQSize
 	}()
 
-	updateCassIdx = true
-	updateInterval = 10
-	writeQueueSize = 5
+	CasIdxConfig.updateCassIdx = true
+	CasIdxConfig.updateInterval = 10
+	CasIdxConfig.writeQueueSize = 5
 	ix := New()
 	initForTests(ix)
 	metrics := getMetricData(1, 2, 5, 10, "metric.demo")
@@ -415,15 +415,15 @@ func TestFind(t *testing.T) {
 
 func BenchmarkIndexing(b *testing.B) {
 	cluster.Manager.SetPartitions([]int32{1})
-	keyspace = "metrictank"
-	hosts = "localhost:9042"
-	consistency = "one"
-	timeout = time.Second
-	numConns = 10
-	writeQueueSize = 10
-	protoVer = 4
-	updateInterval = time.Hour
-	updateCassIdx = true
+	CasIdxConfig.keyspace = "metrictank"
+	CasIdxConfig.hosts = "localhost:9042"
+	CasIdxConfig.consistency = "one"
+	CasIdxConfig.timeout = 1
+	CasIdxConfig.numConns = 10
+	CasIdxConfig.writeQueueSize = 10
+	CasIdxConfig.protoVer = 4
+	CasIdxConfig.updateInterval = 3600
+	CasIdxConfig.updateCassIdx = true
 	ix := New()
 	tmpSession, err := ix.cluster.CreateSession()
 	if err != nil {
@@ -463,15 +463,15 @@ func insertDefs(ix idx.MetricIndex, i int) {
 
 func BenchmarkLoad(b *testing.B) {
 	cluster.Manager.SetPartitions([]int32{1})
-	keyspace = "metrictank"
-	hosts = "localhost:9042"
-	consistency = "one"
-	timeout = time.Second
-	numConns = 10
-	writeQueueSize = 10
-	protoVer = 4
-	updateInterval = time.Hour
-	updateCassIdx = true
+	CasIdxConfig.keyspace = "metrictank"
+	CasIdxConfig.hosts = "localhost:9042"
+	CasIdxConfig.consistency = "one"
+	CasIdxConfig.timeout = 1
+	CasIdxConfig.numConns = 10
+	CasIdxConfig.writeQueueSize = 10
+	CasIdxConfig.protoVer = 4
+	CasIdxConfig.updateInterval = 3600
+	CasIdxConfig.updateCassIdx = true
 	ix := New()
 
 	tmpSession, err := ix.cluster.CreateSession()
@@ -496,15 +496,15 @@ func BenchmarkLoad(b *testing.B) {
 
 func BenchmarkIndexingWithUpdates(b *testing.B) {
 	cluster.Manager.SetPartitions([]int32{1})
-	keyspace = "metrictank"
-	hosts = "localhost:9042"
-	consistency = "one"
-	timeout = time.Second
-	numConns = 10
-	writeQueueSize = 10
-	protoVer = 4
-	updateInterval = time.Hour
-	updateCassIdx = true
+	CasIdxConfig.keyspace = "metrictank"
+	CasIdxConfig.hosts = "localhost:9042"
+	CasIdxConfig.consistency = "one"
+	CasIdxConfig.timeout = 1
+	CasIdxConfig.numConns = 10
+	CasIdxConfig.writeQueueSize = 10
+	CasIdxConfig.protoVer = 4
+	CasIdxConfig.updateInterval = 3600
+	CasIdxConfig.updateCassIdx = true
 	ix := New()
 	tmpSession, err := ix.cluster.CreateSession()
 	if err != nil {

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -1,0 +1,97 @@
+package cassandra
+
+import (
+	"flag"
+
+	"github.com/rakyll/globalconf"
+)
+
+// IdxConfig holds all configuration variables for a Cassandra Index
+type IdxConfig struct {
+	Enabled                  bool
+	ssl                      bool
+	auth                     bool
+	hostverification         bool
+	createKeyspace           bool
+	schemaFile               string
+	keyspace                 string
+	hosts                    string
+	capath                   string
+	username                 string
+	password                 string
+	consistency              string
+	timeoutStr               string
+	timeout                  uint32 // in seconds
+	numConns                 int
+	writeQueueSize           int
+	protoVer                 int
+	maxStaleStr              string
+	maxStale                 uint32 // in seconds
+	pruneIntervalStr         string
+	pruneInterval            uint32 // in seconds
+	updateCassIdx            bool
+	updateIntervalStr        string
+	updateInterval           uint32 // in seconds
+	disableInitialHostLookup bool
+}
+
+// NewCasIdxConfig returns a new IdxConfig with default values set
+func NewCasIdxConfig() *IdxConfig {
+	return &IdxConfig{
+		Enabled:                  true,
+		hosts:                    "localhost:9042",
+		keyspace:                 "metrictank",
+		consistency:              "one",
+		timeoutStr:               "1s",
+		numConns:                 10,
+		writeQueueSize:           100000,
+		updateCassIdx:            true,
+		updateIntervalStr:        "3h",
+		maxStaleStr:              "0s",
+		pruneIntervalStr:         "3h",
+		protoVer:                 4,
+		createKeyspace:           true,
+		schemaFile:               "/etc/metrictank/schema-idx-cassandra.toml",
+		disableInitialHostLookup: false,
+		ssl:                      false,
+		capath:                   "/etc/metrictank/ca.pem",
+		hostverification:         true,
+		auth:                     false,
+		username:                 "cassandra",
+		password:                 "cassandra",
+	}
+}
+
+// CasIdxConfig stores a Cassandra Index configuration with default values
+var CasIdxConfig = NewCasIdxConfig()
+
+// ConfigSetup creates a Cassandra Index configuration using default values, values passed in through the command line, or values from the environment
+func ConfigSetup() *flag.FlagSet {
+	casIdx := flag.NewFlagSet("cassandra-idx", flag.ExitOnError)
+
+	casIdx.BoolVar(&CasIdxConfig.Enabled, "enabled", CasIdxConfig.Enabled, "")
+	casIdx.StringVar(&CasIdxConfig.hosts, "hosts", CasIdxConfig.hosts, "comma separated list of cassandra addresses in host:port form")
+	casIdx.StringVar(&CasIdxConfig.keyspace, "keyspace", CasIdxConfig.keyspace, "Cassandra keyspace to store metricDefinitions in.")
+	casIdx.StringVar(&CasIdxConfig.consistency, "consistency", CasIdxConfig.consistency, "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
+	casIdx.StringVar(&CasIdxConfig.timeoutStr, "timeout", CasIdxConfig.timeoutStr, "cassandra request timeout")
+	casIdx.IntVar(&CasIdxConfig.numConns, "num-conns", CasIdxConfig.numConns, "number of concurrent connections to cassandra")
+	casIdx.IntVar(&CasIdxConfig.writeQueueSize, "write-queue-size", CasIdxConfig.writeQueueSize, "Max number of metricDefs allowed to be unwritten to cassandra")
+	casIdx.BoolVar(&CasIdxConfig.updateCassIdx, "update-cassandra-index", CasIdxConfig.updateCassIdx, "synchronize index changes to cassandra. not all your nodes need to do this.")
+	casIdx.StringVar(&CasIdxConfig.updateIntervalStr, "update-interval", CasIdxConfig.updateIntervalStr, "frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates")
+	casIdx.StringVar(&CasIdxConfig.maxStaleStr, "max-stale", CasIdxConfig.maxStaleStr, "clear series from the index if they have not been seen for this much time.")
+	casIdx.StringVar(&CasIdxConfig.pruneIntervalStr, "prune-interval", CasIdxConfig.pruneIntervalStr, "Interval at which the index should be checked for stale series.")
+	casIdx.IntVar(&CasIdxConfig.protoVer, "protocol-version", CasIdxConfig.protoVer, "cql protocol version to use")
+	casIdx.BoolVar(&CasIdxConfig.createKeyspace, "create-keyspace", CasIdxConfig.createKeyspace, "enable the creation of the index keyspace and tables, only one node needs this")
+	casIdx.StringVar(&CasIdxConfig.schemaFile, "schema-file", CasIdxConfig.schemaFile, "File containing the needed schemas in case database needs initializing")
+	casIdx.BoolVar(&CasIdxConfig.disableInitialHostLookup, "disable-initial-host-lookup", CasIdxConfig.disableInitialHostLookup, "instruct the driver to not attempt to get host info from the system.peers table")
+	casIdx.BoolVar(&CasIdxConfig.ssl, "ssl", CasIdxConfig.ssl, "enable SSL connection to cassandra")
+	casIdx.StringVar(&CasIdxConfig.capath, "ca-path", CasIdxConfig.capath, "cassandra CA certficate path when using SSL")
+	casIdx.BoolVar(&CasIdxConfig.hostverification, "host-verification", CasIdxConfig.hostverification, "host (hostname and server cert) verification when using SSL")
+
+	casIdx.BoolVar(&CasIdxConfig.auth, "auth", CasIdxConfig.auth, "enable cassandra user authentication")
+	casIdx.StringVar(&CasIdxConfig.username, "username", CasIdxConfig.username, "username for authentication")
+	casIdx.StringVar(&CasIdxConfig.password, "password", CasIdxConfig.password, "password for authentication")
+
+	globalconf.Register("cassandra-idx", casIdx)
+	return casIdx
+}

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -349,7 +349,7 @@ num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
 #automatically clear series from the index if they have not been seen for this much time.
-max-stale = 0
+max-stale = 0s
 #Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -346,7 +346,7 @@ num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
 #automatically clear series from the index if they have not been seen for this much time.
-max-stale = 0
+max-stale = 0s
 #Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -346,7 +346,7 @@ num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
 #automatically clear series from the index if they have not been seen for this much time.
-max-stale = 0
+max-stale = 0s
 #Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.


### PR DESCRIPTION
Change flag.Duration and flag.DurationVar to flag.StringVar for parsing
Add config.go to cassandra idx to align with cassandra store
Add variables to cassandra idx to avoid indirection in calls to config
Update docs and metrictank example configs to reflect changes

Duration configuration settings in cassandra idx will now accept the
following time units: s/sec/secs/second/seconds, m/min/mins/minute/minutes,
h/hour/hours, d/day/days, w/week/weeks, mon/month/months, y/year/years

First step in implementing flag.StringVar throughout all of metrictank to allow
easier parsing and control

See also: #944