### PR TITLE
update ffi build dependency

### DIFF
--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem "fpm", "~> 1.4"
 gem "package_cloud", "~> 0.2"
+gem "ffi", ">= 1.9.24"

--- a/scripts/Gemfile.lock
+++ b/scripts/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     colorize (0.7.7)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.10)
+    ffi (1.9.25)
     fpm (1.4.0)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
@@ -46,8 +46,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ffi (>= 1.9.24)
   fpm (~> 1.4)
   package_cloud (~> 0.2)
 
 BUNDLED WITH
-   1.10.5
+   1.16.6


### PR DESCRIPTION
per Github:

CVE-2018-1000201 More information
moderate severity
Vulnerable versions: < 1.9.24
Patched version: 1.9.24
ruby-ffi version 1.9.23 and earlier has a DLL loading issue which can be
hijacked on Windows OS, when a Symbol is used as DLL name instead of a
String This vulnerability appears to have been fixed in v1.9.24 and
later.

https://nvd.nist.gov/vuln/detail/CVE-2018-1000201

====

see https://github.com/ffi/ffi/blob/master/CHANGELOG.md and 
https://github.com/ffi/ffi/releases -> no major changes