### PR TITLE
[WIP] implement two trees and benchmarks

### DIFF
--- a/idx/memory/map_tree/map_tree.go
+++ b/idx/memory/map_tree/map_tree.go
@@ -1,0 +1,136 @@
+package memory
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/raintank/schema"
+)
+
+type edges map[string]node
+type leaf struct {
+	defs []schema.MKey
+}
+
+type node struct {
+	leaf  *leaf
+	edges edges
+}
+
+type mapTree struct {
+	root node
+}
+
+func newMapTree() mapTree {
+	return mapTree{root: node{edges: make(edges)}}
+}
+
+func (t *mapTree) insert(path []string, mKey schema.MKey) {
+	currentNode := &t.root
+	for i, pathElement := range path {
+		if i == len(path)-1 {
+			if n, ok := currentNode.edges[pathElement]; ok {
+				if n.leaf != nil {
+					n.leaf.defs = append(n.leaf.defs, mKey)
+				} else {
+					n.leaf = &leaf{defs: []schema.MKey{mKey}}
+				}
+			} else {
+				currentNode.edges[pathElement] = node{
+					edges: make(edges),
+					leaf:  &leaf{defs: []schema.MKey{mKey}},
+				}
+			}
+		} else {
+			if childNode, ok := currentNode.edges[pathElement]; ok {
+				currentNode = &childNode
+			} else {
+				n := &node{edges: make(edges)}
+				currentNode.edges[pathElement] = *n
+				currentNode = n
+			}
+		}
+	}
+}
+
+func (t *mapTree) walker() *mapTreeWalker {
+	return &mapTreeWalker{
+		root:    &t.root,
+		results: make(chan *leaf, runtime.GOMAXPROCS(0)),
+	}
+}
+
+type mapTreeWalker struct {
+	wg      sync.WaitGroup
+	results chan *leaf
+	root    *node
+}
+
+func (t *mapTreeWalker) reset() {
+	t.results = make(chan *leaf, runtime.GOMAXPROCS(0))
+}
+
+func (t *mapTreeWalker) get(path []string) []schema.MKey {
+	t.wg.Add(1)
+	go t.getBranch(t.root, path, true)
+
+	go func() {
+		t.wg.Wait()
+		close(t.results)
+	}()
+
+	var results []schema.MKey
+	for leaf := range t.results {
+		if leaf == nil {
+			continue
+		}
+		for _, leaf := range leaf.defs {
+			results = append(results, leaf)
+		}
+	}
+
+	return results
+}
+
+func (t *mapTreeWalker) getBranch(n *node, path []string, routine bool) {
+	// if this getBranch call is running in a separate routine it needs to
+	// notify the waitgroup once it's done
+	if routine {
+		defer t.wg.Done()
+	}
+
+	if len(path) == 0 {
+		if n.leaf != nil {
+			t.results <- n.leaf
+		}
+		return
+	}
+
+	if strings.ContainsAny(path[0], "*{}[]?") {
+		matcher, _ := getMatcher(path[0])
+		var firstMatch *node
+
+		for edge, child := range n.edges {
+			if matcher(edge) {
+				// need to copy that because the next iteration will overwrite child
+				childCopy := child
+				if firstMatch == nil {
+					firstMatch = &childCopy
+					continue
+				}
+
+				t.wg.Add(1)
+				go t.getBranch(&childCopy, path[1:], true)
+			}
+		}
+
+		if firstMatch != nil {
+			t.getBranch(firstMatch, path[1:], false)
+		}
+	} else {
+		if child, ok := n.edges[path[0]]; ok {
+			t.getBranch(&child, path[1:], false)
+		}
+	}
+}

--- a/idx/memory/map_tree/map_tree_test.go
+++ b/idx/memory/map_tree/map_tree_test.go
@@ -35,10 +35,8 @@ func getRandomPaths(paths, nodes, nodeLen int) []string {
 	return res
 }
 
