### PR TITLE
re-enable metrics2docs + simplify code a bit

### DIFF
--- a/scripts/dev/sync-configs.sh
+++ b/scripts/dev/sync-configs.sh
@@ -17,4 +17,5 @@ done
 echo "updating docs/config.md"
 ./scripts/dev/config-to-doc.sh > docs/config.md
 
-# metrics2docs .> docs/metrics.md this doesn't work very well yet
+go get github.com/Dieterbe/metrics2docs
+metrics2docs . > docs/metrics.md

--- a/scripts/qa/docs.sh
+++ b/scripts/qa/docs.sh
@@ -13,12 +13,10 @@ if [ ! -r docs/tools.md ]; then
 	exit 2
 fi
 scripts/dev/tools-to-doc.sh > $tmp
-diff docs/tools.md $tmp
-ret=$?
-rm $tmp
-if [ $ret -gt 0 ]; then
+if ! diff docs/tools.md $tmp; then
   echo "docs/tools.md does not match output of scripts/dev/tools-to-doc.sh"
-  exit $ret
+  rm $tmp
+  exit 2
 fi
 
 echo "checking configs"
@@ -27,12 +25,19 @@ if [ ! -r docs/config.md ]; then
 	exit 2
 fi
 scripts/dev/config-to-doc.sh > $tmp
-diff docs/config.md $tmp
+if ! diff docs/config.md $tmp; then
+  echo "docs/config.md does not match output of scripts/dev/config-to-doc.sh"
+  rm $tmp
+  exit 2
+fi
+
+echo "checking metrics.md"
+go get github.com/Dieterbe/metrics2docs
+metrics2docs . > $tmp
+diff docs/metrics.md $tmp
 ret=$?
 rm $tmp
 if [ $ret -gt 0 ]; then
-  echo "docs/config.md does not match output of scripts/dev/config-to-doc.sh"
+  echo "docs/metrics.md does not match output of docs2metrics"
 fi
 exit $ret
-
-# metrics2docs .> docs/metrics.md this doesn't work very well yet


### PR DESCRIPTION
apparently metrics2docs works fine again. not sure why. maybe cause we no longer intantiate metrics using the type of more dynamic code it used to struggle with.