### PR TITLE
Cleanup Aggmetric

### DIFF
--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -32,7 +32,7 @@ type AggMetric struct {
 	sync.RWMutex
 	Key             schema.AMKey
 	rob             *ReorderBuffer
-	CurrentChunkPos int    // element in []Chunks that is active. All others are either finished or nil.
+	CurrentChunkPos int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(Chunks) > 0, e.g. when data has been written (excl ROB data)
 	NumChunks       uint32 // max size of the circular buffer
 	ChunkSpan       uint32 // span of individual chunks in seconds
 	Chunks          []*chunk.Chunk


### PR DESCRIPTION
it looks like much is going on here, but if you look at the individual commits you'll see most of the diff is simple renames.

the more interesting, and potentially contentious part is the removal of some safety measures.
I would argue we don't need to re-invent out-ouf-bounds checking, and much of this are relics from when all this code was more fresh and less trusted.
a valid critique of this change could be that you need a deeper understanding of the code to assert correct function through reasoning, and perhaps the old version was more friendly to casual readers. but i'm not sure to which extent this is true. For most of our other code, we don't have these kinds of safety measures either because we feel confident enough. Note that the `getChunk` call would panic anyway, just with a nicer message, so it never bought us much.

what do you think?
i rather aim to remove cruft and make the more simpler and more obvious. i was thinking perhaps we could even isolate out the ringbuffer-of-chunks into a separate type, which would be embedded by AggMetric.  but that wouldn't buy us anything, I think.