### PR TITLE
fix bigtable idx pruning + index-rules.conf pruning for bigtable idx

### DIFF
--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -426,8 +426,6 @@ write-concurrency = 5
 update-bigtable-index = true
 # frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
 update-interval = 3h
-# clear series from the index if they have not been seen for this much time.
-max-stale = 0
 # Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # enable the creation of the table and column families

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -426,8 +426,6 @@ write-concurrency = 5
 update-bigtable-index = true
 # frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
 update-interval = 3h
-# clear series from the index if they have not been seen for this much time.
-max-stale = 0
 # Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # enable the creation of the table and column families

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -426,8 +426,6 @@ write-concurrency = 5
 update-bigtable-index = true
 # frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
 update-interval = 3h
-# clear series from the index if they have not been seen for this much time.
-max-stale = 0
 # Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # enable the creation of the table and column families

--- a/docs/config.md
+++ b/docs/config.md
@@ -498,8 +498,6 @@ write-concurrency = 5
 update-bigtable-index = true
 # frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
 update-interval = 3h
-# clear series from the index if they have not been seen for this much time.
-max-stale = 0
 # Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # enable the creation of the table and column families

--- a/idx/bigtable/config.go
+++ b/idx/bigtable/config.go
@@ -20,7 +20,6 @@ type IdxConfig struct {
 	UpdateBigtableIdx bool
 	UpdateInterval    time.Duration
 	updateInterval32  uint32
-	MaxStale          time.Duration
 	PruneInterval     time.Duration
 	CreateCF          bool
 }
@@ -33,7 +32,7 @@ func (cfg *IdxConfig) Validate() error {
 	if cfg.WriteMaxFlushSize >= cfg.WriteQueueSize {
 		return errors.New("write-queue-size must be larger then write-max-flush-size")
 	}
-	if cfg.MaxStale > 0 && cfg.PruneInterval == 0 {
+	if cfg.PruneInterval == 0 {
 		return errors.New("pruneInterval must be greater then 0")
 	}
 	return nil
@@ -51,7 +50,6 @@ func NewIdxConfig() *IdxConfig {
 		WriteConcurrency:  5,
 		UpdateBigtableIdx: true,
 		UpdateInterval:    time.Hour * 3,
-		MaxStale:          0,
 		PruneInterval:     time.Hour * 3,
 		CreateCF:          true,
 	}
@@ -71,7 +69,6 @@ func ConfigSetup() {
 	btIdx.IntVar(&CliConfig.WriteConcurrency, "write-concurrency", CliConfig.WriteConcurrency, "Number of writer threads to use")
 	btIdx.BoolVar(&CliConfig.UpdateBigtableIdx, "update-bigtable-index", CliConfig.UpdateBigtableIdx, "synchronize index changes to bigtable. not all your nodes need to do this.")
 	btIdx.DurationVar(&CliConfig.UpdateInterval, "update-interval", CliConfig.UpdateInterval, "frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates")
-	btIdx.DurationVar(&CliConfig.MaxStale, "max-stale", CliConfig.MaxStale, "clear series from the index if they have not been seen for this much time.")
 	btIdx.DurationVar(&CliConfig.PruneInterval, "prune-interval", CliConfig.PruneInterval, "Interval at which the index should be checked for stale series.")
 	btIdx.BoolVar(&CliConfig.CreateCF, "create-cf", CliConfig.CreateCF, "enable the creation of the table and column families")
 

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -416,14 +416,14 @@ func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, now time
 	cutoffs := memory.IndexRules.Cutoffs(now)
 
 NAMES:
-	for name, defsByName := range defsByNames {
-		irId, _ := memory.IndexRules.Match(name)
+	for nameWithTags, defsByName := range defsByNames {
+		irId, _ := memory.IndexRules.Match(nameWithTags)
 		cutoff := cutoffs[irId]
 		for _, def := range defsByName {
 			if def.LastUpdate >= cutoff {
-				// if one of the defs in a name is not stale, then we'll need to add
-				// all the associated MDs to the defs slice
-				for _, defToAdd := range defsByNames[name] {
+				// if any of the defs for a given nameWithTags is not stale, then we need to load
+				// all the defs for that nameWithTags.
+				for _, defToAdd := range defsByNames[nameWithTags] {
 					defs = append(defs, *defToAdd)
 				}
 				continue NAMES

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -429,8 +429,6 @@ write-concurrency = 5
 update-bigtable-index = true
 # frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
 update-interval = 3h
-# clear series from the index if they have not been seen for this much time.
-max-stale = 0
 # Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # enable the creation of the table and column families

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -426,8 +426,6 @@ write-concurrency = 5
 update-bigtable-index = true
 # frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
 update-interval = 3h
-# clear series from the index if they have not been seen for this much time.
-max-stale = 0
 # Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # enable the creation of the table and column families

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -426,8 +426,6 @@ write-concurrency = 5
 update-bigtable-index = true
 # frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates
 update-interval = 3h
-# clear series from the index if they have not been seen for this much time.
-max-stale = 0
 # Interval at which the index should be checked for stale series.
 prune-interval = 3h
 # enable the creation of the table and column families


### PR DESCRIPTION
    fix bigtable idx pruning + index-rules.conf pruning for bigtable idx
    
    1) both the at-runtime pruning of the memory index, as well as the
       on-startup initialisation of the cassandra index group metrics by
       nameWithTags, whereas the on-startup init of the bigtable index
       did it by name.  So even if all defs for a.b;foo=bar are stale,
       bigtable idx wouldn't prune it if there's e.g.
       a non stale a.b;foo=quux, in contrast with cassandra and memory
       index which consider these separate series for pruning.
       We fix it here, and also clarify some things a bit, making
       the cassandra and bigtable index implementation on par and easily
       diffable.
    
    2) implement index-rules.conf based pruning for bigtable idx,
       rather than the old max-stale mechanism.
       fix #1108
