### PR TITLE
Improve performance of SetTags

### DIFF
--- a/api/models/series.go
+++ b/api/models/series.go
@@ -30,7 +30,7 @@ func (s *Series) SetTags() {
 
 	if s.Tags == nil {
 		// +1 for the name tag
-		s.Tags = make(map[string]string, numTags)
+		s.Tags = make(map[string]string, numTags+1)
 	} else {
 		for k := range s.Tags {
 			delete(s.Tags, k)
@@ -43,7 +43,7 @@ func (s *Series) SetTags() {
 	}
 
 	index := strings.IndexByte(s.Target, ';')
-	name := s.Target[0:index]
+	name := s.Target[:index]
 
 	remainder := s.Target
 	for index > 0 {
@@ -61,10 +61,10 @@ func (s *Series) SetTags() {
 			continue
 		}
 
-		s.Tags[tagPair[0:equalsPos]] = tagPair[equalsPos+1:]
+		s.Tags[tagPair[:equalsPos]] = tagPair[equalsPos+1:]
 	}
 
-	// Do this last to overwrite any invalid "name" tag that might be preset
+	// Do this last to overwrite any "name" tag that might have been specified in the series tags.
 	s.Tags["name"] = name
 }
 

--- a/api/models/series_test.go
+++ b/api/models/series_test.go
@@ -168,7 +168,7 @@ func benchmarkSetTags(b *testing.B, numTags, tagKeyLength, tagValueLength int, r
 	}
 
 	for i := 0; i < numTags; i++ {
-		in.Target = in.Target + ";" + randString(tagKeyLength) + "=" + randString(tagValueLength)
+		in.Target += ";" + randString(tagKeyLength) + "=" + randString(tagValueLength)
 	}
 
 	b.ResetTimer()

--- a/api/models/series_test.go
+++ b/api/models/series_test.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"encoding/json"
+	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/raintank/schema"
@@ -89,4 +91,104 @@ func TestJsonMarshal(t *testing.T) {
 			t.Fatalf("bad json output.\nexpected:%s\ngot:     %s\n", c.out, got)
 		}
 	}
+}
+
+func TestSetTags(t *testing.T) {
+	cases := []struct {
+		in  Series
+		out map[string]string
+	}{
+		{
+			in: Series{},
+			out: map[string]string{
+				"name": "",
+			},
+		},
+		{
+			in: Series{
+				Target: "a",
+			},
+			out: map[string]string{
+				"name": "a",
+			},
+		},
+		{
+			in: Series{
+				Target: `a\b`,
+			},
+			out: map[string]string{
+				"name": `a\b`,
+			},
+		},
+		{
+			in: Series{
+				Target: "a;b=c;c=d",
+			},
+			out: map[string]string{
+				"name": "a",
+				"b":    "c",
+				"c":    "d",
+			},
+		},
+		{
+			in: Series{
+				Target: "a;biglongtagkeyhere=andithasabiglongtagvaluetoo;c=d",
+			},
+			out: map[string]string{
+				"name":              "a",
+				"biglongtagkeyhere": "andithasabiglongtagvaluetoo",
+				"c":                 "d",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c.in.SetTags()
+		if !reflect.DeepEqual(c.out, c.in.Tags) {
+			t.Fatalf("SetTags incorrect\nexpected:%v\ngot:     %v\n", c.out, c.in.Tags)
+		}
+	}
+}
+
+func BenchmarkSetTags_00tags_00chars(b *testing.B) {
+	benchmarkSetTags(b, 0, 0, 0)
+}
+
+func BenchmarkSetTags_20tags_32chars(b *testing.B) {
+	benchmarkSetTags(b, 20, 32, 32)
+}
+
+func benchmarkSetTags(b *testing.B, numTags, tagKeyLength, tagValueLength int) {
+	in := Series{
+		Target: "my.metric.name",
+	}
+
+	for i := 0; i < numTags; i++ {
+		in.Target = in.Target + ";" + randString(tagKeyLength)
+		in.Target = in.Target + "="
+		in.Target = in.Target + randString(tagValueLength)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		in.SetTags()
+		if len(in.Tags) != numTags+1 {
+			b.Fatalf("Expected %d tags, got %d, target = %s, tags = %v", numTags+1, len(in.Tags), in.Target, in.Tags)
+		}
+		// Reset so as to not game the allocations
+		in.Tags = nil
+	}
+	b.SetBytes(int64(len(in.Target)))
+}
+
+func randString(n int) string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
While debugging slowness in `groupByTags`, the performance of SetTags stood out. I don't believe this was the primary source of slowness in my case, but it certainly could be a contributing factor, since this is called for every series that is processed via `render`.  Aside from replacing `SplitN` with `IndexByte`, I also only allocate a new map if the existing one is `nil`. I ran the benchmark in two modes, one where I leave the Tags and one where I `nil` them out.

Here's the benchcmp when `s.Tags == nil`
```
benchmark                             old ns/op     new ns/op     delta
BenchmarkSetTags_00tags_00chars-8     272           193           -29.04%
BenchmarkSetTags_20tags_32chars-8     3725          1798          -51.73%

benchmark                             old MB/s     new MB/s     speedup
BenchmarkSetTags_00tags_00chars-8     51.36        72.48        1.41x
BenchmarkSetTags_20tags_32chars-8     358.05       741.88       2.07x

benchmark                             old allocs     new allocs     delta
BenchmarkSetTags_00tags_00chars-8     3              2              -33.33%
BenchmarkSetTags_20tags_32chars-8     23             2              -91.30%

benchmark                             old bytes     new bytes     delta
BenchmarkSetTags_00tags_00chars-8     352           336           -4.55%
BenchmarkSetTags_20tags_32chars-8     2256          1264          -43.97%
```

and here is when we reuse the Tags:
```
benchmark                             old ns/op     new ns/op     delta
BenchmarkSetTags_00tags_00chars-8     272           99.3          -63.49%
BenchmarkSetTags_20tags_32chars-8     3725          2081          -44.13%

benchmark                             old MB/s     new MB/s     speedup
BenchmarkSetTags_00tags_00chars-8     51.36        140.92       2.74x
BenchmarkSetTags_20tags_32chars-8     358.05       640.78       1.79x

benchmark                             old allocs     new allocs     delta
BenchmarkSetTags_00tags_00chars-8     3              0              -100.00%
BenchmarkSetTags_20tags_32chars-8     23             0              -100.00%

benchmark                             old bytes     new bytes     delta
BenchmarkSetTags_00tags_00chars-8     352           0             -100.00%
BenchmarkSetTags_20tags_32chars-8     2256          0             -100.00%
```

With a lot of tags, the cost of clearing the map is higher than reallocating, but this was go 1.10.3 and I know go 1.11 has optimized map clearing.