### PR TITLE
Use more cache friendly implementations

### DIFF
--- a/expr/seriesaggregators.go
+++ b/expr/seriesaggregators.go
@@ -66,96 +66,72 @@ func crossSeriesAvg(in []models.Series, out *[]schema.Point) {
 
 func crossSeriesMin(in []models.Series, out *[]schema.Point) {
 	for i := 0; i < len(in[0].Datapoints); i++ {
-		nan := true
-		min := math.Inf(1)
-		for j := 0; j < len(in); j++ {
-			p := in[j].Datapoints[i].Val
-			if !math.IsNaN(p) && p < min {
-				nan = false
-				min = p
+		*out = append(*out, in[0].Datapoints[i])
+	}
+
+	for i := 1; i < len(in); i++ {
+		dps := in[i].Datapoints
+		for j := 0; j < len(in[i].Datapoints); j++ {
+			p := dps[j].Val
+			if !math.IsNaN(p) {
+				v := (*out)[j].Val
+				if math.IsNaN(v) || v > p {
+					(*out)[j].Val = p
+				}
 			}
 		}
-
-		point := schema.Point{
-			Ts: in[0].Datapoints[i].Ts,
-		}
-		if nan {
-			point.Val = math.NaN()
-		} else {
-			point.Val = min
-		}
-
-		*out = append(*out, point)
 	}
 }
 
 func crossSeriesMax(in []models.Series, out *[]schema.Point) {
 	for i := 0; i < len(in[0].Datapoints); i++ {
-		nan := true
-		max := math.Inf(-1)
-		for j := 0; j < len(in); j++ {
-			p := in[j].Datapoints[i].Val
-			if !math.IsNaN(p) && p > max {
-				nan = false
-				max = p
+		*out = append(*out, in[0].Datapoints[i])
+	}
+
+	for i := 1; i < len(in); i++ {
+		dps := in[i].Datapoints
+		for j := 0; j < len(in[i].Datapoints); j++ {
+			p := dps[j].Val
+			if !math.IsNaN(p) {
+				v := (*out)[j].Val
+				if math.IsNaN(v) || v < p {
+					(*out)[j].Val = p
+				}
 			}
 		}
-
-		point := schema.Point{
-			Ts: in[0].Datapoints[i].Ts,
-		}
-		if nan {
-			point.Val = math.NaN()
-		} else {
-			point.Val = max
-		}
-
-		*out = append(*out, point)
 	}
 }
 
 func crossSeriesSum(in []models.Series, out *[]schema.Point) {
 	for i := 0; i < len(in[0].Datapoints); i++ {
-		nan := true
-		sum := float64(0)
-		for j := 0; j < len(in); j++ {
-			p := in[j].Datapoints[i].Val
+		*out = append(*out, in[0].Datapoints[i])
+	}
+
+	for i := 1; i < len(in); i++ {
+		dps := in[i].Datapoints
+		for j := 0; j < len(in[i].Datapoints); j++ {
+			p := dps[j].Val
 			if !math.IsNaN(p) {
-				nan = false
-				sum += p
+				if math.IsNaN((*out)[j].Val) {
+					(*out)[j].Val = p
+				} else {
+					(*out)[j].Val += p
+				}
 			}
 		}
-		point := schema.Point{
-			Ts: in[0].Datapoints[i].Ts,
-		}
-		if nan {
-			point.Val = math.NaN()
-		} else {
-			point.Val = sum
-		}
-
-		*out = append(*out, point)
 	}
 }
 
 func crossSeriesMultiply(in []models.Series, out *[]schema.Point) {
 	for i := 0; i < len(in[0].Datapoints); i++ {
-		product := float64(1)
-		for j := 0; j < len(in); j++ {
-			p := in[j].Datapoints[i].Val
-			if math.IsNaN(p) {
-				// NaN * anything equals NaN()
-				product = math.NaN()
-				break
-			}
-			product *= p
-		}
-		point := schema.Point{
-			Ts:  in[0].Datapoints[i].Ts,
-			Val: product,
-		}
+		*out = append(*out, in[0].Datapoints[i])
+	}
 
-		*out = append(*out, point)
+	for i := 1; i < len(in); i++ {
+		dps := in[i].Datapoints
+		for j := 0; j < len(in[i].Datapoints); j++ {
+			(*out)[j].Val *= dps[j].Val
+		}
 	}
 }
 
@@ -190,68 +166,52 @@ func crossSeriesMedian(in []models.Series, out *[]schema.Point) {
 
 func crossSeriesDiff(in []models.Series, out *[]schema.Point) {
 	for i := 0; i < len(in[0].Datapoints); i++ {
-		val := math.NaN()
-		for j := 0; j < len(in); j++ {
-			p := in[j].Datapoints[i].Val
+		*out = append(*out, in[0].Datapoints[i])
+	}
+
+	for i := 1; i < len(in); i++ {
+		for j := 0; j < len(in[i].Datapoints); j++ {
+			p := in[i].Datapoints[j].Val
 			if !math.IsNaN(p) {
-				if math.IsNaN(val) {
-					val = p
+				if math.IsNaN((*out)[j].Val) {
+					(*out)[j].Val = p
 				} else {
-					val -= p
+					(*out)[j].Val -= p
 				}
 			}
-		}
-		point := schema.Point{
-			Ts:  in[0].Datapoints[i].Ts,
-			Val: val,
-		}
 
-		*out = append(*out, point)
+		}
 	}
 }
 
 func crossSeriesStddev(in []models.Series, out *[]schema.Point) {
-	averages := make([]schema.Point, 0, len(in[0].Datapoints))
-	crossSeriesAvg(in, &averages)
+	crossSeriesAvg(in, out)
 
 	for i := 0; i < len(in[0].Datapoints); i++ {
-		point := schema.Point{
-			Ts:  in[0].Datapoints[i].Ts,
-			Val: math.NaN(),
-		}
-
-		if !math.IsNaN(averages[i].Val) {
+		if !math.IsNaN((*out)[i].Val) {
 			num := float64(0)
 			totalDeviationSquared := float64(0)
 			for j := 0; j < len(in); j++ {
 				p := in[j].Datapoints[i].Val
 				if !math.IsNaN(p) {
 					num++
-					deviation := p - averages[i].Val
+					deviation := p - (*out)[i].Val
 					totalDeviationSquared += deviation * deviation
 				}
 			}
 
-			point.Val = math.Sqrt(totalDeviationSquared / num)
+			(*out)[i].Val = math.Sqrt(totalDeviationSquared / num)
 		}
-
-		*out = append(*out, point)
 	}
 }
 
 func crossSeriesRange(in []models.Series, out *[]schema.Point) {
-	maxes := make([]schema.Point, 0, len(in[0].Datapoints))
 	mins := make([]schema.Point, 0, len(in[0].Datapoints))
 
-	crossSeriesMax(in, &maxes)
+	crossSeriesMax(in, out)
 	crossSeriesMin(in, &mins)
 
 	for i := 0; i < len(in[0].Datapoints); i++ {
-		point := schema.Point{
-			Ts:  in[0].Datapoints[i].Ts,
-			Val: maxes[i].Val - mins[i].Val,
-		}
-
-		*out = append(*out, point)
+		(*out)[i].Val -= mins[i].Val
 	}
 }


### PR DESCRIPTION
While debugging slow `groupByTags` performance I noticed that a lot of the time was in `math.IsNaN`. This function should be fast, so I figured it was due to cpu cache line misses. Some of the functions were easy to make more cache friendly, so I did.

```
benchmark                                              old ns/op     new ns/op     delta
BenchmarkSeriesAggregateSum10k_100NoNulls-8            4520815       1746490       -61.37%
BenchmarkSeriesAggregateSum10k_100WithNulls-8          4458155       1744894       -60.86%
BenchmarkSeriesAggregateMax10k_100NoNulls-8            3263282       1772731       -45.68%
BenchmarkSeriesAggregateMax10k_100WithNulls-8          3288302       1777941       -45.93%
BenchmarkSeriesAggregateMin10k_100NoNulls-8            3417546       1737670       -49.15%
BenchmarkSeriesAggregateMin10k_100WithNulls-8          3526632       1759587       -50.11%
BenchmarkSeriesAggregateMultiply10k_100NoNulls-8       2998636       1293014       -56.88%
BenchmarkSeriesAggregateMultiply10k_100WithNulls-8     2987237       1290399       -56.80%
BenchmarkSeriesAggregateDiff10k_100NoNulls-8           4737603       1951431       -58.81%
BenchmarkSeriesAggregateDiff10k_100WithNulls-8         4656263       1942149       -58.29%
BenchmarkSeriesAggregateRange10k_100NoNulls-8          6827062       3519037       -48.45%
BenchmarkSeriesAggregateRange10k_100WithNulls-8        6853572       3535418       -48.41%

benchmark                                              old MB/s     new MB/s     speedup
BenchmarkSeriesAggregateSum10k_100NoNulls-8            2654.39      6870.92      2.59x
BenchmarkSeriesAggregateSum10k_100WithNulls-8          2691.70      6877.21      2.55x
BenchmarkSeriesAggregateMax10k_100NoNulls-8            3677.28      6769.22      1.84x
BenchmarkSeriesAggregateMax10k_100WithNulls-8          3649.30      6749.38      1.85x
BenchmarkSeriesAggregateMin10k_100NoNulls-8            3511.29      6905.80      1.97x
BenchmarkSeriesAggregateMin10k_100WithNulls-8          3402.68      6819.78      2.00x
BenchmarkSeriesAggregateMultiply10k_100NoNulls-8       4001.82      9280.63      2.32x
BenchmarkSeriesAggregateMultiply10k_100WithNulls-8     4017.09      9299.45      2.31x
BenchmarkSeriesAggregateDiff10k_100NoNulls-8           2532.93      6149.33      2.43x
BenchmarkSeriesAggregateDiff10k_100WithNulls-8         2577.17      6178.72      2.40x
BenchmarkSeriesAggregateRange10k_100NoNulls-8          1757.71      3410.02      1.94x
BenchmarkSeriesAggregateRange10k_100WithNulls-8        1750.91      3394.22      1.94x
```