### PR TITLE
fix duration vars processing and error handling in cass idx

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -324,11 +324,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:35772ed89320fd473d3ff0a434c155cfda5c577f91c4d31d78191275ef61b6c3"
+  digest = "1:817bb03ae4cb923f024602aa1753f1dcea87c83e10fb3a175ca4fa7a088b1cc7"
   name = "github.com/grafana/globalconf"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "1dcfee16dd532cf6206e704d3ae6ca31ff4c6df7"
+  revision = "7a1aae0695d90c7ce662097c9589dfe1ae3c4f47"
 
 [[projects]]
   digest = "1:a191ed8e21025522d5857d14c3ec0a6513f83bea2ff45967f301fb701f3849dd"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,6 +323,14 @@
   revision = "4b53e1bddba0e2f734514aeb6c02db652f4c6fe8"
 
 [[projects]]
+  branch = "master"
+  digest = "1:35772ed89320fd473d3ff0a434c155cfda5c577f91c4d31d78191275ef61b6c3"
+  name = "github.com/grafana/globalconf"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "1dcfee16dd532cf6206e704d3ae6ca31ff4c6df7"
+
+[[projects]]
   digest = "1:a191ed8e21025522d5857d14c3ec0a6513f83bea2ff45967f301fb701f3849dd"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
@@ -663,14 +671,6 @@
   pruneopts = "NUT"
   revision = "62e6d7933846832d7f2381631fbd956cd40234cb"
   version = "v2.2"
-
-[[projects]]
-  branch = "master"
-  digest = "1:56e1fe0cbca1744fa51e946af6fcbecee6df3d57fd77647dd48e0ca2da049ada"
-  name = "github.com/rakyll/globalconf"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "f3ec558991f8d5e7b1efcc291fa36edef6c47123"
 
 [[projects]]
   branch = "master"
@@ -1035,6 +1035,7 @@
     "github.com/gocql/gocql",
     "github.com/gogo/protobuf/proto",
     "github.com/golang/snappy",
+    "github.com/grafana/globalconf",
     "github.com/hailocab/go-hostpool",
     "github.com/hashicorp/memberlist",
     "github.com/kisielk/og-rek",
@@ -1060,7 +1061,6 @@
     "github.com/raintank/met/helper",
     "github.com/raintank/schema",
     "github.com/raintank/schema/msg",
-    "github.com/rakyll/globalconf",
     "github.com/rs/cors",
     "github.com/sergi/go-diff/diffmatchpatch",
     "github.com/sirupsen/logrus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,10 +114,6 @@ unused-packages = true
   version = "^2"
 
 [[constraint]]
-  name = "github.com/rakyll/globalconf"
-  branch = "master"
-
-[[constraint]]
   name = "github.com/rs/cors"
   version = "1.0.0"
 

