### PR TITLE
Retention ready timestamp

### DIFF
--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -24,7 +24,7 @@ func newSrv(delSeries, delArchives int) (*Server, *cache.MockCache) {
 	srv.RegisterRoutes()
 
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
-	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, true))
+	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, 0))
 
 	store := mdata.NewMockStore()
 	store.Drop = true

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -344,7 +344,7 @@ func TestGetSeriesFixed(t *testing.T) {
 	store.Drop = true
 
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
-	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, true))
+	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, 0))
 
 	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0)
 	srv, _ := NewServer()

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -63,7 +63,7 @@ func alignRequests(now, from, to uint32, reqs []models.Req) ([]models.Req, uint3
 		retentions := mdata.Schemas.Get(req.SchemaId).Retentions
 		for i, ret := range retentions {
 			// skip non-ready option.
-			if !ret.Ready {
+			if ret.Ready > from {
 				continue
 			}
 			req.Archive = i
@@ -119,7 +119,7 @@ func alignRequests(now, from, to uint32, reqs []models.Req) ([]models.Req, uint3
 			retentions := mdata.Schemas.Get(req.SchemaId).Retentions
 			for i, ret := range retentions[req.Archive+1:] {
 				archInterval := uint32(ret.SecondsPerPoint)
-				if interval == archInterval && ret.Ready {
+				if interval == archInterval && ret.Ready <= from {
 					// we're in luck. this will be more efficient than runtime consolidation
 					req.Archive = req.Archive + 1 + i
 					req.ArchInterval = archInterval

--- a/api/query_engine_test.go
+++ b/api/query_engine_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"math"
 	"regexp"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestAlignRequestsBasic(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(60, 1200, 0, 0, true),
+				conf.NewRetentionMT(60, 1200, 0, 0, 0),
 			},
 		},
 		[]models.Req{
@@ -75,10 +76,10 @@ func TestAlignRequestsBasicDiff(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(60, 1200, 0, 0, true),
+				conf.NewRetentionMT(60, 1200, 0, 0, 0),
 			},
 			{
-				conf.NewRetentionMT(60, 1200, 0, 0, true),
+				conf.NewRetentionMT(60, 1200, 0, 0, 0),
 			},
 		},
 		[]models.Req{
@@ -99,9 +100,9 @@ func TestAlignRequestsAlerting(t *testing.T) {
 		reqRaw(test.GetMKey(2), 0, 30, 800, 60, consolidation.Avg, 1, 0),
 	},
 		[][]conf.Retention{{
-			conf.NewRetentionMT(10, 1200, 0, 0, true),
+			conf.NewRetentionMT(10, 1200, 0, 0, 0),
 		}, {
-			conf.NewRetentionMT(60, 1200, 0, 0, true),
+			conf.NewRetentionMT(60, 1200, 0, 0, 0),
 		},
 		},
 		[]models.Req{
@@ -122,9 +123,9 @@ func TestAlignRequestsBasicBestEffort(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 800, 0, 0, true),
+				conf.NewRetentionMT(10, 800, 0, 0, 0),
 			}, {
-				conf.NewRetentionMT(60, 1100, 0, 0, true),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0),
 			},
 		},
 		[]models.Req{
@@ -145,8 +146,8 @@ func TestAlignRequestsMultipleIntervalsPerSchema(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(1, 800, 0, 0, true),
-				conf.NewRetentionMT(60, 1100, 0, 0, true),
+				conf.NewRetentionMT(1, 800, 0, 0, 0),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0),
 			},
 		},
 		[]models.Req{
@@ -167,8 +168,8 @@ func TestAlignRequestsMultiIntervalsWithRuntimeConsolidation(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 800, 0, 0, true),
-				conf.NewRetentionMT(60, 1200, 0, 0, true),
+				conf.NewRetentionMT(10, 800, 0, 0, 0),
+				conf.NewRetentionMT(60, 1200, 0, 0, 0),
 			},
 		},
 		[]models.Req{
@@ -189,10 +190,10 @@ func TestAlignRequestsHalfGood(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 800, 0, 0, true),
+				conf.NewRetentionMT(10, 800, 0, 0, 0),
 			}, {
-				conf.NewRetentionMT(60, 1100, 0, 0, true),
-				conf.NewRetentionMT(120, 1200, 0, 0, true),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0),
+				conf.NewRetentionMT(120, 1200, 0, 0, 0),
 			},
 		},
 		[]models.Req{
@@ -213,12 +214,12 @@ func TestAlignRequestsGoodRollup(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 1199, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(120, 1200, 600, 2, true),
+				conf.NewRetentionMT(10, 1199, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(120, 1200, 600, 2, 0),
 			},
 			{
-				conf.NewRetentionMT(60, 1199, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(120, 1200, 600, 2, true),
+				conf.NewRetentionMT(60, 1199, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(120, 1200, 600, 2, 0),
 			},
 		},
 		[]models.Req{
@@ -239,12 +240,12 @@ func TestAlignRequestsDiffGoodRollup(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 1199, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(100, 1200, 600, 2, true),
+				conf.NewRetentionMT(10, 1199, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(100, 1200, 600, 2, 0),
 			},
 			{
-				conf.NewRetentionMT(60, 1199, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(600, 1200, 600, 2, true),
+				conf.NewRetentionMT(60, 1199, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(600, 1200, 600, 2, 0),
 			},
 		},
 		[]models.Req{
@@ -265,11 +266,11 @@ func TestAlignRequestsWeird(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 1199, 0, 0, true),
-				conf.NewRetentionMT(60, 1200, 600, 2, true),
+				conf.NewRetentionMT(10, 1199, 0, 0, 0),
+				conf.NewRetentionMT(60, 1200, 600, 2, 0),
 			},
 			{
-				conf.NewRetentionMT(60, 1200, 0, 0, true),
+				conf.NewRetentionMT(60, 1200, 0, 0, 0),
 			},
 		},
 		[]models.Req{
@@ -290,12 +291,12 @@ func TestAlignRequestsWeird2(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 1100, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(120, 1200, 600, 2, true),
+				conf.NewRetentionMT(10, 1100, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(120, 1200, 600, 2, 0),
 			},
 			{
-				conf.NewRetentionMT(60, 1100, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(120, 1200, 600, 2, true),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(120, 1200, 600, 2, 0),
 			},
 		},
 		[]models.Req{
@@ -316,12 +317,12 @@ func TestAlignRequestsNoOtherChoice(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 1100, 0, 0, true),
-				conf.NewRetentionMT(120, 1199, 600, 2, true),
+				conf.NewRetentionMT(10, 1100, 0, 0, 0),
+				conf.NewRetentionMT(120, 1199, 600, 2, 0),
 			},
 			{
-				conf.NewRetentionMT(60, 1100, 0, 0, true),
-				conf.NewRetentionMT(120, 1199, 600, 2, true),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0),
+				conf.NewRetentionMT(120, 1199, 600, 2, 0),
 			},
 		},
 		[]models.Req{
@@ -342,13 +343,13 @@ func TestAlignRequests3rdBand(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(1, 1100, 0, 0, true),
-				conf.NewRetentionMT(120, 1199, 600, 2, true),
-				conf.NewRetentionMT(240, 1200, 600, 2, true),
+				conf.NewRetentionMT(1, 1100, 0, 0, 0),
+				conf.NewRetentionMT(120, 1199, 600, 2, 0),
+				conf.NewRetentionMT(240, 1200, 600, 2, 0),
 			},
 			{
-				conf.NewRetentionMT(60, 1100, 0, 0, true),
-				conf.NewRetentionMT(240, 1200, 600, 2, true),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0),
+				conf.NewRetentionMT(240, 1200, 600, 2, 0),
 			},
 		},
 		[]models.Req{
@@ -369,13 +370,13 @@ func TestAlignRequests2RollupsDisabled(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(10, 1100, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(120, 1199, 600, 2, false),
-				conf.NewRetentionMT(240, 1200, 600, 2, false),
+				conf.NewRetentionMT(10, 1100, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(120, 1199, 600, 2, math.MaxUint32),
+				conf.NewRetentionMT(240, 1200, 600, 2, math.MaxUint32),
 			},
 			{
-				conf.NewRetentionMT(60, 1100, 0, 0, true), // just not long enough
-				conf.NewRetentionMT(240, 1200, 600, 2, false),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0), // just not long enough
+				conf.NewRetentionMT(240, 1200, 600, 2, math.MaxUint32),
 			},
 		},
 		[]models.Req{
@@ -394,13 +395,13 @@ func TestAlignRequestsHuh(t *testing.T) {
 	},
 		[][]conf.Retention{
 			{
-				conf.NewRetentionMT(1, 1000, 0, 0, true),
-				conf.NewRetentionMT(120, 1080, 600, 2, true),
-				conf.NewRetentionMT(240, 1200, 600, 2, false),
+				conf.NewRetentionMT(1, 1000, 0, 0, 0),
+				conf.NewRetentionMT(120, 1080, 600, 2, 0),
+				conf.NewRetentionMT(240, 1200, 600, 2, math.MaxUint32),
 			},
 			{
-				conf.NewRetentionMT(60, 1100, 0, 0, true),
-				conf.NewRetentionMT(240, 1200, 600, 2, false),
+				conf.NewRetentionMT(60, 1100, 0, 0, 0),
+				conf.NewRetentionMT(240, 1200, 600, 2, math.MaxUint32),
 			},
 		},
 		[]models.Req{
@@ -425,9 +426,9 @@ func testMaxPointsPerReq(maxPointsSoft, maxPointsHard int, reqs []models.Req, t 
 	mdata.Schemas = conf.NewSchemas([]conf.Schema{{
 		Pattern: regexp.MustCompile(".*"),
 		Retentions: conf.Retentions([]conf.Retention{
-			conf.NewRetentionMT(1, 2*day, 600, 2, true),
-			conf.NewRetentionMT(60, 7*day, 600, 2, true),
-			conf.NewRetentionMT(3600, 30*day, 600, 2, true),
+			conf.NewRetentionMT(1, 2*day, 600, 2, 0),
+			conf.NewRetentionMT(60, 7*day, 600, 2, 0),
+			conf.NewRetentionMT(3600, 30*day, 600, 2, 0),
 		}),
 	}})
 
@@ -495,30 +496,30 @@ func BenchmarkAlignRequests(b *testing.B) {
 			Pattern: regexp.MustCompile("a"),
 			Retentions: conf.Retentions(
 				[]conf.Retention{
-					conf.NewRetentionMT(10, 35*24*3600, 0, 0, true),
-					conf.NewRetentionMT(600, 60*24*3600, 0, 0, true),
-					conf.NewRetentionMT(7200, 180*24*3600, 0, 0, true),
-					conf.NewRetentionMT(21600, 2*365*24*3600, 0, 0, true),
+					conf.NewRetentionMT(10, 35*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(600, 60*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(7200, 180*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(21600, 2*365*24*3600, 0, 0, 0),
 				}),
 		},
 		{
 			Pattern: regexp.MustCompile("b"),
 			Retentions: conf.Retentions(
 				[]conf.Retention{
-					conf.NewRetentionMT(30, 35*24*3600, 0, 0, true),
-					conf.NewRetentionMT(600, 60*24*3600, 0, 0, true),
-					conf.NewRetentionMT(7200, 180*24*3600, 0, 0, true),
-					conf.NewRetentionMT(21600, 2*365*24*3600, 0, 0, true),
+					conf.NewRetentionMT(30, 35*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(600, 60*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(7200, 180*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(21600, 2*365*24*3600, 0, 0, 0),
 				}),
 		},
 		{
 			Pattern: regexp.MustCompile(".*"),
 			Retentions: conf.Retentions(
 				[]conf.Retention{
-					conf.NewRetentionMT(60, 35*24*3600, 0, 0, true),
-					conf.NewRetentionMT(600, 60*24*3600, 0, 0, true),
-					conf.NewRetentionMT(7200, 180*24*3600, 0, 0, true),
-					conf.NewRetentionMT(21600, 2*365*24*3600, 0, 0, true),
+					conf.NewRetentionMT(60, 35*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(600, 60*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(7200, 180*24*3600, 0, 0, 0),
+					conf.NewRetentionMT(21600, 2*365*24*3600, 0, 0, 0),
 				}),
 		},
 	})

--- a/api/query_engine_test.go
+++ b/api/query_engine_test.go
@@ -414,6 +414,28 @@ func TestAlignRequestsHuh(t *testing.T) {
 	)
 }
 
+func TestAlignRequestsDifferentReadyStates(t *testing.T) {
+	testAlign([]models.Req{
+		reqRaw(test.GetMKey(1), 100, 300, 800, 1, consolidation.Avg, 0, 0),
+	},
+		[][]conf.Retention{
+			{
+				conf.NewRetentionMT(1, 300, 120, 5, 0),              // TTL not good enough
+				conf.NewRetentionMT(5, 450, 600, 4, math.MaxUint32), // TTL good, but not ready
+				conf.NewRetentionMT(10, 460, 600, 3, 150),           // TTL good, but not ready since long enough
+				conf.NewRetentionMT(20, 470, 600, 2, 101),           // TTL good, but not ready since long enough
+				conf.NewRetentionMT(60, 480, 600, 1, 100),           // TTL good and ready since long enough
+			},
+		},
+		[]models.Req{
+			reqOut(test.GetMKey(1), 100, 300, 800, 1, consolidation.Avg, 0, 0, 4, 60, 480, 60, 1),
+		},
+		nil,
+		500,
+		t,
+	)
+}
+
 var hour uint32 = 60 * 60
 var day uint32 = 24 * hour
 

--- a/cmd/mt-schemas-explain/main.go
+++ b/cmd/mt-schemas-explain/main.go
@@ -88,7 +88,7 @@ func display(schema conf.Schema) {
 		}
 		chunkSpanStr := time.Duration(time.Duration(ret.ChunkSpan) * time.Second).String()
 		windowSizeStr := time.Duration(time.Duration(table.WindowSize) * time.Hour).String()
-		fmt.Printf("           %10d %10s %10s %10d %10t %15s %10s\n", ret.SecondsPerPoint, retStr, chunkSpanStr, ret.NumChunks, ret.Ready, table.Name, windowSizeStr)
+		fmt.Printf("           %10d %10s %10s %10d %12d %15s %10s\n", ret.SecondsPerPoint, retStr, chunkSpanStr, ret.NumChunks, ret.Ready, table.Name, windowSizeStr)
 	}
 	fmt.Println()
 }

--- a/conf/retention.go
+++ b/conf/retention.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -13,6 +14,8 @@ import (
 )
 
 const Month_sec = 60 * 60 * 24 * 28
+
+var errReadyFormat = errors.New("'ready' field must be a bool or unsigned integer")
 
 type Retentions []Retention
 
@@ -61,7 +64,7 @@ type Retention struct {
 	NumberOfPoints  int    // ~ttl
 	ChunkSpan       uint32 // duration of chunk of aggregated metric for storage, controls how many aggregated points go into 1 chunk
 	NumChunks       uint32 // number of chunks to keep in memory. remember, for a query from now until 3 months ago, we will end up querying the memory server as well.
-	Ready           bool   // ready for reads?
+	Ready           uint32 // ready for reads for data as of this timestamp (or as of now-TTL, whichever is highest)
 }
 
 func (r Retention) MaxRetention() int {
@@ -75,7 +78,7 @@ func NewRetention(secondsPerPoint, numberOfPoints int) Retention {
 	}
 }
 
-func NewRetentionMT(secondsPerPoint int, ttl, chunkSpan, numChunks uint32, ready bool) Retention {
+func NewRetentionMT(secondsPerPoint int, ttl, chunkSpan, numChunks, ready uint32) Retention {
 	return Retention{
 		SecondsPerPoint: secondsPerPoint,
 		NumberOfPoints:  int(ttl) / secondsPerPoint,
@@ -145,11 +148,20 @@ func ParseRetentions(defs string) (Retentions, error) {
 			}
 			retention.NumChunks = uint32(i)
 		}
-		retention.Ready = true
 		if len(parts) == 5 {
-			retention.Ready, err = strconv.ParseBool(parts[4])
-			if err != nil {
-				return nil, err
+			// 0 (default) is effectively the same as 'true'
+			// math.MaxUint32 is effectively the same as 'false'
+			readyInt, err := strconv.ParseUint(parts[4], 10, 32)
+			if err == nil {
+				retention.Ready = uint32(readyInt)
+			} else {
+				readyBool, err := strconv.ParseBool(parts[4])
+				if err != nil {
+					return nil, errReadyFormat
+				}
+				if !readyBool {
+					retention.Ready = math.MaxUint32
+				}
 			}
 		}
 

--- a/conf/retention.go
+++ b/conf/retention.go
@@ -149,6 +149,8 @@ func ParseRetentions(defs string) (Retentions, error) {
 			retention.NumChunks = uint32(i)
 		}
 		if len(parts) == 5 {
+			// user is allowed to specify both a bool or a timestamp.
+			// internally we map both to timestamp.
 			// 0 (default) is effectively the same as 'true'
 			// math.MaxUint32 is effectively the same as 'false'
 			readyInt, err := strconv.ParseUint(parts[4], 10, 32)

--- a/conf/retention_test.go
+++ b/conf/retention_test.go
@@ -1,0 +1,62 @@
+package conf
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestParseRetentions(t *testing.T) {
+	cases := []struct {
+		in  string
+		err bool
+		out []Retention
+	}{
+		{
+			in:  "1s:1d:1h:2,1m:8d:4h:2:1234567890,10m:120d:6h:1:true,30m:2y:6h:1:false",
+			err: false,
+			out: []Retention{
+				{
+					SecondsPerPoint: 1,
+					NumberOfPoints:  24 * 3600,
+					ChunkSpan:       60 * 60,
+					NumChunks:       2,
+					Ready:           0,
+				},
+				{
+					SecondsPerPoint: 60,
+					NumberOfPoints:  8 * 24 * 3600 / 60,
+					ChunkSpan:       4 * 60 * 60,
+					NumChunks:       2,
+					Ready:           1234567890,
+				},
+				{
+					SecondsPerPoint: 600,
+					NumberOfPoints:  120 * 24 * 3600 / 600,
+					ChunkSpan:       6 * 60 * 60,
+					NumChunks:       1,
+					Ready:           0,
+				},
+				{
+					SecondsPerPoint: 30 * 60,
+					NumberOfPoints:  2 * 365 * 24 * 3600 / (30 * 60),
+					ChunkSpan:       6 * 60 * 60,
+					NumChunks:       1,
+					Ready:           math.MaxUint32,
+				},
+			},
+		},
+	}
+	for i, c := range cases {
+		got, err := ParseRetentions(c.in)
+		if (err != nil) != c.err {
+			t.Fatalf("case %d: exp error %t but got err %v", i, c.err, err)
+		}
+		if c.err {
+			continue
+		}
+		if !reflect.DeepEqual(Retentions(c.out), got) {
+			t.Fatalf("case %d: exp retentions\n%v\nbut got\n%v", i, c.out, got)
+		}
+	}
+}

--- a/conf/schemas.go
+++ b/conf/schemas.go
@@ -39,7 +39,7 @@ func NewSchemas(schemas []Schema) Schemas {
 		DefaultSchema: Schema{
 			Name:       "default",
 			Pattern:    regexp.MustCompile(".*"),
-			Retentions: Retentions([]Retention{NewRetentionMT(1, 3600*24*1, 600, 2, true)}), // 1s:1day:10mim:2:true
+			Retentions: Retentions([]Retention{NewRetentionMT(1, 3600*24*1, 600, 2, 0)}), // 1s:1day:10mim:2:true
 		},
 	}
 	s.BuildIndex()

--- a/conf/schemas_test.go
+++ b/conf/schemas_test.go
@@ -12,27 +12,27 @@ func schemasForTest() Schemas {
 			Name:    "a",
 			Pattern: regexp.MustCompile("^a\\..*"),
 			Retentions: []Retention{
-				NewRetentionMT(10, 3600, 60*10, 0, true),
-				NewRetentionMT(3600, 86400, 60*60*6, 0, true),
+				NewRetentionMT(10, 3600, 60*10, 0, 0),
+				NewRetentionMT(3600, 86400, 60*60*6, 0, 0),
 			},
 		},
 		{
 			Name:    "b",
 			Pattern: regexp.MustCompile("^b\\..*"),
 			Retentions: []Retention{
-				NewRetentionMT(1, 60, 60*10, 0, true),
-				NewRetentionMT(30, 120, 60*30, 0, true),
-				NewRetentionMT(600, 86400, 60*60*6, 0, true),
+				NewRetentionMT(1, 60, 60*10, 0, 0),
+				NewRetentionMT(30, 120, 60*30, 0, 0),
+				NewRetentionMT(600, 86400, 60*60*6, 0, 0),
 			},
 		},
 		{
 			Name:    "default",
 			Pattern: regexp.MustCompile(".*"),
 			Retentions: []Retention{
-				NewRetentionMT(1, 60, 60*10, 0, true),
-				NewRetentionMT(60, 3600, 60*60*2, 0, true),
-				NewRetentionMT(600, 86400, 60*60*6, 0, true),
-				NewRetentionMT(3600, 86400*7, 60*60*6, 0, true),
+				NewRetentionMT(1, 60, 60*10, 0, 0),
+				NewRetentionMT(60, 3600, 60*60*2, 0, 0),
+				NewRetentionMT(600, 86400, 60*60*6, 0, 0),
+				NewRetentionMT(3600, 86400*7, 60*60*6, 0, 0),
 			},
 		},
 	})
@@ -126,8 +126,8 @@ func TestDefaultSchema(t *testing.T) {
 			Name:    "a",
 			Pattern: regexp.MustCompile("^a\\..*"),
 			Retentions: []Retention{
-				NewRetentionMT(10, 3600, 60*10, 0, true),
-				NewRetentionMT(3600, 86400, 60*60*6, 0, true),
+				NewRetentionMT(10, 3600, 60*10, 0, 0),
+				NewRetentionMT(3600, 86400, 60*60*6, 0, 0),
 			},
 		},
 	})

--- a/docs/config.md
+++ b/docs/config.md
@@ -567,8 +567,11 @@ aggregationMethod = avg,min,max
 # which may be a more effective method to cache data and alleviate workload for cassandra.
 # Defaults to 2
 #
-# ready: whether the archive is ready for querying.  This is useful if you recently introduced a new archive, but it's still being populated
-# so you rather query other archives, even if they don't have the retention to serve your queries
+# ready: whether, or as of what data timestamp, the archive is ready for querying.
+# This is useful if you recently introduced a new archive, but it's still being populated, so doesn't have the data metrictank might otherwise think there is
+# It supports to syntaxes:
+# * unix timestamp: the archive can be used for data as of this timestamp
+# * boolean: (legacy): whether or not the archive is completely ready or not ready at all.
 # Defaults to true
 #
 # Here's an example with multiple retentions:

--- a/docs/config.md
+++ b/docs/config.md
@@ -569,7 +569,7 @@ aggregationMethod = avg,min,max
 #
 # ready: whether, or as of what data timestamp, the archive is ready for querying.
 # This is useful if you recently introduced a new archive, but it's still being populated, so doesn't have the data metrictank might otherwise think there is
-# It supports to syntaxes:
+# It supports two syntaxes:
 # * unix timestamp: the archive can be used for data as of this timestamp
 # * boolean: (legacy): whether or not the archive is completely ready or not ready at all.
 # Defaults to true

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -991,7 +991,7 @@ func TestMatchSchemaWithTags(t *testing.T) {
 		{
 			Name:       "tag1_is_value3_or_value5",
 			Pattern:    regexp.MustCompile(".*;tag1=value[35](;.*|$)"),
-			Retentions: conf.Retentions([]conf.Retention{conf.NewRetentionMT(1, 3600*24*1, 600, 2, true)}),
+			Retentions: conf.Retentions([]conf.Retention{conf.NewRetentionMT(1, 3600*24*1, 600, 2, 0)}),
 		},
 	})
 

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -19,7 +19,7 @@ func BenchmarkProcessMetricDataUniqueMetrics(b *testing.B) {
 
 	store := backendStore.NewDevnullStore()
 
-	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, true))
+	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, 0))
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 
 	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 800, 8000, 0)
@@ -56,7 +56,7 @@ func BenchmarkProcessMetricDataSameMetric(b *testing.B) {
 
 	store := backendStore.NewDevnullStore()
 
-	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, true))
+	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, 0))
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 
 	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 800, 8000, 0)

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -127,7 +127,7 @@ func testMetricPersistOptionalPrimary(t *testing.T, primary bool) {
 	mockCache.AddIfHotCb = func() { calledCb <- true }
 
 	numChunks, chunkAddCount, chunkSpan := uint32(5), uint32(10), uint32(300)
-	ret := []conf.Retention{conf.NewRetentionMT(1, 1, chunkSpan, numChunks, true)}
+	ret := []conf.Retention{conf.NewRetentionMT(1, 1, chunkSpan, numChunks, 0)}
 	agg := NewAggMetric(mockstore, &mockCache, test.GetAMKey(42), ret, 0, nil, false)
 
 	for ts := chunkSpan; ts <= chunkSpan*chunkAddCount; ts += chunkSpan {
@@ -163,7 +163,7 @@ func testMetricPersistOptionalPrimary(t *testing.T, primary bool) {
 func TestAggMetric(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 
-	ret := []conf.Retention{conf.NewRetentionMT(1, 1, 120, 5, true)}
+	ret := []conf.Retention{conf.NewRetentionMT(1, 1, 120, 5, 0)}
 	c := NewChecker(t, NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, nil, false))
 
 	// chunk t0's: 120, 240, 360, 480, 600, 720, 840, 960
@@ -241,7 +241,7 @@ func TestAggMetricWithReorderBuffer(t *testing.T) {
 		XFilesFactor:      0.5,
 		AggregationMethod: []conf.Method{conf.Avg},
 	}
-	ret := []conf.Retention{conf.NewRetentionMT(1, 1, 120, 5, true)}
+	ret := []conf.Retention{conf.NewRetentionMT(1, 1, 120, 5, 0)}
 	c := NewChecker(t, NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 10, &agg, false))
 
 	// basic adds and verifies with test data
@@ -281,7 +281,7 @@ func TestAggMetricDropFirstChunk(t *testing.T) {
 	mockstore.Reset()
 	chunkSpan := uint32(10)
 	numChunks := uint32(5)
-	ret := []conf.Retention{conf.NewRetentionMT(1, 1, chunkSpan, numChunks, true)}
+	ret := []conf.Retention{conf.NewRetentionMT(1, 1, chunkSpan, numChunks, 0)}
 	m := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, nil, true)
 	m.Add(10, 10)
 	m.Add(11, 11)
@@ -317,7 +317,7 @@ func BenchmarkAggMetricAdd(b *testing.B) {
 			NumberOfPoints:  10e9, // TTL
 			ChunkSpan:       1800, // 30 min. contains 180 points at 10s resolution
 			NumChunks:       1,
-			Ready:           true,
+			Ready:           0,
 		},
 	}
 

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -71,7 +71,7 @@ func TestAggregator(t *testing.T) {
 		}
 		cluster.Manager.SetPrimary(false)
 	}
-	ret := conf.NewRetentionMT(60, 86400, 120, 10, true)
+	ret := conf.NewRetentionMT(60, 86400, 120, 10, 0)
 	aggs := conf.Aggregation{
 		AggregationMethod: []conf.Method{conf.Avg, conf.Min, conf.Max, conf.Sum, conf.Lst},
 	}

--- a/scripts/config/storage-schemas.conf
+++ b/scripts/config/storage-schemas.conf
@@ -40,7 +40,7 @@
 #
 # ready: whether, or as of what data timestamp, the archive is ready for querying.
 # This is useful if you recently introduced a new archive, but it's still being populated, so doesn't have the data metrictank might otherwise think there is
-# It supports to syntaxes:
+# It supports two syntaxes:
 # * unix timestamp: the archive can be used for data as of this timestamp
 # * boolean: (legacy): whether or not the archive is completely ready or not ready at all.
 # Defaults to true

--- a/scripts/config/storage-schemas.conf
+++ b/scripts/config/storage-schemas.conf
@@ -38,8 +38,11 @@
 # which may be a more effective method to cache data and alleviate workload for cassandra.
 # Defaults to 2
 #
-# ready: whether the archive is ready for querying.  This is useful if you recently introduced a new archive, but it's still being populated
-# so you rather query other archives, even if they don't have the retention to serve your queries
+# ready: whether, or as of what data timestamp, the archive is ready for querying.
+# This is useful if you recently introduced a new archive, but it's still being populated, so doesn't have the data metrictank might otherwise think there is
+# It supports to syntaxes:
+# * unix timestamp: the archive can be used for data as of this timestamp
+# * boolean: (legacy): whether or not the archive is completely ready or not ready at all.
 # Defaults to true
 #
 # Here's an example with multiple retentions:


### PR DESCRIPTION
allow retention 'ready' to be a unix timestamp.
this helps in situations where an archive for example has TTL of 2 months, but only 1 month worth of data.
previously we could only control whether the archive was used (for all of the 2 months window) or not.
now we can control to only use it for requests that need data more recent than 1 month.