### PR TITLE
fix building of el7 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 * correctly return error from NewCassandraStore() #1111
 * clean way of skipping expensive and integration tests. #1155, #1156
 * fix duration vars processing and error handling in cass idx #1141
-* update release process, tagging, repo layout and version formatting. update to go1.11.4 #1177, #1180
+* update release process, tagging, repo layout and version formatting. update to go1.11.4 #1177, #1180, #1181
 
 # v0.10.1. performance fix: pruning effect on latency, go 1.11, etc.  Sep 24, 2018
 

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -128,7 +128,8 @@ cp ${BUILD_ROOT}/{metrictank,mt-*} ${BUILD}/usr/bin/
 
 PACKAGE_NAME="${PKG}/metrictank-${version_raw}.el7.${ARCH}.rpm"
 fpm -s dir -t rpm \
-  -v ${version_raw} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \ --config-files /etc/metrictank/ \
+  -v ${version_raw} -n metrictank -a ${ARCH} --description "metrictank, the gorilla-inspired timeseries database backend for graphite" \
+  --config-files /etc/metrictank/ \
   -m "Raintank Inc. <hello@grafana.com>" --vendor "grafana.com" \
   --license "Apache2.0" -C ${BUILD} -p ${PACKAGE_NAME} .
 


### PR DESCRIPTION
as of #1177, would error like:
```
+ fpm -s dir -t rpm -v 0.10.1-340-g0cabc13 -n metrictank -a x86_64 --description 'metrictank, the gorilla-inspired timeseries database backend for graphite' ' --config-files' /etc/metrictank/ -m 'Raintank Inc. <hello@grafana.com>' --vendor grafana.com --license Apache2.0 -C /home/circleci/project/build_tmp/systemd-centos7 -p /home/circleci/project/build_pkg/systemd-centos7/metrictank-0.10.1-340-g0cabc13.el7.x86_64.rpm .
All flags should be before the first argument (stray flags found: ["-m", "--vendor", "--license", "-C", "-p"] {:level=>:warn}
Invalid package configuration: Cannot package the path './ --config-files', does it exist? {:level=>:error}
```