--- a/api/config.go
+++ b/api/config.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/grafana/globalconf"
 	"github.com/raintank/dur"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,7 +54,7 @@ func ConfigSetup() {
 	apiCfg.IntVar(&getTargetsConcurrency, "get-targets-concurrency", 20, "maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.")
 	apiCfg.UintVar(&tagdbDefaultLimit, "tagdb-default-limit", 100, "default limit for tagdb query results, can be overridden with query parameter \"limit\"")
 	apiCfg.Float64Var(&speculationThreshold, "speculation-threshold", 1, "ratio of peer responses after which speculation is used. Set to 1 to disable.")
-	globalconf.Register("http", apiCfg)
+	globalconf.Register("http", apiCfg, flag.ExitOnError)
 }
 
 func ConfigProcess() {

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rakyll/globalconf"
+	"github.com/grafana/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,7 +54,7 @@ func ConfigSetup() {
 	clusterCfg.DurationVar(&httpTimeout, "http-timeout", time.Second*60, "How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable")
 	clusterCfg.IntVar(&maxPrio, "max-priority", 10, "maximum priority before a node should be considered not-ready.")
 	clusterCfg.IntVar(&minAvailableShards, "min-available-shards", 0, "minimum number of shards that must be available for a query to be handled.")
-	globalconf.Register("cluster", clusterCfg)
+	globalconf.Register("cluster", clusterCfg, flag.ExitOnError)
 
 	swimCfg := flag.NewFlagSet("swim", flag.ExitOnError)
 	swimCfg.StringVar(&swimUseConfig, "use-config", "manual", "config setting to use. If set to anything but manual, will override all other swim settings. Use manual|default-lan|default-local|default-wan. see https://godoc.org/github.com/hashicorp/memberlist#Config . Note all our swim settings correspond to default-lan")
@@ -75,7 +75,7 @@ func ConfigSetup() {
 	swimCfg.DurationVar(&swimGossipToTheDeadTime, "gossip-to-the-dead-time", 30*time.Second, "interval after which a node has died that we will still try to gossip to it. This gives it a chance to refute")
 	swimCfg.BoolVar(&swimEnableCompression, "enable-compression", true, "message compression")
 	swimCfg.StringVar(&swimDNSConfigPath, "dns-config-path", "/etc/resolv.conf", "system's DNS config file. Override allows for easier testing")
-	globalconf.Register("swim", swimCfg)
+	globalconf.Register("swim", swimCfg, flag.ExitOnError)
 }
 
 func ConfigProcess() {

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Dieterbe/profiletrigger/heap"
 	"github.com/Shopify/sarama"
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/api"
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/conf"
@@ -37,7 +38,6 @@ import (
 	bigtableStore "github.com/grafana/metrictank/store/bigtable"
 	cassandraStore "github.com/grafana/metrictank/store/cassandra"
 	"github.com/raintank/dur"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	l "log"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -13,8 +14,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	_ "net/http/pprof"
 
 	"github.com/Dieterbe/profiletrigger/heap"
 	"github.com/Shopify/sarama"
@@ -184,6 +183,7 @@ func main() {
 	statsConfig.ConfigProcess(*instance)
 	mdata.ConfigProcess()
 	memory.ConfigProcess()
+	cassandra.ConfigProcess()
 	bigtable.ConfigProcess()
 	bigtableStore.ConfigProcess(mdata.MaxChunkSpan())
 
@@ -336,11 +336,11 @@ func main() {
 		}
 		metricIndex = memory.New()
 	}
-	if cassandra.Enabled {
+	if cassandra.CliConfig.Enabled {
 		if metricIndex != nil {
 			log.Fatal("Only 1 metricIndex handler can be enabled.")
 		}
-		metricIndex = cassandra.New()
+		metricIndex = cassandra.New(cassandra.CliConfig)
 	}
 	if bigtable.CliConfig.Enabled {
 		if metricIndex != nil {

--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -158,7 +158,7 @@ func main() {
 
 	globalFlags.Parse(os.Args[1:cassI])
 	cassFlags.Parse(os.Args[cassI+1 : len(os.Args)-1])
-	cassandra.Enabled = true
+	cassandra.CliConfig.Enabled = true
 
 	if regexStr != "" {
 		var err error
@@ -184,7 +184,7 @@ func main() {
 		show = out.Template(format)
 	}
 
-	idx := cassandra.New()
+	idx := cassandra.New(cassandra.CliConfig)
 	err := idx.InitBare()
 	perror(err)
 

--- a/cmd/mt-kafka-mdm-sniff-out-of-order/main.go
+++ b/cmd/mt-kafka-mdm-sniff-out-of-order/main.go
@@ -14,12 +14,12 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/grafana/globalconf"
 	inKafkaMdm "github.com/grafana/metrictank/input/kafkamdm"
 	"github.com/grafana/metrictank/logger"
 	"github.com/grafana/metrictank/stats"
 	"github.com/raintank/schema"
 	"github.com/raintank/schema/msg"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/cmd/mt-kafka-mdm-sniff/main.go
+++ b/cmd/mt-kafka-mdm-sniff/main.go
@@ -14,12 +14,12 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/grafana/globalconf"
 	inKafkaMdm "github.com/grafana/metrictank/input/kafkamdm"
 	"github.com/grafana/metrictank/logger"
 	"github.com/grafana/metrictank/stats"
 	"github.com/raintank/schema"
 	"github.com/raintank/schema/msg"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/cmd/mt-store-cat/main.go
+++ b/cmd/mt-store-cat/main.go
@@ -9,16 +9,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/raintank/schema"
-
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/conf"
 	"github.com/grafana/metrictank/logger"
-	opentracing "github.com/opentracing/opentracing-go"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/grafana/metrictank/store/cassandra"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/raintank/dur"
-	"github.com/rakyll/globalconf"
+	"github.com/raintank/schema"
+	log "github.com/sirupsen/logrus"
 )
 
 const tsFormat = "2006-01-02 15:04:05"

--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -155,6 +155,7 @@ func main() {
 	globalFlags.Parse(os.Args[1:cassI])
 	cassFlags.Parse(os.Args[cassI+1 : len(os.Args)])
 	cassandra.CliConfig.Enabled = true
+	cassandra.ConfigProcess()
 
 	if *verbose {
 		log.SetLevel(log.DebugLevel)
@@ -180,8 +181,6 @@ func main() {
 	}
 
 	cluster.Init("mt-whisper-importer-writer", gitHash, time.Now(), "http", int(80))
-
-	cassandra.ConfigProcess()
 
 	server := &Server{
 		Session:     store.Session,

--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/raintank/schema"
-
 	"github.com/gocql/gocql"
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/cluster/partitioner"
@@ -22,6 +20,7 @@ import (
 	"github.com/grafana/metrictank/mdata/chunk/archive"
 	cassandraStore "github.com/grafana/metrictank/store/cassandra"
 	"github.com/raintank/dur"
+	"github.com/raintank/schema"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -155,7 +154,7 @@ func main() {
 
 	globalFlags.Parse(os.Args[1:cassI])
 	cassFlags.Parse(os.Args[cassI+1 : len(os.Args)])
-	cassandra.Enabled = true
+	cassandra.CliConfig.Enabled = true
 
 	if *verbose {
 		log.SetLevel(log.DebugLevel)
@@ -186,7 +185,7 @@ func main() {
 		Session:     store.Session,
 		TTLTables:   ttlTables,
 		Partitioner: p,
-		Index:       cassandra.New(),
+		Index:       cassandra.New(cassandra.CliConfig),
 		HTTPServer: &http.Server{
 			Addr:        *httpEndpoint,
 			ReadTimeout: 10 * time.Minute,

--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -181,6 +181,8 @@ func main() {
 
 	cluster.Init("mt-whisper-importer-writer", gitHash, time.Now(), "http", int(80))
 
+	cassandra.ConfigProcess()
+
 	server := &Server{
 		Session:     store.Session,
 		TTLTables:   ttlTables,

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -355,7 +355,7 @@ write-queue-size = 100000
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -331,7 +331,7 @@ partitions = *
 # When using a duration but the offset request fails (e.g. Kafka doesn't have data so far back), metrictank falls back to `oldest`.
 # Should match your kafka-mdm-in setting
 offset = newest
-# Maximum time backlog processing can block during metrictank startup.
+# Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss
 backlog-process-timeout = 60s
 
 ## metric metadata index ##

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -345,17 +345,17 @@ hosts = cassandra:9042
 protocol-version = 4
 # write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
 consistency = one
-# cassandra request timeout
+# cassandra request timeout. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 timeout = 1s
 # number of concurrent connections to cassandra
 num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
-#Interval at which the index should be checked for stale series.
+#Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -156,6 +156,8 @@ prefix = metrictank.stats.docker-cluster.$instance
 addr = graphitemon:2003
 # interval at which to send statistics
 interval = 1
+# timeout after which a write is considered not successful
+timeout = 10s
 # how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable.
 # With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed
 buffer-size = 20000

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -355,7 +355,7 @@ write-queue-size = 100000
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -345,17 +345,17 @@ hosts = cassandra:9042
 protocol-version = 4
 # write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
 consistency = one
-# cassandra request timeout
+# cassandra request timeout. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 timeout = 1s
 # number of concurrent connections to cassandra
 num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
-#Interval at which the index should be checked for stale series.
+#Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -156,6 +156,8 @@ prefix = metrictank.stats.docker-cluster.$instance
 addr = graphitemon:2003
 # interval at which to send statistics
 interval = 1
+# timeout after which a write is considered not successful
+timeout = 10s
 # how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable.
 # With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed
 buffer-size = 20000

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -331,7 +331,7 @@ partitions = *
 # When using a duration but the offset request fails (e.g. Kafka doesn't have data so far back), metrictank falls back to `oldest`.
 # Should match your kafka-mdm-in setting
 offset = oldest
-# Maximum time backlog processing can block during metrictank startup.
+# Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss
 backlog-process-timeout = 60s
 
 ## metric metadata index ##

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -355,7 +355,7 @@ write-queue-size = 100000
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -345,17 +345,17 @@ hosts = cassandra:9042
 protocol-version = 4
 # write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
 consistency = one
-# cassandra request timeout
+# cassandra request timeout. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 timeout = 1s
 # number of concurrent connections to cassandra
 num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
-#Interval at which the index should be checked for stale series.
+#Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -156,6 +156,8 @@ prefix = metrictank.stats.docker-dev-custom-cfg-kafka.$instance
 addr = localhost:2003
 # interval at which to send statistics
 interval = 1
+# timeout after which a write is considered not successful
+timeout = 10s
 # how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable.
 # With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed
 buffer-size = 20000

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -331,7 +331,7 @@ partitions = *
 # When using a duration but the offset request fails (e.g. Kafka doesn't have data so far back), metrictank falls back to `oldest`.
 # Should match your kafka-mdm-in setting
 offset = oldest
-# Maximum time backlog processing can block during metrictank startup.
+# Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss
 backlog-process-timeout = 60s
 
 ## metric metadata index ##

--- a/docs/config.md
+++ b/docs/config.md
@@ -419,7 +419,7 @@ write-queue-size = 100000
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docs/config.md
+++ b/docs/config.md
@@ -393,7 +393,7 @@ partitions = *
 # When using a duration but the offset request fails (e.g. Kafka doesn't have data so far back), metrictank falls back to `oldest`.
 # Should match your kafka-mdm-in setting
 offset = newest
-# Maximum time backlog processing can block during metrictank startup.
+# Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss
 backlog-process-timeout = 60s
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -195,6 +195,8 @@ prefix = metrictank.stats.default.$instance
 addr = localhost:2003
 # interval at which to send statistics
 interval = 1
+# timeout after which a write is considered not successful
+timeout = 10s
 # how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable.
 # With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed
 buffer-size = 20000

--- a/docs/config.md
+++ b/docs/config.md
@@ -409,17 +409,17 @@ hosts = localhost:9042
 protocol-version = 4
 # write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
 consistency = one
-# cassandra request timeout
+# cassandra request timeout. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 timeout = 1s
 # number of concurrent connections to cassandra
 num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
-#Interval at which the index should be checked for stale series.
+#Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -273,7 +273,7 @@ Print what's flowing through kafka metric persist topic
 Flags:
 
   -backlog-process-timeout string
-    	Maximum time backlog processing can block during metrictank startup. (default "60s")
+    	Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss (default "60s")
   -brokers string
     	tcp address for kafka (may be given multiple times as comma separated list) (default "kafka:9092")
   -enabled

--- a/idx/bigtable/config.go
+++ b/idx/bigtable/config.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"time"
 
-	"github.com/rakyll/globalconf"
+	"github.com/grafana/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -72,7 +72,7 @@ func ConfigSetup() {
 	btIdx.DurationVar(&CliConfig.PruneInterval, "prune-interval", CliConfig.PruneInterval, "Interval at which the index should be checked for stale series.")
 	btIdx.BoolVar(&CliConfig.CreateCF, "create-cf", CliConfig.CreateCF, "enable the creation of the table and column families")
 
-	globalconf.Register("bigtable-idx", btIdx)
+	globalconf.Register("bigtable-idx", btIdx, flag.ExitOnError)
 }
 
 func ConfigProcess() {

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -94,15 +94,14 @@ func New(cfg *IdxConfig) *CasIdx {
 	}
 
 	idx := &CasIdx{
-		MemoryIdx: *memory.New(),
-		cfg:       cfg,
-		cluster:   cluster,
+		MemoryIdx:        *memory.New(),
+		cfg:              cfg,
+		cluster:          cluster,
+		updateInterval32: uint32(cfg.updateInterval.Nanoseconds() / int64(time.Second)),
 	}
 	if cfg.updateCassIdx {
 		idx.writeQueue = make(chan writeReq, cfg.writeQueueSize)
 	}
-
-	idx.updateInterval32 = uint32(cfg.updateInterval.Nanoseconds() / int64(time.Second))
 
 	return idx
 }

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -100,6 +100,9 @@ func New(cfg *IdxConfig) *CasIdx {
 	if cfg.updateCassIdx {
 		idx.writeQueue = make(chan writeReq, cfg.writeQueueSize)
 	}
+
+	cfg.updateInterval32 = uint32(cfg.updateInterval.Nanoseconds() / int64(time.Second))
+
 	return idx
 }
 

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -1,7 +1,6 @@
 package cassandra
 
 import (
-	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,7 +15,6 @@ import (
 	"github.com/grafana/metrictank/stats"
 	"github.com/grafana/metrictank/util"
 	"github.com/raintank/schema"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -48,60 +46,7 @@ var (
 	// metric idx.cassandra.save.skipped is how many saves have been skipped due to the writeQueue being full
 	statSaveSkipped = stats.NewCounter32("idx.cassandra.save.skipped")
 	errmetrics      = cassandra.NewErrMetrics("idx.cassandra")
-
-	Enabled          bool
-	pruneInterval    time.Duration
-	updateCassIdx    bool
-	updateInterval   time.Duration
-	updateInterval32 uint32
-
-	writeQueueSize int
-
-	ssl                      bool
-	auth                     bool
-	hostverification         bool
-	createKeyspace           bool
-	schemaFile               string
-	keyspace                 string
-	hosts                    string
-	capath                   string
-	username                 string
-	password                 string
-	consistency              string
-	timeout                  time.Duration
-	numConns                 int
-	protoVer                 int
-	disableInitialHostLookup bool
 )
-
-func ConfigSetup() *flag.FlagSet {
-	casIdx := flag.NewFlagSet("cassandra-idx", flag.ExitOnError)
-
-	casIdx.BoolVar(&Enabled, "enabled", true, "")
-	casIdx.StringVar(&hosts, "hosts", "localhost:9042", "comma separated list of cassandra addresses in host:port form")
-	casIdx.StringVar(&keyspace, "keyspace", "metrictank", "Cassandra keyspace to store metricDefinitions in.")
-	casIdx.StringVar(&consistency, "consistency", "one", "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
-	casIdx.DurationVar(&timeout, "timeout", time.Second, "cassandra request timeout")
-	casIdx.IntVar(&numConns, "num-conns", 10, "number of concurrent connections to cassandra")
-	casIdx.IntVar(&writeQueueSize, "write-queue-size", 100000, "Max number of metricDefs allowed to be unwritten to cassandra")
-	casIdx.BoolVar(&updateCassIdx, "update-cassandra-index", true, "synchronize index changes to cassandra. not all your nodes need to do this.")
-	casIdx.DurationVar(&updateInterval, "update-interval", time.Hour*3, "frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates")
-	casIdx.DurationVar(&pruneInterval, "prune-interval", time.Hour*3, "Interval at which the index should be checked for stale series.")
-	casIdx.IntVar(&protoVer, "protocol-version", 4, "cql protocol version to use")
-	casIdx.BoolVar(&createKeyspace, "create-keyspace", true, "enable the creation of the index keyspace and tables, only one node needs this")
-	casIdx.StringVar(&schemaFile, "schema-file", "/etc/metrictank/schema-idx-cassandra.toml", "File containing the needed schemas in case database needs initializing")
-	casIdx.BoolVar(&disableInitialHostLookup, "disable-initial-host-lookup", false, "instruct the driver to not attempt to get host info from the system.peers table")
-	casIdx.BoolVar(&ssl, "ssl", false, "enable SSL connection to cassandra")
-	casIdx.StringVar(&capath, "ca-path", "/etc/metrictank/ca.pem", "cassandra CA certficate path when using SSL")
-	casIdx.BoolVar(&hostverification, "host-verification", true, "host (hostname and server cert) verification when using SSL")
-
-	casIdx.BoolVar(&auth, "auth", false, "enable cassandra user authentication")
-	casIdx.StringVar(&username, "username", "cassandra", "username for authentication")
-	casIdx.StringVar(&password, "password", "cassandra", "password for authentication")
-
-	globalconf.Register("cassandra-idx", casIdx)
-	return casIdx
-}
 
 type writeReq struct {
 	def      *schema.MetricDefinition
@@ -111,6 +56,7 @@ type writeReq struct {
 // Implements the the "MetricIndex" interface
 type CasIdx struct {
 	memory.MemoryIdx
+	cfg        *IdxConfig
 	cluster    *gocql.ClusterConfig
 	session    *gocql.Session
 	writeQueue chan writeReq
@@ -122,35 +68,38 @@ type cqlIterator interface {
 	Close() error
 }
 
-func New() *CasIdx {
-	cluster := gocql.NewCluster(strings.Split(hosts, ",")...)
-	cluster.Consistency = gocql.ParseConsistency(consistency)
-	cluster.Timeout = timeout
+func New(cfg *IdxConfig) *CasIdx {
+	if err := cfg.Validate(); err != nil {
+		log.Fatalf("cassandra-idx: %s", err)
+	}
+	cluster := gocql.NewCluster(strings.Split(cfg.hosts, ",")...)
+	cluster.Consistency = gocql.ParseConsistency(cfg.consistency)
+	cluster.Timeout = cfg.timeout
 	cluster.ConnectTimeout = cluster.Timeout
-	cluster.NumConns = numConns
-	cluster.ProtoVersion = protoVer
-	cluster.DisableInitialHostLookup = disableInitialHostLookup
-	if ssl {
+	cluster.NumConns = cfg.numConns
+	cluster.ProtoVersion = cfg.protoVer
+	cluster.DisableInitialHostLookup = cfg.disableInitialHostLookup
+	if cfg.ssl {
 		cluster.SslOpts = &gocql.SslOptions{
-			CaPath:                 capath,
-			EnableHostVerification: hostverification,
+			CaPath:                 cfg.capath,
+			EnableHostVerification: cfg.hostverification,
 		}
 	}
-	if auth {
+	if cfg.auth {
 		cluster.Authenticator = gocql.PasswordAuthenticator{
-			Username: username,
-			Password: password,
+			Username: cfg.username,
+			Password: cfg.password,
 		}
 	}
 
 	idx := &CasIdx{
 		MemoryIdx: *memory.New(),
+		cfg:       cfg,
 		cluster:   cluster,
 	}
-	if updateCassIdx {
-		idx.writeQueue = make(chan writeReq, writeQueueSize)
+	if cfg.updateCassIdx {
+		idx.writeQueue = make(chan writeReq, cfg.writeQueueSize)
 	}
-	updateInterval32 = uint32(updateInterval.Nanoseconds() / int64(time.Second))
 	return idx
 }
 
@@ -163,25 +112,25 @@ func (c *CasIdx) InitBare() error {
 	}
 
 	// read templates
-	schemaKeyspace := util.ReadEntry(schemaFile, "schema_keyspace").(string)
-	schemaTable := util.ReadEntry(schemaFile, "schema_table").(string)
+	schemaKeyspace := util.ReadEntry(c.cfg.schemaFile, "schema_keyspace").(string)
+	schemaTable := util.ReadEntry(c.cfg.schemaFile, "schema_table").(string)
 
 	// create the keyspace or ensure it exists
-	if createKeyspace {
-		log.Infof("cassandra-idx: ensuring that keyspace %s exist.", keyspace)
-		err = tmpSession.Query(fmt.Sprintf(schemaKeyspace, keyspace)).Exec()
+	if c.cfg.createKeyspace {
+		log.Infof("cassandra-idx: ensuring that keyspace %s exist.", c.cfg.keyspace)
+		err = tmpSession.Query(fmt.Sprintf(schemaKeyspace, c.cfg.keyspace)).Exec()
 		if err != nil {
 			return fmt.Errorf("failed to initialize cassandra keyspace: %s", err)
 		}
 		log.Info("cassandra-idx: ensuring that table metric_idx exist.")
-		err = tmpSession.Query(fmt.Sprintf(schemaTable, keyspace)).Exec()
+		err = tmpSession.Query(fmt.Sprintf(schemaTable, c.cfg.keyspace)).Exec()
 		if err != nil {
 			return fmt.Errorf("failed to initialize cassandra table: %s", err)
 		}
 	} else {
 		var keyspaceMetadata *gocql.KeyspaceMetadata
 		for attempt := 1; attempt > 0; attempt++ {
-			keyspaceMetadata, err = tmpSession.KeyspaceMetadata(keyspace)
+			keyspaceMetadata, err = tmpSession.KeyspaceMetadata(c.cfg.keyspace)
 			if err != nil {
 				if attempt >= 5 {
 					return fmt.Errorf("cassandra keyspace not found. %d attempts", attempt)
@@ -204,7 +153,7 @@ func (c *CasIdx) InitBare() error {
 	}
 
 	tmpSession.Close()
-	c.cluster.Keyspace = keyspace
+	c.cluster.Keyspace = c.cfg.keyspace
 	session, err := c.cluster.CreateSession()
 	if err != nil {
 		return fmt.Errorf("failed to create cassandra session: %s", err)
@@ -218,7 +167,7 @@ func (c *CasIdx) InitBare() error {
 // Init makes sure the needed keyspace, table, index in cassandra exists, creates the session,
 // rebuilds the in-memory index, sets up write queues, metrics and pruning routines
 func (c *CasIdx) Init() error {
-	log.Infof("initializing cassandra-idx. Hosts=%s", hosts)
+	log.Infof("initializing cassandra-idx. Hosts=%s", c.cfg.hosts)
 	if err := c.MemoryIdx.Init(); err != nil {
 		return err
 	}
@@ -227,21 +176,18 @@ func (c *CasIdx) Init() error {
 		return err
 	}
 
-	if updateCassIdx {
-		c.wg.Add(numConns)
-		for i := 0; i < numConns; i++ {
+	if c.cfg.updateCassIdx {
+		c.wg.Add(c.cfg.numConns)
+		for i := 0; i < c.cfg.numConns; i++ {
 			go c.processWriteQueue()
 		}
-		log.Infof("cassandra-idx: started %d writeQueue handlers", numConns)
+		log.Infof("cassandra-idx: started %d writeQueue handlers", c.cfg.numConns)
 	}
 
 	//Rebuild the in-memory index.
 	c.rebuildIndex()
 
 	if memory.IndexRules.Prunable() {
-		if pruneInterval == 0 {
-			return fmt.Errorf("pruneInterval must be greater then 0")
-		}
 		go c.prune()
 	}
 	return nil
@@ -252,7 +198,7 @@ func (c *CasIdx) Stop() {
 	c.MemoryIdx.Stop()
 
 	// if updateCassIdx is disabled then writeQueue should never have been initialized
-	if updateCassIdx {
+	if c.cfg.updateCassIdx {
 		close(c.writeQueue)
 	}
 	c.wg.Wait()
@@ -266,7 +212,7 @@ func (c *CasIdx) Update(point schema.MetricPoint, partition int32) (idx.Archive,
 
 	archive, oldPartition, inMemory := c.MemoryIdx.Update(point, partition)
 
-	if !updateCassIdx {
+	if !c.cfg.updateCassIdx {
 		statUpdateDuration.Value(time.Since(pre))
 		return archive, oldPartition, inMemory
 	}
@@ -281,7 +227,7 @@ func (c *CasIdx) Update(point schema.MetricPoint, partition int32) (idx.Archive,
 
 		// check if we need to save to cassandra.
 		now := uint32(time.Now().Unix())
-		if archive.LastSave < (now - updateInterval32) {
+		if archive.LastSave < (now - c.cfg.updateInterval32) {
 			archive = c.updateCassandra(now, inMemory, archive, partition)
 		}
 	}
@@ -300,7 +246,7 @@ func (c *CasIdx) AddOrUpdate(mkey schema.MKey, data *schema.MetricData, partitio
 		stat = statAddDuration
 	}
 
-	if !updateCassIdx {
+	if !c.cfg.updateCassIdx {
 		stat.Value(time.Since(pre))
 		return archive, oldPartition, inMemory
 	}
@@ -316,7 +262,7 @@ func (c *CasIdx) AddOrUpdate(mkey schema.MKey, data *schema.MetricData, partitio
 
 	// check if we need to save to cassandra.
 	now := uint32(time.Now().Unix())
-	if archive.LastSave < (now - updateInterval32) {
+	if archive.LastSave < (now - c.cfg.updateInterval32) {
 		archive = c.updateCassandra(now, inMemory, archive, partition)
 	}
 
@@ -329,7 +275,7 @@ func (c *CasIdx) AddOrUpdate(mkey schema.MKey, data *schema.MetricData, partitio
 func (c *CasIdx) updateCassandra(now uint32, inMemory bool, archive idx.Archive, partition int32) idx.Archive {
 	// if the entry has not been saved for 1.5x updateInterval
 	// then perform a blocking save.
-	if archive.LastSave < (now - updateInterval32 - updateInterval32/2) {
+	if archive.LastSave < (now - c.cfg.updateInterval32 - c.cfg.updateInterval32/2) {
 		log.Debugf("cassandra-idx: updating def %s in index.", archive.MetricDefinition.Id)
 		c.writeQueue <- writeReq{recvTime: time.Now(), def: &archive.MetricDefinition}
 		archive.LastSave = now
@@ -492,7 +438,7 @@ func (c *CasIdx) Delete(orgId uint32, pattern string) ([]idx.Archive, error) {
 	if err != nil {
 		return defs, err
 	}
-	if updateCassIdx {
+	if c.cfg.updateCassIdx {
 		for _, def := range defs {
 			err = c.deleteDef(def.Id, def.Partition)
 			if err != nil {
@@ -547,7 +493,7 @@ func (c *CasIdx) Prune(now time.Time) ([]idx.Archive, error) {
 }
 
 func (c *CasIdx) prune() {
-	ticker := time.NewTicker(pruneInterval)
+	ticker := time.NewTicker(c.cfg.pruneInterval)
 	for now := range ticker.C {
 		c.Prune(now)
 	}

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -66,14 +66,14 @@ func (i *testIterator) Close() error {
 }
 
 func init() {
-	keyspace = "metrictank"
-	hosts = ""
-	consistency = "one"
-	timeout = time.Second
-	numConns = 1
-	writeQueueSize = 1000
-	protoVer = 4
-	updateCassIdx = false
+	CliConfig.keyspace = "metrictank"
+	CliConfig.hosts = ""
+	CliConfig.consistency = "one"
+	CliConfig.timeout = time.Second
+	CliConfig.numConns = 1
+	CliConfig.writeQueueSize = 1000
+	CliConfig.protoVer = 4
+	CliConfig.updateCassIdx = false
 
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 }
@@ -128,7 +128,7 @@ func TestGetAddKey(t *testing.T) {
 	idx.OrgIdPublic = 100
 	defer func() { idx.OrgIdPublic = 0 }()
 
-	ix := New()
+	ix := New(CliConfig)
 	initForTests(ix)
 
 	publicSeries := getMetricData(idx.OrgIdPublic, 2, 5, 10, "metric.public")
@@ -176,20 +176,20 @@ func TestGetAddKey(t *testing.T) {
 }
 
 func TestAddToWriteQueue(t *testing.T) {
-	originalUpdateCassIdx := updateCassIdx
-	originalUpdateInterval := updateInterval
-	originalWriteQSize := writeQueueSize
+	originalUpdateCassIdx := CliConfig.updateCassIdx
+	originalUpdateInterval := CliConfig.updateInterval
+	originalWriteQSize := CliConfig.writeQueueSize
 
 	defer func() {
-		updateCassIdx = originalUpdateCassIdx
-		updateInterval = originalUpdateInterval
-		writeQueueSize = originalWriteQSize
+		CliConfig.updateCassIdx = originalUpdateCassIdx
+		CliConfig.updateInterval = originalUpdateInterval
+		CliConfig.writeQueueSize = originalWriteQSize
 	}()
 
-	updateCassIdx = true
-	updateInterval = 10
-	writeQueueSize = 5
-	ix := New()
+	CliConfig.updateCassIdx = true
+	CliConfig.updateInterval = 10
+	CliConfig.writeQueueSize = 5
+	ix := New(CliConfig)
 	initForTests(ix)
 	metrics := getMetricData(1, 2, 5, 10, "metric.demo")
 	Convey("When writeQueue is enabled", t, func() {
@@ -300,7 +300,7 @@ func TestAddToWriteQueue(t *testing.T) {
 func TestFind(t *testing.T) {
 	idx.OrgIdPublic = 100
 	defer func() { idx.OrgIdPublic = 0 }()
-	ix := New()
+	ix := New(CliConfig)
 	initForTests(ix)
 	for _, s := range getMetricData(idx.OrgIdPublic, 2, 5, 10, "metric.demo") {
 		mkey, err := schema.MKeyFromString(s.Id)
@@ -423,16 +423,16 @@ func BenchmarkIndexing(b *testing.B) {
 		b.Skip("skipping " + b.Name() + " in short mode")
 	}
 	cluster.Manager.SetPartitions([]int32{1})
-	keyspace = "metrictank"
-	hosts = "localhost:9042"
-	consistency = "one"
-	timeout = time.Second
-	numConns = 10
-	writeQueueSize = 10
-	protoVer = 4
-	updateInterval = time.Hour
-	updateCassIdx = true
-	ix := New()
+	CliConfig.keyspace = "metrictank"
+	CliConfig.hosts = "localhost:9042"
+	CliConfig.consistency = "one"
+	CliConfig.timeout = time.Second
+	CliConfig.numConns = 10
+	CliConfig.writeQueueSize = 10
+	CliConfig.protoVer = 4
+	CliConfig.updateInterval = time.Hour
+	CliConfig.updateCassIdx = true
+	ix := New(CliConfig)
 	tmpSession, err := ix.cluster.CreateSession()
 	if err != nil {
 		b.Skipf("can't connect to cassandra: %s", err)
@@ -474,16 +474,16 @@ func BenchmarkLoad(b *testing.B) {
 		b.Skip("skipping " + b.Name() + " in short mode")
 	}
 	cluster.Manager.SetPartitions([]int32{1})
-	keyspace = "metrictank"
-	hosts = "localhost:9042"
-	consistency = "one"
-	timeout = time.Second
-	numConns = 10
-	writeQueueSize = 10
-	protoVer = 4
-	updateInterval = time.Hour
-	updateCassIdx = true
-	ix := New()
+	CliConfig.keyspace = "metrictank"
+	CliConfig.hosts = "localhost:9042"
+	CliConfig.consistency = "one"
+	CliConfig.timeout = time.Second
+	CliConfig.numConns = 10
+	CliConfig.writeQueueSize = 10
+	CliConfig.protoVer = 4
+	CliConfig.updateInterval = time.Hour
+	CliConfig.updateCassIdx = true
+	ix := New(CliConfig)
 
 	tmpSession, err := ix.cluster.CreateSession()
 	if err != nil {
@@ -500,7 +500,7 @@ func BenchmarkLoad(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	ix = New()
+	ix = New(CliConfig)
 	ix.Init()
 	ix.Stop()
 }
@@ -510,16 +510,16 @@ func BenchmarkIndexingWithUpdates(b *testing.B) {
 		b.Skip("skipping " + b.Name() + " in short mode")
 	}
 	cluster.Manager.SetPartitions([]int32{1})
-	keyspace = "metrictank"
-	hosts = "localhost:9042"
-	consistency = "one"
-	timeout = time.Second
-	numConns = 10
-	writeQueueSize = 10
-	protoVer = 4
-	updateInterval = time.Hour
-	updateCassIdx = true
-	ix := New()
+	CliConfig.keyspace = "metrictank"
+	CliConfig.hosts = "localhost:9042"
+	CliConfig.consistency = "one"
+	CliConfig.timeout = time.Second
+	CliConfig.numConns = 10
+	CliConfig.writeQueueSize = 10
+	CliConfig.protoVer = 4
+	CliConfig.updateInterval = time.Hour
+	CliConfig.updateCassIdx = true
+	ix := New(CliConfig)
 	tmpSession, err := ix.cluster.CreateSession()
 	if err != nil {
 		b.Skipf("can't connect to cassandra: %s", err)

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -1,0 +1,115 @@
+package cassandra
+
+import (
+	"errors"
+	"flag"
+	"time"
+
+	"github.com/rakyll/globalconf"
+	log "github.com/sirupsen/logrus"
+)
+
+type IdxConfig struct {
+	Enabled          bool
+	pruneInterval    time.Duration
+	updateCassIdx    bool
+	updateInterval   time.Duration
+	updateInterval32 uint32
+
+	writeQueueSize int
+
+	ssl                      bool
+	auth                     bool
+	hostverification         bool
+	createKeyspace           bool
+	schemaFile               string
+	keyspace                 string
+	hosts                    string
+	capath                   string
+	username                 string
+	password                 string
+	consistency              string
+	timeout                  time.Duration
+	numConns                 int
+	protoVer                 int
+	disableInitialHostLookup bool
+}
+
+const timeUnits = "Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'"
+
+func (cfg *IdxConfig) Validate() error {
+	if cfg.updateInterval == 0 {
+		return errors.New("updateInterval must be greater than 0. " + timeUnits)
+	}
+	if cfg.pruneInterval == 0 {
+		return errors.New("pruneInterval must be greater then 0. " + timeUnits)
+	}
+	if cfg.timeout == 0 {
+		return errors.New("timeout must be greater than 0. " + timeUnits)
+	}
+	cfg.updateInterval32 = uint32(cfg.updateInterval.Nanoseconds() / int64(time.Second))
+	return nil
+}
+
+// NewIdxConfig returns StoreConfig with default values set.
+func NewIdxConfig() *IdxConfig {
+	return &IdxConfig{
+		Enabled:                  true,
+		hosts:                    "localhost:9042",
+		keyspace:                 "metrictank",
+		consistency:              "one",
+		timeout:                  time.Second,
+		numConns:                 10,
+		writeQueueSize:           100000,
+		updateCassIdx:            true,
+		updateInterval:           time.Hour * 3,
+		pruneInterval:            time.Hour * 3,
+		protoVer:                 4,
+		createKeyspace:           true,
+		schemaFile:               "/etc/metrictank/schema-idx-cassandra.toml",
+		disableInitialHostLookup: false,
+		ssl:                      false,
+		capath:                   "/etc/metrictank/ca.pem",
+		hostverification:         true,
+		auth:                     false,
+		username:                 "cassandra",
+		password:                 "cassandra",
+	}
+}
+
+var CliConfig = NewIdxConfig()
+
+func ConfigSetup() *flag.FlagSet {
+	casIdx := flag.NewFlagSet("cassandra-idx", flag.ExitOnError)
+
+	casIdx.BoolVar(&CliConfig.Enabled, "enabled", CliConfig.Enabled, "")
+	casIdx.StringVar(&CliConfig.hosts, "hosts", CliConfig.hosts, "comma separated list of cassandra addresses in host:port form")
+	casIdx.StringVar(&CliConfig.keyspace, "keyspace", CliConfig.keyspace, "Cassandra keyspace to store metricDefinitions in.")
+	casIdx.StringVar(&CliConfig.consistency, "consistency", CliConfig.consistency, "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
+	casIdx.DurationVar(&CliConfig.timeout, "timeout", CliConfig.timeout, "cassandra request timeout")
+	casIdx.IntVar(&CliConfig.numConns, "num-conns", CliConfig.numConns, "number of concurrent connections to cassandra")
+	casIdx.IntVar(&CliConfig.writeQueueSize, "write-queue-size", CliConfig.writeQueueSize, "Max number of metricDefs allowed to be unwritten to cassandra")
+	casIdx.BoolVar(&CliConfig.updateCassIdx, "update-cassandra-index", CliConfig.updateCassIdx, "synchronize index changes to cassandra. not all your nodes need to do this.")
+	casIdx.DurationVar(&CliConfig.updateInterval, "update-interval", CliConfig.updateInterval, "frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates")
+	casIdx.DurationVar(&CliConfig.pruneInterval, "prune-interval", CliConfig.pruneInterval, "Interval at which the index should be checked for stale series.")
+	casIdx.IntVar(&CliConfig.protoVer, "protocol-version", CliConfig.protoVer, "cql protocol version to use")
+	casIdx.BoolVar(&CliConfig.createKeyspace, "create-keyspace", CliConfig.createKeyspace, "enable the creation of the index keyspace and tables, only one node needs this")
+	casIdx.StringVar(&CliConfig.schemaFile, "schema-file", CliConfig.schemaFile, "File containing the needed schemas in case database needs initializing")
+	casIdx.BoolVar(&CliConfig.disableInitialHostLookup, "disable-initial-host-lookup", CliConfig.disableInitialHostLookup, "instruct the driver to not attempt to get host info from the system.peers table")
+	casIdx.BoolVar(&CliConfig.ssl, "ssl", CliConfig.ssl, "enable SSL connection to cassandra")
+	casIdx.StringVar(&CliConfig.capath, "ca-path", CliConfig.capath, "cassandra CA certficate path when using SSL")
+	casIdx.BoolVar(&CliConfig.hostverification, "host-verification", CliConfig.hostverification, "host (hostname and server cert) verification when using SSL")
+
+	casIdx.BoolVar(&CliConfig.auth, "auth", CliConfig.auth, "enable cassandra user authentication")
+	casIdx.StringVar(&CliConfig.username, "username", CliConfig.username, "username for authentication")
+	casIdx.StringVar(&CliConfig.password, "password", CliConfig.password, "password for authentication")
+
+	globalconf.Register("cassandra-idx", casIdx)
+	return casIdx
+}
+
+func ConfigProcess() {
+	if err := CliConfig.Validate(); err != nil {
+		log.Fatalf("cassandra-idx: Config validation error. %s", err)
+	}
+}

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -108,7 +108,7 @@ func ConfigSetup() *flag.FlagSet {
 	return casIdx
 }
 
-// ConfigProcess calls IdxConfig.Validate() on CliConfig. If an error is discovered this will exist with status set to 1.
+// ConfigProcess calls IdxConfig.Validate() on CliConfig. If an error is discovered this will exit with status set to 1.
 func ConfigProcess() {
 	if err := CliConfig.Validate(); err != nil {
 		log.Fatalf("cassandra-idx: Config validation error. %s", err)

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"time"
 
-	"github.com/rakyll/globalconf"
+	"github.com/grafana/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -70,9 +70,6 @@ func NewIdxConfig() *IdxConfig {
 
 // Validate validates IdxConfig settings
 func (cfg *IdxConfig) Validate() error {
-	if cfg.updateInterval == 0 {
-		return errors.New("updateInterval must be greater than 0. " + timeUnits)
-	}
 	if cfg.pruneInterval == 0 {
 		return errors.New("pruneInterval must be greater then 0. " + timeUnits)
 	}
@@ -108,7 +105,7 @@ func ConfigSetup() *flag.FlagSet {
 	casIdx.StringVar(&CliConfig.username, "username", CliConfig.username, "username for authentication")
 	casIdx.StringVar(&CliConfig.password, "password", CliConfig.password, "password for authentication")
 
-	globalconf.Register("cassandra-idx", casIdx)
+	globalconf.Register("cassandra-idx", casIdx, flag.ExitOnError)
 	return casIdx
 }
 

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -17,11 +17,10 @@ var CliConfig = NewIdxConfig()
 
 // IdxConfig stores configuration settings for a cassandra index
 type IdxConfig struct {
-	Enabled          bool
-	pruneInterval    time.Duration
-	updateCassIdx    bool
-	updateInterval   time.Duration
-	updateInterval32 uint32
+	Enabled        bool
+	pruneInterval  time.Duration
+	updateCassIdx  bool
+	updateInterval time.Duration
 
 	writeQueueSize int
 

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -68,7 +68,7 @@ func NewIdxConfig() *IdxConfig {
 	}
 }
 
-// Validate validates specific settings. It also sets updateInterval32 to an appropriate value.
+// Validate validates IdxConfig settings
 func (cfg *IdxConfig) Validate() error {
 	if cfg.updateInterval == 0 {
 		return errors.New("updateInterval must be greater than 0. " + timeUnits)
@@ -79,7 +79,6 @@ func (cfg *IdxConfig) Validate() error {
 	if cfg.timeout == 0 {
 		return errors.New("timeout must be greater than 0. " + timeUnits)
 	}
-	cfg.updateInterval32 = uint32(cfg.updateInterval.Nanoseconds() / int64(time.Second))
 	return nil
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -11,13 +11,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/conf"
 	"github.com/grafana/metrictank/errors"
 	"github.com/grafana/metrictank/idx"
 	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/stats"
 	"github.com/raintank/schema"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -65,7 +65,7 @@ func ConfigSetup() {
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
 	memoryIdx.StringVar(&indexRulesFile, "rules-file", "/etc/metrictank/index-rules.conf", "path to index-rules.conf file")
 	memoryIdx.StringVar(&maxPruneLockTimeStr, "max-prune-lock-time", "100ms", "Maximum duration each second a prune job can lock the index.")
-	globalconf.Register("memory-idx", memoryIdx)
+	globalconf.Register("memory-idx", memoryIdx, flag.ExitOnError)
 }
 
 func ConfigProcess() {

--- a/input/carbon/carbon.go
+++ b/input/carbon/carbon.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/input"
 	"github.com/grafana/metrictank/stats"
 	"github.com/metrics20/go-metrics20/carbon20"
 	"github.com/raintank/schema"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -81,7 +81,7 @@ func ConfigSetup() {
 	inCarbon.BoolVar(&Enabled, "enabled", false, "")
 	inCarbon.StringVar(&addr, "addr", ":2003", "tcp listen address")
 	inCarbon.IntVar(&partitionId, "partition", 0, "partition Id.")
-	globalconf.Register("carbon-in", inCarbon)
+	globalconf.Register("carbon-in", inCarbon, flag.ExitOnError)
 }
 
 func ConfigProcess() {

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -9,17 +9,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/raintank/schema"
-	"github.com/raintank/schema/msg"
-
 	"github.com/Shopify/sarama"
-	"github.com/rakyll/globalconf"
-	log "github.com/sirupsen/logrus"
-
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/input"
 	"github.com/grafana/metrictank/kafka"
 	"github.com/grafana/metrictank/stats"
+	"github.com/raintank/schema"
+	"github.com/raintank/schema/msg"
+	log "github.com/sirupsen/logrus"
 )
 
 // metric input.kafka-mdm.metrics_per_message is how many metrics per message were seen.
@@ -82,7 +80,7 @@ func ConfigSetup() {
 	inKafkaMdm.DurationVar(&consumerMaxWaitTime, "consumer-max-wait-time", time.Second, "The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it returns fewer than that anyway")
 	inKafkaMdm.DurationVar(&consumerMaxProcessingTime, "consumer-max-processing-time", time.Second, "The maximum amount of time the consumer expects a message takes to process")
 	inKafkaMdm.IntVar(&netMaxOpenRequests, "net-max-open-requests", 100, "How many outstanding requests a connection is allowed to have before sending on it blocks")
-	globalconf.Register("kafka-mdm-in", inKafkaMdm)
+	globalconf.Register("kafka-mdm-in", inKafkaMdm, flag.ExitOnError)
 }
 
 func ConfigProcess(instance string) {

--- a/input/prometheus/prometheus.go
+++ b/input/prometheus/prometheus.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/input"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/raintank/schema"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -139,7 +139,7 @@ func ConfigSetup() {
 	inPrometheus.BoolVar(&Enabled, "enabled", false, "")
 	inPrometheus.StringVar(&addr, "addr", ":8000", "http listen address")
 	inPrometheus.IntVar(&partitionID, "partition", 0, "partition Id.")
-	globalconf.Register("prometheus-in", inPrometheus)
+	globalconf.Register("prometheus-in", inPrometheus, flag.ExitOnError)
 }
 
 func ConfigProcess() {

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -7,13 +7,13 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/mdata/cache/accnt"
 	"github.com/grafana/metrictank/mdata/chunk"
 	"github.com/grafana/metrictank/stats"
 	"github.com/grafana/metrictank/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/raintank/schema"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -27,7 +27,7 @@ func init() {
 	flags := flag.NewFlagSet("chunk-cache", flag.ExitOnError)
 	// (1024 ^ 3) * 4 = 4294967296 = 4G
 	flags.Uint64Var(&maxSize, "max-size", 4294967296, "Maximum size of chunk cache in bytes. 0 disables cache")
-	globalconf.Register("chunk-cache", flags)
+	globalconf.Register("chunk-cache", flags, flag.ExitOnError)
 }
 
 type CCache struct {

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -7,11 +7,11 @@ import (
 	"flag"
 	"io/ioutil"
 
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/conf"
 	"github.com/grafana/metrictank/stats"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -80,7 +80,7 @@ func ConfigSetup() {
 	retentionConf := flag.NewFlagSet("retention", flag.ExitOnError)
 	retentionConf.StringVar(&schemasFile, "schemas-file", "/etc/metrictank/storage-schemas.conf", "path to storage-schemas.conf file")
 	retentionConf.StringVar(&aggFile, "aggregations-file", "/etc/metrictank/storage-aggregation.conf", "path to storage-aggregation.conf file")
-	globalconf.Register("retention", retentionConf)
+	globalconf.Register("retention", retentionConf, flag.ExitOnError)
 }
 
 func ConfigProcess() {

--- a/mdata/notifierKafka/cfg.go
+++ b/mdata/notifierKafka/cfg.go
@@ -47,7 +47,7 @@ func init() {
 	FlagSet.StringVar(&topic, "topic", "metricpersist", "kafka topic")
 	FlagSet.StringVar(&partitionStr, "partitions", "*", "kafka partitions to consume. use '*' or a comma separated list of id's. This should match the partitions used for kafka-mdm-in")
 	FlagSet.StringVar(&offsetStr, "offset", "newest", "Set the offset to start consuming from. Can be oldest, newest or a time duration")
-	FlagSet.StringVar(&backlogProcessTimeoutStr, "backlog-process-timeout", "60s", "Maximum time backlog processing can block during metrictank startup.")
+	FlagSet.StringVar(&backlogProcessTimeoutStr, "backlog-process-timeout", "60s", "Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss")
 	globalconf.Register("kafka-cluster", FlagSet, flag.ExitOnError)
 }
 

--- a/mdata/notifierKafka/cfg.go
+++ b/mdata/notifierKafka/cfg.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/kafka"
 	"github.com/grafana/metrictank/stats"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -48,7 +48,7 @@ func init() {
 	FlagSet.StringVar(&partitionStr, "partitions", "*", "kafka partitions to consume. use '*' or a comma separated list of id's. This should match the partitions used for kafka-mdm-in")
 	FlagSet.StringVar(&offsetStr, "offset", "newest", "Set the offset to start consuming from. Can be oldest, newest or a time duration")
 	FlagSet.StringVar(&backlogProcessTimeoutStr, "backlog-process-timeout", "60s", "Maximum time backlog processing can block during metrictank startup.")
-	globalconf.Register("kafka-cluster", FlagSet)
+	globalconf.Register("kafka-cluster", FlagSet, flag.ExitOnError)
 }
 
 func ConfigProcess(instance string) {

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -358,7 +358,7 @@ write-queue-size = 100000
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -348,17 +348,17 @@ hosts = localhost:9042
 protocol-version = 4
 # write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
 consistency = one
-# cassandra request timeout
+# cassandra request timeout. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 timeout = 1s
 # number of concurrent connections to cassandra
 num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
-#Interval at which the index should be checked for stale series.
+#Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -159,6 +159,8 @@ prefix = metrictank.stats.default.$instance
 addr = localhost:2003
 # interval at which to send statistics
 interval = 1
+# timeout after which a write is considered not successful
+timeout = 10s
 # how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable.
 # With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed
 buffer-size = 20000

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -334,7 +334,7 @@ partitions = *
 # When using a duration but the offset request fails (e.g. Kafka doesn't have data so far back), metrictank falls back to `oldest`.
 # Should match your kafka-mdm-in setting
 offset = newest
-# Maximum time backlog processing can block during metrictank startup.
+# Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss
 backlog-process-timeout = 60s
 
 ## metric metadata index ##

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -355,7 +355,7 @@ write-queue-size = 100000
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -156,6 +156,8 @@ prefix = metrictank.stats.docker-env.$instance
 addr = localhost:2003
 # interval at which to send statistics
 interval = 1
+# timeout after which a write is considered not successful
+timeout = 10s
 # how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable.
 # With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed
 buffer-size = 20000

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -345,17 +345,17 @@ hosts = cassandra:9042
 protocol-version = 4
 # write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
 consistency = one
-# cassandra request timeout
+# cassandra request timeout. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 timeout = 10s
 # number of concurrent connections to cassandra
 num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
-#Interval at which the index should be checked for stale series.
+#Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -331,7 +331,7 @@ partitions = *
 # When using a duration but the offset request fails (e.g. Kafka doesn't have data so far back), metrictank falls back to `oldest`.
 # Should match your kafka-mdm-in setting
 offset = newest
-# Maximum time backlog processing can block during metrictank startup.
+# Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss
 backlog-process-timeout = 60s
 
 ## metric metadata index ##

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -355,7 +355,7 @@ write-queue-size = 100000
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -345,17 +345,17 @@ hosts = localhost:9042
 protocol-version = 4
 # write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one
 consistency = one
-# cassandra request timeout
+# cassandra request timeout. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 timeout = 1s
 # number of concurrent connections to cassandra
 num-conns = 10
 # Max number of metricDefs allowed to be unwritten to cassandra
 write-queue-size = 100000
-#Interval at which the index should be checked for stale series.
+#Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
-#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true.
+#frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 update-interval = 4h
 # enable SSL connection to cassandra
 ssl = false

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -331,7 +331,7 @@ partitions = *
 # When using a duration but the offset request fails (e.g. Kafka doesn't have data so far back), metrictank falls back to `oldest`.
 # Should match your kafka-mdm-in setting
 offset = newest
-# Maximum time backlog processing can block during metrictank startup.
+# Maximum time backlog processing can block during metrictank startup. Setting to a low value may result in data loss
 backlog-process-timeout = 60s
 
 ## metric metadata index ##

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -156,6 +156,8 @@ prefix = metrictank.stats.default.$instance
 addr = localhost:2003
 # interval at which to send statistics
 interval = 1
+# timeout after which a write is considered not successful
+timeout = 10s
 # how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable.
 # With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed
 buffer-size = 20000

--- a/stats/config/init.go
+++ b/stats/config/init.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/globalconf"
 	"github.com/grafana/metrictank/stats"
-	"github.com/rakyll/globalconf"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -25,7 +25,7 @@ func ConfigSetup() {
 	inStats.IntVar(&interval, "interval", 1, "interval at which to send statistics")
 	inStats.DurationVar(&timeout, "timeout", time.Second*10, "timeout after which a write is considered not successful")
 	inStats.IntVar(&bufferSize, "buffer-size", 20000, "how many messages (holding all measurements from one interval. rule of thumb: a message is ~25kB) to buffer up in case graphite endpoint is unavailable. With the default of 20k you will use max about 500MB and bridge 5 hours of downtime when needed")
-	globalconf.Register("stats", inStats)
+	globalconf.Register("stats", inStats, flag.ExitOnError)
 }
 
 func ConfigProcess(instance string) {

--- a/store/bigtable/config.go
+++ b/store/bigtable/config.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/rakyll/globalconf"
+	"github.com/grafana/globalconf"
 )
 
 type StoreConfig struct {
@@ -82,7 +82,7 @@ func ConfigSetup() {
 	btStore.DurationVar(&CliConfig.WriteTimeout, "write-timeout", CliConfig.WriteTimeout, "write timeout")
 	btStore.BoolVar(&CliConfig.CreateCF, "create-cf", CliConfig.CreateCF, "enable the creation of the table and column families")
 
-	globalconf.Register("bigtable-store", btStore)
+	globalconf.Register("bigtable-store", btStore, flag.ExitOnError)
 	return
 }
 

--- a/store/cassandra/config.go
+++ b/store/cassandra/config.go
@@ -3,7 +3,7 @@ package cassandra
 import (
 	"flag"
 
-	"github.com/rakyll/globalconf"
+	"github.com/grafana/globalconf"
 )
 
 type StoreConfig struct {
@@ -88,6 +88,6 @@ func ConfigSetup() *flag.FlagSet {
 	cas.StringVar(&CliConfig.Username, "username", CliConfig.Username, "username for authentication")
 	cas.StringVar(&CliConfig.Password, "password", CliConfig.Password, "password for authentication")
 	cas.StringVar(&CliConfig.SchemaFile, "schema-file", CliConfig.SchemaFile, "File containing the needed schemas in case database needs initializing")
-	globalconf.Register("cassandra", cas)
+	globalconf.Register("cassandra", cas, flag.ExitOnError)
 	return cas
 }

--- a/vendor/github.com/grafana/globalconf/globalconf.go
+++ b/vendor/github.com/grafana/globalconf/globalconf.go
@@ -143,7 +143,11 @@ func (g *GlobalConf) Parse() {
 					case flag.ContinueOnError:
 						return
 					case flag.ExitOnError:
-						fmt.Printf("failed to set %s\n%s\n", f.Name, err)
+						var section string
+						if name != "" {
+							section = name + "."
+						}
+						fmt.Printf("failed to set %s%s: %s\n", section, f.Name, err)
 						os.Exit(2)
 					case flag.PanicOnError:
 						panic(err)
@@ -159,7 +163,11 @@ func (g *GlobalConf) Parse() {
 					case flag.ContinueOnError:
 						return
 					case flag.ExitOnError:
-						fmt.Printf("failed to set %s\n%s\n", f.Name, err)
+						var section string
+						if name != "" {
+							section = name + "."
+						}
+						fmt.Printf("failed to set %s%s: %s\n", section, f.Name, err)
 						os.Exit(2)
 					case flag.PanicOnError:
 						panic(err)

--- a/vendor/github.com/grafana/globalconf/globalconf.go
+++ b/vendor/github.com/grafana/globalconf/globalconf.go
@@ -2,6 +2,7 @@ package globalconf
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -15,7 +16,12 @@ const (
 	defaultConfigFileName = "config.ini"
 )
 
-var flags map[string]*flag.FlagSet = make(map[string]*flag.FlagSet)
+type flagSet struct {
+	*flag.FlagSet
+	errorHandling flag.ErrorHandling
+}
+
+var flags map[string]*flagSet = make(map[string]*flagSet)
 
 // Represents a GlobalConf context.
 type GlobalConf struct {
@@ -33,7 +39,7 @@ type Options struct {
 // Options. The caller is responsible for creating any
 // referenced config files.
 func NewWithOptions(opts *Options) (g *GlobalConf, err error) {
-	Register("", flag.CommandLine)
+	Register("", flag.CommandLine, flag.ExitOnError)
 
 	var dict ini.Dict
 	if opts.Filename != "" {
@@ -132,14 +138,35 @@ func (g *GlobalConf) Parse() {
 			}
 
 			if val, ok := getEnv(g.EnvPrefix, name, f.Name); ok {
-				set.Set(f.Name, val)
+				if err := set.Set(f.Name, val); err != nil {
+					switch set.errorHandling {
+					case flag.ContinueOnError:
+						return
+					case flag.ExitOnError:
+						fmt.Printf("failed to set %s\n%s\n", f.Name, err)
+						os.Exit(2)
+					case flag.PanicOnError:
+						panic(err)
+					}
+				}
 				return
 			}
 
 			val, found := g.dict.GetString(name, f.Name)
 			if found {
-				set.Set(f.Name, val)
+				if err := set.Set(f.Name, val); err != nil {
+					switch set.errorHandling {
+					case flag.ContinueOnError:
+						return
+					case flag.ExitOnError:
+						fmt.Printf("failed to set %s\n%s\n", f.Name, err)
+						os.Exit(2)
+					case flag.PanicOnError:
+						panic(err)
+					}
+				}
 			}
+			return
 		})
 	}
 }
@@ -174,6 +201,6 @@ func getEnv(envPrefix, flagSetName, flagName string) (string, bool) {
 // Register registers a flag set to be parsed. Register all flag sets
 // before calling this function. flag.CommandLine is automatically
 // registered.
-func Register(flagSetName string, set *flag.FlagSet) {
-	flags[flagSetName] = set
+func Register(flagSetName string, set *flag.FlagSet, errorHandling flag.ErrorHandling) {
+	flags[flagSetName] = &flagSet{set, errorHandling}
 }


### PR DESCRIPTION
add err handling for 0 value durations in cass idx
add ability to implement custom validation for config values in cass idx
add config.go for cass idx configuration
update cass idx tests to use new config
update metrictank config and docs to show valid time units

update mt-index-cat to use new cass idx config
update mt-whisper-importer-writer to use new cass idx config

For earlier discussions on the previous PR to address this issue please see #1098

See also: #944, https://github.com/grafana/globalconf/pull/3