### PR TITLE
fix panic caused by multiple closes of pluginFatal channel

### DIFF
--- a/cmd/mt-kafka-mdm-sniff-out-of-order/main.go
+++ b/cmd/mt-kafka-mdm-sniff-out-of-order/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -211,14 +212,14 @@ func main() {
 	stats.NewDevnull() // make sure metrics don't pile up without getting discarded
 
 	mdm := inKafkaMdm.New()
-	pluginFatal := make(chan struct{})
-	mdm.Start(newInputOOOFinder(*format), pluginFatal)
+	ctx, cancel := context.WithCancel(context.Background())
+	mdm.Start(newInputOOOFinder(*format), cancel)
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	select {
 	case sig := <-sigChan:
 		log.Infof("Received signal %q. Shutting down", sig)
-	case <-pluginFatal:
+	case <-ctx.Done():
 		log.Info("Mdm input plugin signalled a fatal error. Shutting down")
 	}
 	mdm.Stop()

--- a/input/carbon/carbon.go
+++ b/input/carbon/carbon.go
@@ -4,6 +4,7 @@ package carbon
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"io"
 	"net"
@@ -106,7 +107,7 @@ func (c *Carbon) IntervalGetter(i IntervalGetter) {
 	c.intervalGetter = i
 }
 
-func (c *Carbon) Start(handler input.Handler, fatal chan struct{}) error {
+func (c *Carbon) Start(handler input.Handler, cancel context.CancelFunc) error {
 	c.Handler = handler
 	l, err := net.ListenTCP("tcp", c.addr)
 	if nil != err {

--- a/input/plugin.go
+++ b/input/plugin.go
@@ -1,13 +1,15 @@
 package input
 
+import "context"
+
 type Plugin interface {
 	Name() string
 	// Start starts the plugin.
-	// The plugin closes the fatal chan should any non-recoverable error occur after Start has returned.
-	// if Start returns an error, or the fatal chan is closed by the plugin,
+	// The plugin calls cancel should any non-recoverable error occur after Start has returned.
+	// if Start returns an error, or cancel is called by the plugin,
 	// the caller (e.g. main process) should shut down all its resources and exit.
 	// Note that upon fatal close, metrictank will call Stop() on all plugins, also the one that triggered it.
-	Start(handler Handler, fatal chan struct{}) error
+	Start(handler Handler, cancel context.CancelFunc) error
 	MaintainPriority()
 	ExplainPriority() interface{}
 	Stop() // Should block until shutdown is complete.

--- a/input/prometheus/prometheus.go
+++ b/input/prometheus/prometheus.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -25,7 +26,6 @@ var (
 
 type prometheusWriteHandler struct {
 	input.Handler
-	quit chan struct{}
 }
 
 func New() *prometheusWriteHandler {
@@ -36,9 +36,8 @@ func (p *prometheusWriteHandler) Name() string {
 	return "prometheus"
 }
 
-func (p *prometheusWriteHandler) Start(handler input.Handler, fatal chan struct{}) error {
+func (p *prometheusWriteHandler) Start(handler input.Handler, cancel context.CancelFunc) error {
 	p.Handler = handler
-	p.quit = fatal
 	ConfigSetup()
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
multiple input plugins, or multiple goroutines within a plugin
could try to close the same pluginFatal channel, which
results in a panic.

We fix this by switching to a context and cancelFunc, which
can be called multiple times

fix #870