### PR TITLE
Dynamic GC control

### DIFF
--- a/api/gc.go
+++ b/api/gc.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"github.com/grafana/metrictank/api/middleware"
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/response"
+	"github.com/grafana/metrictank/input/kafkamdm"
+)
+
+func (s *Server) getStartupGCPercent(ctx *middleware.Context) {
+	response.Write(ctx, response.NewJson(200, models.StartupGCPercent{Value: kafkamdm.StartupGCPercent}, ""))
+}
+
+func (s *Server) getNormalGCPercent(ctx *middleware.Context) {
+	response.Write(ctx, response.NewJson(200, models.NormalGCPercent{Value: kafkamdm.NormalGCPercent}, ""))
+}
+
+func (s *Server) setStartupGCPercent(ctx *middleware.Context, percent models.StartupGCPercent) {
+	kafkamdm.StartupGCPercent = percent.Value
+	ctx.PlainText(200, []byte("OK"))
+}
+
+func (s *Server) setNormalGCPercent(ctx *middleware.Context, percent models.NormalGCPercent) {
+	kafkamdm.NormalGCPercent = percent.Value
+	ctx.PlainText(200, []byte("OK"))
+}

--- a/api/gc.go
+++ b/api/gc.go
@@ -16,11 +16,15 @@ func (s *Server) getNormalGCPercent(ctx *middleware.Context) {
 }
 
 func (s *Server) setStartupGCPercent(ctx *middleware.Context, percent models.StartupGCPercent) {
+	kafkamdm.GoGCmutex.Lock()
+	defer kafkamdm.GoGCmutex.Unlock()
 	kafkamdm.StartupGCPercent = percent.Value
 	ctx.PlainText(200, []byte("OK"))
 }
 
 func (s *Server) setNormalGCPercent(ctx *middleware.Context, percent models.NormalGCPercent) {
+	kafkamdm.GoGCmutex.Lock()
+	defer kafkamdm.GoGCmutex.Unlock()
 	kafkamdm.NormalGCPercent = percent.Value
 	ctx.PlainText(200, []byte("OK"))
 }

