### PR TITLE
add checks to entrypoint.sh to ensure kafka is enabled

### DIFF
--- a/scripts/k8s/entrypoint.sh
+++ b/scripts/k8s/entrypoint.sh
@@ -16,11 +16,11 @@ for line in $(env | sed -n '/^MT_GO/s/MT_//p'); do
 done
 
 # set offsets
-if [ x"$MT_KAFKA_MDM_IN_OFFSET" = "xauto" ]; then
+if [ x"$MT_KAFKA_MDM_IN_OFFSET" = "xauto" ] && [ x"$MT_KAFKA_MDM_IN_ENABLED" = "xtrue" ]; then
   export MT_KAFKA_MDM_IN_OFFSET=$(/getOffset.py $MT_KAFKA_MDM_IN_TOPICS)
 fi
 
-if [ x"$MT_KAFKA_CLUSTER_OFFSET" = "xauto" ]; then
+if [ x"$MT_KAFKA_CLUSTER_OFFSET" = "xauto" ] && [ x"$MT_KAFKA_CLUSTER_ENABLED" = "xtrue" ]; then
   export MT_KAFKA_CLUSTER_OFFSET=$(/getOffset.py $MT_KAFKA_CLUSTER_TOPIC)
 fi
 


### PR DESCRIPTION
`entrypoint.sh` script was not checking to see if kafka cluster and kafka mdm-in were enabled before attempting to get offsets which could result in`getOffset.py` being called without an argument, thus setting environment variables to the usage help returned by `getOffset.py` as is shown in the last line below.

```
'[' xauto '=' xauto ]
/getOffset.py m-1-S-<name>
export 'MT_KAFKA_MDM_IN_OFFSET=432m'
'[' xauto '=' xauto ]
/getOffset.py
export 'MT_KAFKA_CLUSTER_OFFSET=Usage: /getOffset.py <topic>'
```