-func BenchmarkTreeSearch(b *testing.B) {
-
-	randomPaths := getRandomPaths(1000000, 3, 3)
-	pathCount := len(randomPaths)
+func BenchmarkMapTreeInsert(b *testing.B) {
+	randomPaths := getRandomPaths(b.N, 3, 6)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -49,6 +47,21 @@ func BenchmarkTreeSearch(b *testing.B) {
 	for _, k := range randomPaths {
 		tree.insert(strings.Split(k, "."), mkey)
 	}
+}
+
+func BenchmarkMapTreeSearch(b *testing.B) {
+	randomPaths := getRandomPaths(1000000, 3, 3)
+	pathCount := len(randomPaths)
+
+	tree := newMapTree()
+
+	mkey, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+	for _, k := range randomPaths {
+		tree.insert(strings.Split(k, "."), mkey)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
 		walker := tree.walker()

--- a/idx/memory/map_tree/map_tree_test.go
+++ b/idx/memory/map_tree/map_tree_test.go
@@ -1,0 +1,141 @@
+package memory
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/raintank/schema"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func getRandomPaths(paths, nodes, nodeLen int) []string {
+	const letterBytes = "abcde"
+	resMap := make(map[string]struct{})
+	builder := strings.Builder{}
+
+	for i := 0; i < paths; i++ {
+		builder.Reset()
+		for j := 0; j < nodes; j++ {
+			if j > 0 {
+				builder.WriteString(".")
+			}
+			for k := 0; k < nodeLen; k++ {
+				builder.WriteByte(letterBytes[rand.Intn(len(letterBytes))])
+			}
+		}
+		resMap[builder.String()] = struct{}{}
+	}
+
+	res := make([]string, 0, len(resMap))
+	for k := range resMap {
+		res = append(res, k)
+	}
+
+	return res
+}
+
+func BenchmarkTreeSearch(b *testing.B) {
+
+	randomPaths := getRandomPaths(1000000, 3, 3)
+	pathCount := len(randomPaths)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	tree := newMapTree()
+
+	mkey, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+	for _, k := range randomPaths {
+		tree.insert(strings.Split(k, "."), mkey)
+	}
+
+	for n := 0; n < b.N; n++ {
+		walker := tree.walker()
+		res := walker.get(strings.Split(randomPaths[n%pathCount], "."))
+		if len(res) != 1 {
+			b.Fatalf("wrong count: %d", len(res))
+		}
+		walker.reset()
+	}
+}
+
+func TestMapTreeInsertAndGet(t *testing.T) {
+	Convey("When inserting a value into the tree", t, func() {
+		tree := newMapTree()
+		test1Path := []string{"aaa", "bbb", "ccc"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		tree.insert(test1Path, v1)
+		Convey("We should be able to get it from the same path", func() {
+			walker := tree.walker()
+			res1 := walker.get(test1Path)
+			So(len(res1), ShouldEqual, 1)
+			So(res1[0].String(), ShouldEqual, v1.String())
+		})
+	})
+
+	Convey("When inserting two values into the tree in the same branch", t, func() {
+		tree := newMapTree()
+		test1Path := []string{"aaa", "bbb", "ccc"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		v2, _ := schema.MKeyFromString("1.01234567890123456789012345678902")
+		tree.insert(test1Path, v1)
+		tree.insert(test1Path, v2)
+		Convey("We should be able to get both from the same path", func() {
+			walker := tree.walker()
+			res1 := walker.get(test1Path)
+			So(len(res1), ShouldEqual, 2)
+			So(res1[0].String(), ShouldEqual, v1.String())
+			So(res1[1].String(), ShouldEqual, v2.String())
+		})
+	})
+
+	Convey("When inserting two values into the tree in different branches", t, func() {
+		tree := newMapTree()
+		test1Path := []string{"aaa", "bbb", "ccc"}
+		test2Path := []string{"aaa", "ccc", "ddd"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		v2, _ := schema.MKeyFromString("1.01234567890123456789012345678902")
+		tree.insert(test1Path, v1)
+		tree.insert(test2Path, v2)
+		Convey("We should be able to get both from their according path", func() {
+			walker := tree.walker()
+			res1 := walker.get(test1Path)
+			So(len(res1), ShouldEqual, 1)
+			So(res1[0].String(), ShouldEqual, v1.String())
+			walker.reset()
+			res2 := walker.get(test2Path)
+			So(len(res2), ShouldEqual, 1)
+			So(res2[0].String(), ShouldEqual, v2.String())
+		})
+	})
+
+	Convey("When inserting three values into the tree in different branches", t, func() {
+		tree := newMapTree()
+		test1Path := []string{"aaa", "aaa", "ccc"}
+		test2Path := []string{"aaa", "aab", "ccc"}
+		test3Path := []string{"aaa", "aac", "ccc"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		v2, _ := schema.MKeyFromString("1.01234567890123456789012345678902")
+		v3, _ := schema.MKeyFromString("1.01234567890123456789012345678903")
+		tree.insert(test1Path, v1)
+		tree.insert(test2Path, v2)
+		tree.insert(test3Path, v3)
+		Convey("We should be able to get two of them by querying a pattern", func() {
+			walker := tree.walker()
+			results := walker.get([]string{"aaa", "aa[bc]", "*"})
+			So(len(results), ShouldEqual, 2)
+
+			found := make([]bool, 2)
+			for _, res := range results {
+				if res.String() == v2.String() {
+					found[0] = true
+				}
+				if res.String() == v3.String() {
+					found[1] = true
+				}
+			}
+			So(found[0] && found[1], ShouldBeTrue)
+		})
+	})
+}

--- a/idx/memory/map_tree/matcher.go
+++ b/idx/memory/map_tree/matcher.go
@@ -1,0 +1,106 @@
+package memory
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/grafana/metrictank/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func getMatcher(path string) (func(string) bool, error) {
+	// Matches everything
+	if path == "*" {
+		return func(child string) bool {
+			log.Debug("memory-idx: Matching all children")
+			return true
+		}, nil
+	}
+
+	var patterns []string
+	if strings.ContainsAny(path, "{}") {
+		patterns = expandQueries(path)
+	} else {
+		patterns = []string{path}
+	}
+
+	// Convert to regex and match
+	if strings.ContainsAny(path, "*[]?") {
+		regexes := make([]*regexp.Regexp, 0, len(patterns))
+		for _, p := range patterns {
+			r, err := regexp.Compile(toRegexp(p))
+			if err != nil {
+				log.Debugf("memory-idx: regexp failed to compile. %s - %s", p, err)
+				return nil, errors.NewBadRequest(err.Error())
+			}
+			regexes = append(regexes, r)
+		}
+
+		return func(child string) bool {
+			for _, r := range regexes {
+				if !r.MatchString(child) {
+					return false
+				}
+			}
+			return true
+		}, nil
+	}
+
+	// Exact match one or more values
+	return func(child string) bool {
+		for _, p := range patterns {
+			if child == p {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+// We don't use filepath.Match as it doesn't support {} because that's not posix, it's a bashism
+// the easiest way of implementing this extra feature is just expanding single queries
+// that contain these queries into multiple queries, which will be checked separately
+// and the results of which will be ORed.
+func expandQueries(query string) []string {
+	queries := []string{query}
+
+	// as long as we find a { followed by a }, split it up into subqueries, and process
+	// all queries again
+	// we only stop once there are no more queries that still have {..} in them
+	keepLooking := true
+	for keepLooking {
+		expanded := make([]string, 0)
+		keepLooking = false
+		for _, query := range queries {
+			lbrace := strings.Index(query, "{")
+			rbrace := -1
+			if lbrace > -1 {
+				rbrace = strings.Index(query[lbrace:], "}")
+				if rbrace > -1 {
+					rbrace += lbrace
+				}
+			}
+
+			if lbrace > -1 && rbrace > -1 {
+				keepLooking = true
+				expansion := query[lbrace+1 : rbrace]
+				options := strings.Split(expansion, ",")
+				for _, option := range options {
+					expanded = append(expanded, query[:lbrace]+option+query[rbrace+1:])
+				}
+			} else {
+				expanded = append(expanded, query)
+			}
+		}
+		queries = expanded
+	}
+	return queries
+}
+
+func toRegexp(pattern string) string {
+	p := pattern
+	p = strings.Replace(p, "*", ".*", -1)
+	p = strings.Replace(p, "?", ".?", -1)
+	p = "^" + p + "$"
+	return p
+}

--- a/idx/memory/slice_tree/matcher.go
+++ b/idx/memory/slice_tree/matcher.go
@@ -1,0 +1,106 @@
+package memory
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/grafana/metrictank/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func getMatcher(path string) (func(string) bool, error) {
+	// Matches everything
+	if path == "*" {
+		return func(child string) bool {
+			log.Debug("memory-idx: Matching all children")
+			return true
+		}, nil
+	}
+
+	var patterns []string
+	if strings.ContainsAny(path, "{}") {
+		patterns = expandQueries(path)
+	} else {
+		patterns = []string{path}
+	}
+
+	// Convert to regex and match
+	if strings.ContainsAny(path, "*[]?") {
+		regexes := make([]*regexp.Regexp, 0, len(patterns))
+		for _, p := range patterns {
+			r, err := regexp.Compile(toRegexp(p))
+			if err != nil {
+				log.Debugf("memory-idx: regexp failed to compile. %s - %s", p, err)
+				return nil, errors.NewBadRequest(err.Error())
+			}
+			regexes = append(regexes, r)
+		}
+
+		return func(child string) bool {
+			for _, r := range regexes {
+				if !r.MatchString(child) {
+					return false
+				}
+			}
+			return true
+		}, nil
+	}
+
+	// Exact match one or more values
+	return func(child string) bool {
+		for _, p := range patterns {
+			if child == p {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+// We don't use filepath.Match as it doesn't support {} because that's not posix, it's a bashism
+// the easiest way of implementing this extra feature is just expanding single queries
+// that contain these queries into multiple queries, which will be checked separately
+// and the results of which will be ORed.
+func expandQueries(query string) []string {
+	queries := []string{query}
+
+	// as long as we find a { followed by a }, split it up into subqueries, and process
+	// all queries again
+	// we only stop once there are no more queries that still have {..} in them
+	keepLooking := true
+	for keepLooking {
+		expanded := make([]string, 0)
+		keepLooking = false
+		for _, query := range queries {
+			lbrace := strings.Index(query, "{")
+			rbrace := -1
+			if lbrace > -1 {
+				rbrace = strings.Index(query[lbrace:], "}")
+				if rbrace > -1 {
+					rbrace += lbrace
+				}
+			}
+
+			if lbrace > -1 && rbrace > -1 {
+				keepLooking = true
+				expansion := query[lbrace+1 : rbrace]
+				options := strings.Split(expansion, ",")
+				for _, option := range options {
+					expanded = append(expanded, query[:lbrace]+option+query[rbrace+1:])
+				}
+			} else {
+				expanded = append(expanded, query)
+			}
+		}
+		queries = expanded
+	}
+	return queries
+}
+
+func toRegexp(pattern string) string {
+	p := pattern
+	p = strings.Replace(p, "*", ".*", -1)
+	p = strings.Replace(p, "?", ".?", -1)
+	p = "^" + p + "$"
+	return p
+}

--- a/idx/memory/slice_tree/slice_tree.go
+++ b/idx/memory/slice_tree/slice_tree.go
@@ -1,0 +1,156 @@
+package memory
+
+import (
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/raintank/schema"
+)
+
+type edges []node
+type leaf struct {
+	defs []schema.MKey
+}
+
+func (n *node) insertGet(label string) *node {
+	if len(n.edges) == 0 {
+		n.edges = append(n.edges, node{label: label})
+		return &n.edges[0]
+	}
+	index := sort.Search(len(n.edges), func(i int) bool { return n.edges[i].label >= label })
+	if index < len(n.edges) && n.edges[index].label == label {
+		return &n.edges[index]
+	}
+	n.edges = append(n.edges, node{})
+	copy(n.edges[index+1:], n.edges[index:])
+	n.edges[index] = node{label: label}
+	return &n.edges[index]
+}
+
+func (n *node) get(label string) *node {
+	if len(n.edges) == 0 {
+		return nil
+	}
+	index := sort.Search(len(n.edges), func(i int) bool { return n.edges[i].label >= label })
+	if index < len(n.edges) && n.edges[index].label == label {
+		return &n.edges[index]
+	}
+	return nil
+}
+
+type node struct {
+	leaf  *leaf
+	edges edges
+	label string
+}
+
+type sliceTree struct {
+	root node
+}
+
+func newSliceTree() sliceTree {
+	return sliceTree{}
+}
+
+func (t *sliceTree) insert(path []string, mKey schema.MKey) {
+	currentNode := &t.root
+	for i, pathElement := range path {
+		if currentNode.edges == nil {
+			currentNode.edges = make(edges, 0)
+		}
+		if i == len(path)-1 {
+			n := currentNode.insertGet(pathElement)
+			if n.leaf != nil {
+				n.leaf.defs = append(n.leaf.defs, mKey)
+			} else {
+				n.leaf = &leaf{defs: []schema.MKey{mKey}}
+			}
+		} else {
+			currentNode = currentNode.insertGet(pathElement)
+		}
+	}
+}
+
+func (t *sliceTree) walker() *sliceTreeWalker {
+	return &sliceTreeWalker{
+		root:    &t.root,
+		results: make(chan *leaf, runtime.GOMAXPROCS(0)),
+	}
+}
+
+type sliceTreeWalker struct {
+	wg      sync.WaitGroup
+	results chan *leaf
+	root    *node
+}
+
+func (t *sliceTreeWalker) reset() {
+	t.results = make(chan *leaf, runtime.GOMAXPROCS(0))
+}
+
+func (t *sliceTreeWalker) get(path []string) []schema.MKey {
+	t.wg.Add(1)
+	go t.getBranch(t.root, path, true)
+
+	go func() {
+		t.wg.Wait()
+		close(t.results)
+	}()
+
+	var results []schema.MKey
+	for leaf := range t.results {
+		if leaf == nil {
+			continue
+		}
+		for _, leaf := range leaf.defs {
+			results = append(results, leaf)
+		}
+	}
+
+	return results
+}
+
+func (t *sliceTreeWalker) getBranch(n *node, path []string, routine bool) {
+	// if this getBranch call is running in a separate routine it needs to
+	// notify the waitgroup once it's done
+	if routine {
+		defer t.wg.Done()
+	}
+
+	if len(path) == 0 {
+		if n.leaf != nil {
+			t.results <- n.leaf
+		}
+		return
+	}
+
+	if strings.ContainsAny(path[0], "*{}[]?") {
+		matcher, _ := getMatcher(path[0])
+		var firstMatch *node
+
+		for _, child := range n.edges {
+			if matcher(child.label) {
+				// need to copy that because the next iteration will overwrite child
+				childCopy := child
+				if firstMatch == nil {
+					firstMatch = &childCopy
+					continue
+				}
+
+				t.wg.Add(1)
+				go t.getBranch(&childCopy, path[1:], true)
+			}
+		}
+
+		if firstMatch != nil {
+			t.getBranch(firstMatch, path[1:], false)
+		}
+	} else {
+		child := n.get(path[0])
+		if child != nil {
+			t.getBranch(child, path[1:], false)
+		}
+	}
+}

--- a/idx/memory/slice_tree/slice_tree_test.go
+++ b/idx/memory/slice_tree/slice_tree_test.go
@@ -1,0 +1,141 @@
+package memory
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/raintank/schema"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func getRandomPaths(paths, nodes, nodeLen int) []string {
+	const letterBytes = "abcde"
+	resMap := make(map[string]struct{})
+	builder := strings.Builder{}
+
+	for i := 0; i < paths; i++ {
+		builder.Reset()
+		for j := 0; j < nodes; j++ {
+			if j > 0 {
+				builder.WriteString(".")
+			}
+			for k := 0; k < nodeLen; k++ {
+				builder.WriteByte(letterBytes[rand.Intn(len(letterBytes))])
+			}
+		}
+		resMap[builder.String()] = struct{}{}
+	}
+
+	res := make([]string, 0, len(resMap))
+	for k := range resMap {
+		res = append(res, k)
+	}
+
+	return res
+}
+
+func BenchmarkTreeSearch(b *testing.B) {
+
+	randomPaths := getRandomPaths(1000000, 3, 3)
+	pathCount := len(randomPaths)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	tree := newSliceTree()
+
+	mkey, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+	for _, k := range randomPaths {
+		tree.insert(strings.Split(k, "."), mkey)
+	}
+
+	for n := 0; n < b.N; n++ {
+		walker := tree.walker()
+		res := walker.get(strings.Split(randomPaths[n%pathCount], "."))
+		if len(res) != 1 {
+			b.Fatalf("wrong count: %d", len(res))
+		}
+		walker.reset()
+	}
+}
+
+func TestSliceTreeInsertAndGet(t *testing.T) {
+	Convey("When inserting a value into the tree", t, func() {
+		tree := newSliceTree()
+		test1Path := []string{"aaa", "bbb", "ccc"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		tree.insert(test1Path, v1)
+		Convey("We should be able to get it from the same path", func() {
+			walker := tree.walker()
+			res1 := walker.get(test1Path)
+			So(len(res1), ShouldEqual, 1)
+			So(res1[0].String(), ShouldEqual, v1.String())
+		})
+	})
+
+	Convey("When inserting two values into the tree in the same branch", t, func() {
+		tree := newSliceTree()
+		test1Path := []string{"aaa", "bbb", "ccc"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		v2, _ := schema.MKeyFromString("1.01234567890123456789012345678902")
+		tree.insert(test1Path, v1)
+		tree.insert(test1Path, v2)
+		Convey("We should be able to get both from the same path", func() {
+			walker := tree.walker()
+			res1 := walker.get(test1Path)
+			So(len(res1), ShouldEqual, 2)
+			So(res1[0].String(), ShouldEqual, v1.String())
+			So(res1[1].String(), ShouldEqual, v2.String())
+		})
+	})
+
+	Convey("When inserting two values into the tree in different branches", t, func() {
+		tree := newSliceTree()
+		test1Path := []string{"aaa", "bbb", "ccc"}
+		test2Path := []string{"aaa", "ccc", "ddd"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		v2, _ := schema.MKeyFromString("1.01234567890123456789012345678902")
+		tree.insert(test1Path, v1)
+		tree.insert(test2Path, v2)
+		Convey("We should be able to get both from their according path", func() {
+			walker := tree.walker()
+			res1 := walker.get(test1Path)
+			So(len(res1), ShouldEqual, 1)
+			So(res1[0].String(), ShouldEqual, v1.String())
+			walker.reset()
+			res2 := walker.get(test2Path)
+			So(len(res2), ShouldEqual, 1)
+			So(res2[0].String(), ShouldEqual, v2.String())
+		})
+	})
+
+	Convey("When inserting three values into the tree in different branches", t, func() {
+		tree := newSliceTree()
+		test1Path := []string{"aaa", "aaa", "ccc"}
+		test2Path := []string{"aaa", "aab", "ccc"}
+		test3Path := []string{"aaa", "aac", "ccc"}
+		v1, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+		v2, _ := schema.MKeyFromString("1.01234567890123456789012345678902")
+		v3, _ := schema.MKeyFromString("1.01234567890123456789012345678903")
+		tree.insert(test1Path, v1)
+		tree.insert(test2Path, v2)
+		tree.insert(test3Path, v3)
+		Convey("We should be able to get two of them by querying a pattern", func() {
+			walker := tree.walker()
+			results := walker.get([]string{"aaa", "aa[bc]", "*"})
+			So(len(results), ShouldEqual, 2)
+
+			found := make([]bool, 2)
+			for _, res := range results {
+				if res.String() == v2.String() {
+					found[0] = true
+				}
+				if res.String() == v3.String() {
+					found[1] = true
+				}
+			}
+			So(found[0] && found[1], ShouldBeTrue)
+		})
+	})
+}

--- a/idx/memory/slice_tree/slice_tree_test.go
+++ b/idx/memory/slice_tree/slice_tree_test.go
@@ -35,10 +35,8 @@ func getRandomPaths(paths, nodes, nodeLen int) []string {
 	return res
 }
 
-func BenchmarkTreeSearch(b *testing.B) {
-
-	randomPaths := getRandomPaths(1000000, 3, 3)
-	pathCount := len(randomPaths)
+func BenchmarkSliceTreeInsert(b *testing.B) {
+	randomPaths := getRandomPaths(b.N, 3, 6)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -49,6 +47,21 @@ func BenchmarkTreeSearch(b *testing.B) {
 	for _, k := range randomPaths {
 		tree.insert(strings.Split(k, "."), mkey)
 	}
+}
+
+func BenchmarkSliceTreeSearch(b *testing.B) {
+	randomPaths := getRandomPaths(1000000, 3, 3)
+	pathCount := len(randomPaths)
+
+	tree := newSliceTree()
+
+	mkey, _ := schema.MKeyFromString("1.01234567890123456789012345678901")
+	for _, k := range randomPaths {
+		tree.insert(strings.Split(k, "."), mkey)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
 		walker := tree.walker()


### PR DESCRIPTION
Those two tree indexes are both based off of the repo https://github.com/armon/go-radix, but i modified it to fit our requirements.
I wasn't sure if it's better to make the new tree index based on maps or slices, so I implemented both and now we can benchmark to compare. I believe the slice based one will probably be better memory-wise, as we've seen that maps with a lot of adds/deletes can be leaky. The benchmarks look surprisingly similar:

```
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ go test github.com/grafana/metrictank/idx/memory/slice_tree -run=Benchmark -bench=Benchmark  
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/idx/memory/slice_tree
BenchmarkSliceTreeInsert-8   	  500000	      2188 ns/op	     305 B/op	       4 allocs/op
BenchmarkSliceTreeSearch-8   	  200000	     10508 ns/op	     432 B/op	       7 allocs/op
PASS
ok  	github.com/grafana/metrictank/idx/memory/slice_tree	12.999s
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ go test github.com/grafana/metrictank/idx/memory/map_tree -run=Benchmark -bench=Benchmark  
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/idx/memory/map_tree
BenchmarkMapTreeInsert-8   	 1000000	      3223 ns/op	     696 B/op	       9 allocs/op
BenchmarkMapTreeSearch-8   	  200000	      9259 ns/op	     432 B/op	       7 allocs/op
PASS
ok  	github.com/grafana/metrictank/idx/memory/map_tree	15.088s
mst@mst-nb1:~/documents/code/go/src/github.com/grafana/metrictank$ 
```