--- a/api/models/gc.go
+++ b/api/models/gc.go
@@ -1,0 +1,9 @@
+package models
+
+type NormalGCPercent struct {
+	Value int `json:"value" form:"value" binding:"Required"`
+}
+
+type StartupGCPercent struct {
+	Value int `json:"value" form:"value" binding:"Required"`
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/metrictank/api/models"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/raintank/gziper"
-	macaron "gopkg.in/macaron.v1"
+	"gopkg.in/macaron.v1"
 )
 
 func (s *Server) RegisterRoutes() {

--- a/api/routes.go
+++ b/api/routes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/metrictank/api/models"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/raintank/gziper"
-	"gopkg.in/macaron.v1"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func (s *Server) RegisterRoutes() {
@@ -77,4 +77,10 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/prometheus/api/v1/series", cBody, withOrg, ready, form(models.PrometheusSeriesQuery{})).Get(s.prometheusQuerySeries).Post(s.prometheusQuerySeries)
 	r.Get("/prometheus/api/v1/label/:name/values", cBody, withOrg, ready, s.prometheusLabelValues)
 	r.Get("/prometheus/metrics", promhttp.Handler())
+
+	// GC gontrol
+	r.Get("/gc/startup", noTrace, s.getStartupGCPercent)
+	r.Get("/gc/normal", noTrace, s.getNormalGCPercent)
+	r.Post("/gc/startup", bind(models.StartupGCPercent{}), s.setStartupGCPercent)
+	r.Post("/gc/normal", bind(models.NormalGCPercent{}), s.setNormalGCPercent)
 }

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -56,7 +56,7 @@ func ConfigSetup() {
 	clusterCfg.IntVar(&maxPrio, "max-priority", 10, "maximum priority before a node should be considered not-ready.")
 	clusterCfg.IntVar(&minAvailableShards, "min-available-shards", 0, "minimum number of shards that must be available for a query to be handled.")
 	globalconf.Register("cluster", clusterCfg, flag.ExitOnError)
-  MaxPrio = maxPrio
+	MaxPrio = maxPrio
 
 	swimCfg := flag.NewFlagSet("swim", flag.ExitOnError)
 	swimCfg.StringVar(&swimUseConfig, "use-config", "manual", "config setting to use. If set to anything but manual, will override all other swim settings. Use manual|default-lan|default-local|default-wan. see https://godoc.org/github.com/hashicorp/memberlist#Config . Note all our swim settings correspond to default-lan")

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -17,6 +17,7 @@ var (
 	peersStr           string
 	mode               string
 	maxPrio            int
+	MaxPrio            int
 	httpTimeout        time.Duration
 	minAvailableShards int
 
@@ -55,6 +56,7 @@ func ConfigSetup() {
 	clusterCfg.IntVar(&maxPrio, "max-priority", 10, "maximum priority before a node should be considered not-ready.")
 	clusterCfg.IntVar(&minAvailableShards, "min-available-shards", 0, "minimum number of shards that must be available for a query to be handled.")
 	globalconf.Register("cluster", clusterCfg)
+	MaxPrio = maxPrio
 
 	swimCfg := flag.NewFlagSet("swim", flag.ExitOnError)
 	swimCfg.StringVar(&swimUseConfig, "use-config", "manual", "config setting to use. If set to anything but manual, will override all other swim settings. Use manual|default-lan|default-local|default-wan. see https://godoc.org/github.com/hashicorp/memberlist#Config . Note all our swim settings correspond to default-lan")

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,7 +5,7 @@ a [storage-schemas.conf file](https://github.com/grafana/metrictank/blob/master/
 a [storage-aggregation.conf file](https://github.com/grafana/metrictank/blob/master/scripts/config/storage-aggregation.conf)
 an [index-rules.conf file](https://github.com/grafana/metrictank/blob/master/scripts/config/index-rules.conf)
 
-The files themselves are well documented, but for your convenience, they are replicated below.  
+The files themselves are well documented, but for your convenience, they are replicated below.
 
 Config values for the main ini config file can also be set, or overridden via environment variables.
 They require the 'MT_' prefix.  Any delimiter is represented as an underscore.
@@ -25,8 +25,8 @@ MT_KAFKA_MDM_IN_DATA_DIR: /your/data/dir  # MT_<section_title>_<setting_name>
 # Metrictank.ini
 
 
-sample config for metrictank  
-the defaults here match the default behavior.  
+sample config for metrictank
+the defaults here match the default behavior.
 ## misc ##
 
 ```
@@ -299,6 +299,10 @@ consumer-max-wait-time = 1s
 consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
 net-max-open-requests = 100
+# GOGC value during node startup (lag > maxPrio), default sets in runtime using GOGC env. variable
+#gogc-startup = 100
+# GOGC value during normal run (lag <= maxPrio), default sets in runtime using GOGC env. variable
+#gogc-ready = 100
 ```
 
 ## basic clustering settings ##
@@ -498,7 +502,7 @@ create-cf = true
 # * Valid units are s/sec/secs/second/seconds, m/min/mins/minute/minutes, h/hour/hours, d/day/days, w/week/weeks, mon/month/months, y/year/years
 
 [default]
-pattern = 
+pattern =
 max-stale = 0
 ```
 
@@ -539,7 +543,7 @@ aggregationMethod = avg,min,max
 # (note in particular that if you remove archives here, we will no longer read from them)
 # * Retentions must be specified in order of increasing interval and retention
 # * The reorderBuffer an optional buffer that temporarily keeps data points in memory as raw data and allows insertion at random order. The specified value is how many datapoints, based on the raw interval specified in the first defined retention, should be kept before they are flushed out. This is useful if the metric producers cannot guarantee that the data will arrive in order, but it is relatively memory intensive. If you are unsure whether you need this, better leave it disabled to not waste memory.
-# 
+#
 # A given rule is made up of at least 3 lines: the name, regex pattern, retentions and optionally the reorder buffer size.
 # The retentions line can specify multiple retention definitions. You need one or more, space separated.
 #

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,7 +5,7 @@ a [storage-schemas.conf file](https://github.com/grafana/metrictank/blob/master/
 a [storage-aggregation.conf file](https://github.com/grafana/metrictank/blob/master/scripts/config/storage-aggregation.conf)
 an [index-rules.conf file](https://github.com/grafana/metrictank/blob/master/scripts/config/index-rules.conf)
 
-The files themselves are well documented, but for your convenience, they are replicated below.
+The files themselves are well documented, but for your convenience, they are replicated below.  
 
 Config values for the main ini config file can also be set, or overridden via environment variables.
 They require the 'MT_' prefix.  Any delimiter is represented as an underscore.
@@ -25,8 +25,8 @@ MT_KAFKA_MDM_IN_DATA_DIR: /your/data/dir  # MT_<section_title>_<setting_name>
 # Metrictank.ini
 
 
-sample config for metrictank
-the defaults here match the default behavior.
+sample config for metrictank  
+the defaults here match the default behavior.  
 ## misc ##
 
 ```
@@ -502,7 +502,7 @@ create-cf = true
 # * Valid units are s/sec/secs/second/seconds, m/min/mins/minute/minutes, h/hour/hours, d/day/days, w/week/weeks, mon/month/months, y/year/years
 
 [default]
-pattern =
+pattern = 
 max-stale = 0
 ```
 
@@ -543,7 +543,7 @@ aggregationMethod = avg,min,max
 # (note in particular that if you remove archives here, we will no longer read from them)
 # * Retentions must be specified in order of increasing interval and retention
 # * The reorderBuffer an optional buffer that temporarily keeps data points in memory as raw data and allows insertion at random order. The specified value is how many datapoints, based on the raw interval specified in the first defined retention, should be kept before they are flushed out. This is useful if the metric producers cannot guarantee that the data will arrive in order, but it is relatively memory intensive. If you are unsure whether you need this, better leave it disabled to not waste memory.
-#
+# 
 # A given rule is made up of at least 3 lines: the name, regex pattern, retentions and optionally the reorder buffer size.
 # The retentions line can specify multiple retention definitions. You need one or more, space separated.
 #

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -219,6 +219,52 @@ Remove chunks from the cache for matching series, or wipe the entire cache
 curl -v -X POST -d '{"propagate": true, "orgId": 1, "patterns": ["**"]}' -H 'Content-Type: application/json' http://localhost:6060/ccache/delete
 ```
 
+## GC control
+
+```
+GET /gc/startup
+GET /gc/normal
+```
+
+Get startup / normal GC percent value.
+
+#### Example
+
+```bash
+curl -v http://localhost:6060/gc/startup
+*   Trying ::1...
+* TCP_NODELAY set
+* Connected to localhost (::1) port 6060 (#0)
+> GET /gc/startup HTTP/1.1
+> Host: localhost:6060
+> User-Agent: curl/7.54.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< Vary: Origin
+< Date: Fri, 30 Nov 2018 16:12:06 GMT
+< Content-Length: 12
+<
+* Connection #0 to host localhost left intact
+{"value":50}
+```
+
+```
+POST /gc/startup
+POST /gc/normal
+```
+
+Set startup / normal GC percent value.
+* value : target GC percent 
+
+#### Example
+
+```bash
+curl -X POST --data value=200 http://localhost:6060/gc/normal
+OK
+```
+
 ## Misc
 
 ### Tspec

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -155,6 +155,9 @@ The `go tool pprof` command will give you a command prompt.
 Type exit (or ctrl-D) to exit the prompt.
 For more information on profiling see the excellent [Profiling Go Programs](https://blog.golang.org/profiling-go-programs) article.
 
+## GC control
+
+You can use `gogc-startup` and `gogc-ready` parameters in `[kafka-mdm-in]` section for GOGC control. Startup parameter will be used until kafka lag become less then 10 seconds (i.e. during startup and initial catch-up). After startup, GOGC will be set up to `gogc-ready` value. You can also [HTTP API](https://github.com/grafana/metrictank/blob/master/docs/http-api.md) for [GC control](https://github.com/grafana/metrictank/blob/master/docs/http-api.md#gc-control).
 
 ## data doesn't show up
 

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -69,6 +69,7 @@ var partitionLag map[int32]*stats.Gauge64
 var NormalGCPercent int
 var StartupGCPercent int
 var goGC int
+var GoGCmutex sync.Mutex
 
 func ConfigSetup() {
 	inKafkaMdm := flag.NewFlagSet("kafka-mdm-in", flag.ExitOnError)

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -66,6 +68,9 @@ var offsetDuration time.Duration
 var partitionOffset map[int32]*stats.Gauge64
 var partitionLogSize map[int32]*stats.Gauge64
 var partitionLag map[int32]*stats.Gauge64
+var NormalGCPercent int
+var StartupGCPercent int
+var goGC int
 
 func ConfigSetup() {
 	inKafkaMdm := flag.NewFlagSet("kafka-mdm-in", flag.ExitOnError)
@@ -82,6 +87,17 @@ func ConfigSetup() {
 	inKafkaMdm.DurationVar(&consumerMaxWaitTime, "consumer-max-wait-time", time.Second, "The maximum amount of time the broker will wait for Consumer.Fetch.Min bytes to become available before it returns fewer than that anyway")
 	inKafkaMdm.DurationVar(&consumerMaxProcessingTime, "consumer-max-processing-time", time.Second, "The maximum amount of time the consumer expects a message takes to process")
 	inKafkaMdm.IntVar(&netMaxOpenRequests, "net-max-open-requests", 100, "How many outstanding requests a connection is allowed to have before sending on it blocks")
+	if os.Getenv("GOGC") != "" {
+		var err error
+		goGC, err = strconv.Atoi(os.Getenv("GOGC"))
+		if err != nil {
+			goGC = 100
+		}
+	} else {
+		goGC = 100
+	}
+	inKafkaMdm.IntVar(&StartupGCPercent, "gogc-startup", goGC, "GOGC value during node startup (lag > maxPrio)")
+	inKafkaMdm.IntVar(&NormalGCPercent, "gogc-ready", goGC, "GOGC value during normal run (lag <= maxPrio)")
 	globalconf.Register("kafka-mdm-in", inKafkaMdm)
 }
 
@@ -374,6 +390,18 @@ func (k *KafkaMdm) MaintainPriority() {
 				return
 			case <-ticker.C:
 				cluster.Manager.SetPriority(k.lagMonitor.Metric())
+				if NormalGCPercent != goGC || StartupGCPercent != goGC {
+					lag := k.lagMonitor.Metric()
+					if lag >= 0 && lag <= cluster.MaxPrio {
+						// resetting GOGC back to default
+						log.Infof("kafkamdm: lag is %d <= %d - good, setting GOGC to %d", lag, cluster.MaxPrio, NormalGCPercent)
+						debug.SetGCPercent(NormalGCPercent)
+					} else {
+						// we're probably starting
+						log.Infof("kafkamdm: lag is %d > %d, too big, setting GOGC to %d", lag, cluster.MaxPrio, StartupGCPercent)
+						debug.SetGCPercent(StartupGCPercent)
+					}
+				}
 			}
 		}
 	}()

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -249,6 +249,10 @@ consumer-max-wait-time = 1s
 consumer-max-processing-time = 1s
 # How many outstanding requests a connection is allowed to have before sending on it blocks
 net-max-open-requests = 100
+# GOGC value during node startup (lag > maxPrio), default sets in runtime using GOGC env. variable
+#gogc-startup = 100
+# GOGC value during normal run (lag <= maxPrio), default sets in runtime using GOGC env. variable
+#gogc-ready = 100
 
 ## basic clustering settings ##
 [cluster]


### PR DESCRIPTION
Rationale:
when using Kafka input during startup of the node and initial backfill consumption I noticed 50-100% more memory consumption than during normal work.
I tried to mitigate that using GOGC environment variable - but then I found out that it obviously aggressive GOGC affecting rendering performance - and that increased GC pressure is not needed anymore because memory consumption is already lowered.
So, I implemented GOGC control through config file - `gogc-startup` variable in `[kafka-mdm-in]` section controls GOGC for program startup, `gogc-ready` - for normal work.
I also implemented HTTP API for changing these vars, but that part is probably optional.