### PR TITLE
Dynamic GOGC based on ready state

### DIFF
--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -407,8 +407,7 @@ func (c *MemberlistManager) SetPartitions(part []int32) {
 	sort.Slice(part, func(i, j int) bool { return part[i] < part[j] })
 	c.Lock()
 	node := c.members[c.nodeName]
-	node.Partitions = part
-	node.Updated = time.Now()
+	node.SetPartitions(part)
 	c.members[c.nodeName] = node
 	c.Unlock()
 	nodePartitions.Set(len(part))
@@ -511,9 +510,8 @@ func (m *SingleNodeManager) Join(peers []string) (int, error) {
 func (m *SingleNodeManager) SetPartitions(part []int32) {
 	sort.Slice(part, func(i, j int) bool { return part[i] < part[j] })
 	m.Lock()
-	defer m.Unlock()
-	m.node.Partitions = part
-	m.node.Updated = time.Now()
+	m.node.SetPartitions(part)
+	m.Unlock()
 	nodePartitions.Set(len(part))
 }
 

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -370,14 +370,11 @@ func (c *MemberlistManager) SetReady() {
 // Set the state of this node.
 func (c *MemberlistManager) SetState(state NodeState) {
 	c.Lock()
-	if c.members[c.nodeName].State == state {
+	node := c.members[c.nodeName]
+	if !node.SetState(state) {
 		c.Unlock()
 		return
 	}
-	node := c.members[c.nodeName]
-	node.State = state
-	node.Updated = time.Now()
-	node.StateChange = time.Now()
 	c.members[c.nodeName] = node
 	c.Unlock()
 	nodeReady.Set(state == NodeReady)
@@ -432,13 +429,11 @@ func (c *MemberlistManager) GetPartitions() []int32 {
 // lower values == higher priority
 func (c *MemberlistManager) SetPriority(prio int) {
 	c.Lock()
-	if c.members[c.nodeName].Priority == prio {
+	node := c.members[c.nodeName]
+	if !node.SetPriority(prio) {
 		c.Unlock()
 		return
 	}
-	node := c.members[c.nodeName]
-	node.Priority = prio
-	node.Updated = time.Now()
 	c.members[c.nodeName] = node
 	c.Unlock()
 	nodePriority.Set(prio)
@@ -494,12 +489,8 @@ func (m *SingleNodeManager) SetReady() {
 
 func (m *SingleNodeManager) SetState(state NodeState) {
 	m.Lock()
-	defer m.Unlock()
-	if m.node.State == state {
-		return
-	}
-	m.node.State = state
-	m.node.Updated = time.Now()
+	m.node.SetState(state)
+	m.Unlock()
 	nodeReady.Set(state == NodeReady)
 }
 
@@ -545,12 +536,8 @@ func (m *SingleNodeManager) GetPartitions() []int32 {
 // lower values == higher priority
 func (m *SingleNodeManager) SetPriority(prio int) {
 	m.Lock()
-	defer m.Unlock()
-	if m.node.Priority == prio {
-		return
-	}
-	m.node.Priority = prio
-	m.node.Updated = time.Now()
+	m.node.SetPriority(prio)
+	m.Unlock()
 	nodePriority.Set(prio)
 }
 

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -389,19 +389,16 @@ func (c *MemberlistManager) IsPrimary() bool {
 }
 
 // SetPrimary sets the primary status of this node
-func (c *MemberlistManager) SetPrimary(p bool) {
+func (c *MemberlistManager) SetPrimary(primary bool) {
 	c.Lock()
-	if c.members[c.nodeName].Primary == p {
+	node := c.members[c.nodeName]
+	if !node.SetPrimary(primary) {
 		c.Unlock()
 		return
 	}
-	node := c.members[c.nodeName]
-	node.Primary = p
-	node.PrimaryChange = time.Now()
-	node.Updated = time.Now()
 	c.members[c.nodeName] = node
 	c.Unlock()
-	nodePrimary.Set(p)
+	nodePrimary.Set(primary)
 	c.BroadcastUpdate()
 }
 
@@ -467,13 +464,8 @@ func (m *SingleNodeManager) IsPrimary() bool {
 
 func (m *SingleNodeManager) SetPrimary(primary bool) {
 	m.Lock()
-	defer m.Unlock()
-	if m.node.Primary == primary {
-		return
-	}
-	m.node.Primary = primary
-	m.node.PrimaryChange = time.Now()
-	m.node.Updated = time.Now()
+	m.node.SetPrimary(primary)
+	m.Unlock()
 	nodePrimary.Set(primary)
 }
 

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -149,6 +149,18 @@ func (n *HTTPNode) SetPriority(prio int) bool {
 	return true
 }
 
+// SetPrimary sets the primary state of the node and returns whether it changed
+func (n *HTTPNode) SetPrimary(primary bool) bool {
+	if n.Primary == primary {
+		return false
+	}
+	now := time.Now()
+	n.Primary = primary
+	n.Updated = now
+	n.PrimaryChange = now
+	return true
+}
+
 func (n HTTPNode) Post(ctx context.Context, name, path string, body Traceable) (ret []byte, err error) {
 	ctx, span := tracing.NewSpan(ctx, Tracer, name)
 	tags.SpanKindRPCClient.Set(span)

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -127,6 +127,28 @@ func (n HTTPNode) IsLocal() bool {
 	return n.local
 }
 
+// SetState sets the state of the node and returns whether the state changed
+func (n *HTTPNode) SetState(state NodeState) bool {
+	if n.State == state {
+		return false
+	}
+	n.State = state
+	now := time.Now()
+	n.Updated = now
+	n.StateChange = now
+	return true
+}
+
+// SetPriority sets the priority of the node and returns whether it changed
+func (n *HTTPNode) SetPriority(prio int) bool {
+	if n.Priority == prio {
+		return false
+	}
+	n.Priority = prio
+	n.Updated = time.Now()
+	return true
+}
+
 func (n HTTPNode) Post(ctx context.Context, name, path string, body Traceable) (ret []byte, err error) {
 	ctx, span := tracing.NewSpan(ctx, Tracer, name)
 	tags.SpanKindRPCClient.Set(span)

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -161,6 +161,12 @@ func (n *HTTPNode) SetPrimary(primary bool) bool {
 	return true
 }
 
+// SetPartitions sets the partitions that this node is handling
+func (n *HTTPNode) SetPartitions(part []int32) {
+	n.Partitions = part
+	n.Updated = time.Now()
+}
+
 func (n HTTPNode) Post(ctx context.Context, name, path string, body Traceable) (ret []byte, err error) {
 	ctx, span := tracing.NewSpan(ctx, Tracer, name)
 	tags.SpanKindRPCClient.Set(span)

--- a/dashboards/main/metrictank.json
+++ b/dashboards/main/metrictank.json
@@ -35,8 +35,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": null,
-  "iteration": 1535648268402,
+  "id": 21,
+  "iteration": 1547213827205,
   "links": [],
   "panels": [
     {
@@ -176,6 +176,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "metrics in",
       "tooltip": {
@@ -300,6 +301,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "ringbuffer: Metrics & points",
       "tooltip": {
@@ -419,6 +421,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "cluster status",
       "tooltip": {
@@ -499,6 +502,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "metrics active",
       "tooltip": {
@@ -838,6 +842,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "memory",
       "tooltip": {
@@ -894,7 +899,7 @@
       "fill": 0,
       "grid": {},
       "gridPos": {
-        "h": 4,
+        "h": 9,
         "w": 8,
         "x": 8,
         "y": 9
@@ -946,6 +951,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU",
       "tooltip": {
@@ -1065,6 +1071,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "render request duration (all steps)",
       "tooltip": {
@@ -1104,99 +1111,197 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "grid": {},
+      "collapsed": true,
       "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 13
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
       },
-      "id": 13,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": false,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 1,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [
+      "id": 52,
+      "panels": [
         {
-          "alias": "duration",
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 25
+          },
+          "id": 13,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
           "lines": false,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
           "pointradius": 1,
           "points": true,
-          "yaxis": 2
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "refId": "A",
-          "target": "alias(averageSeries(perSecond(metrictank.stats.$environment.$instance.memory.total_gc_cycles.counter64)), 'collections')"
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "duration",
+              "lines": false,
+              "pointradius": 1,
+              "points": true,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(averageSeries(perSecond(metrictank.stats.$environment.$instance.memory.total_gc_cycles.counter64)), 'collections')"
+            },
+            {
+              "refId": "B",
+              "target": "alias(averageSeries(metrictank.stats.$environment.$instance.memory.gc.last_duration.gauge64), 'duration')"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Golang GC",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "hertz",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "ns",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-          "refId": "B",
-          "target": "alias(averageSeries(metrictank.stats.$environment.$instance.memory.gc.last_duration.gauge64), 'duration')"
+          "aliasColors": {
+            "gogc": "#ba43a9"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "fill": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 25
+          },
+          "id": 54,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 3,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(metrictank.stats.$environment.$instance.memory.gc.gogc.sgauge32, 'gogc')"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "GOGC",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Golang GC",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "hertz",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "ns",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "runtime",
+      "type": "row"
     },
     {
       "collapsed": false,
@@ -1204,7 +1309,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 19
       },
       "id": 40,
       "panels": [],
@@ -1223,7 +1328,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 19
+        "y": 20
       },
       "id": 35,
       "legend": {
@@ -1263,6 +1368,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Series Per Request",
       "tooltip": {
@@ -1312,7 +1418,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 19
+        "y": 20
       },
       "id": 33,
       "legend": {
@@ -1364,6 +1470,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Points Per Request",
       "tooltip": {
@@ -1413,7 +1520,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 19
+        "y": 20
       },
       "id": 34,
       "legend": {
@@ -1449,6 +1556,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Response Status per path",
       "tooltip": {
@@ -1493,7 +1601,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 27
       },
       "id": 41,
       "panels": [],
@@ -1524,7 +1632,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 27
+        "y": 28
       },
       "id": 4,
       "legend": {
@@ -1592,6 +1700,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "requests span",
       "tooltip": {
@@ -1652,7 +1761,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 27
+        "y": 28
       },
       "id": 10,
       "legend": {
@@ -1690,6 +1799,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "series requests rate",
       "tooltip": {
@@ -1729,10 +1839,10 @@
     },
     {
       "aliasColors": {
+        "mem to iter": "#EAB839",
         "store get": "#052B51",
         "store get chunks": "#70DBED",
         "store to iter": "#1F78C1",
-        "mem to iter": "#EAB839",
         "total request handle": "#890F02"
       },
       "bars": false,
@@ -1747,7 +1857,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 27
+        "y": 28
       },
       "id": 16,
       "legend": {
@@ -1808,6 +1918,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "render request duration per step",
       "tooltip": {
@@ -1852,7 +1963,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 34
       },
       "id": 42,
       "panels": [],
@@ -1877,7 +1988,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 34
+        "y": 35
       },
       "id": 14,
       "legend": {
@@ -1941,6 +2052,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "write workers & queues",
       "tooltip": {
@@ -1995,7 +2107,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 34
+        "y": 35
       },
       "id": 18,
       "legend": {
@@ -2060,6 +2172,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "metricpersist",
       "tooltip": {
@@ -2124,7 +2237,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 34
+        "y": 35
       },
       "id": 21,
       "legend": {
@@ -2176,6 +2289,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "store queue wait durations",
       "tooltip": {
@@ -2219,7 +2333,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 42
       },
       "id": 43,
       "panels": [],
@@ -2248,7 +2362,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 6,
       "legend": {
@@ -2300,6 +2414,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "chunk sizes",
       "tooltip": {
@@ -2359,7 +2474,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 42
+        "y": 43
       },
       "id": 3,
       "legend": {
@@ -2395,6 +2510,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "store req/s",
       "tooltip": {
@@ -2456,7 +2572,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 42
+        "y": 43
       },
       "id": 11,
       "legend": {
@@ -2500,6 +2616,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "store query durations",
       "tooltip": {
@@ -2543,7 +2660,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 50
       },
       "id": 44,
       "panels": [],
@@ -2572,7 +2689,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 51
       },
       "id": 7,
       "legend": {
@@ -2635,6 +2752,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "store responses",
       "tooltip": {
@@ -2693,7 +2811,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 50
+        "y": 51
       },
       "id": 23,
       "legend": {
@@ -2729,6 +2847,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "store errors",
       "tooltip": {
@@ -2786,7 +2905,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 50
+        "y": 51
       },
       "id": 8,
       "legend": {
@@ -2818,6 +2937,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "chunk operations",
       "tooltip": {
@@ -2861,7 +2981,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 58
       },
       "id": 45,
       "panels": [],
@@ -2880,7 +3000,7 @@
         "h": 7,
         "w": 2,
         "x": 0,
-        "y": 58
+        "y": 59
       },
       "id": 30,
       "legend": {
@@ -2913,6 +3033,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "num metrics",
       "tooltip": {
@@ -2971,7 +3092,7 @@
         "h": 7,
         "w": 10,
         "x": 2,
-        "y": 58
+        "y": 59
       },
       "id": 12,
       "legend": {
@@ -3027,6 +3148,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "op durations",
       "tooltip": {
@@ -3096,7 +3218,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 58
+        "y": 59
       },
       "id": 20,
       "legend": {
@@ -3154,6 +3276,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "backend status",
       "tooltip": {
@@ -3214,7 +3337,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 58
+        "y": 59
       },
       "id": 22,
       "legend": {
@@ -3254,6 +3377,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "idx errors",
       "tooltip": {
@@ -3299,7 +3423,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 66
       },
       "id": 46,
       "panels": [],
@@ -3321,7 +3445,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 66
+        "y": 67
       },
       "id": 24,
       "legend": {
@@ -3353,6 +3477,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "message size",
       "tooltip": {
@@ -3409,7 +3534,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 66
+        "y": 67
       },
       "id": 25,
       "legend": {
@@ -3456,6 +3581,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "conn to graphite",
       "tooltip": {
@@ -3512,7 +3638,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 66
+        "y": 67
       },
       "id": 26,
       "legend": {
@@ -3548,6 +3674,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "queue to graphite",
       "tooltip": {
@@ -3593,7 +3720,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 74
       },
       "id": 47,
       "panels": [],
@@ -3618,7 +3745,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 74
+        "y": 75
       },
       "id": 27,
       "legend": {
@@ -3690,6 +3817,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "size",
       "tooltip": {
@@ -3748,7 +3876,7 @@
         "h": 6,
         "w": 7,
         "x": 8,
-        "y": 74
+        "y": 75
       },
       "id": 50,
       "legend": {
@@ -3822,6 +3950,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "accounting",
       "tooltip": {
@@ -3883,7 +4012,7 @@
         "h": 6,
         "w": 9,
         "x": 15,
-        "y": 74
+        "y": 75
       },
       "id": 28,
       "legend": {
@@ -3948,6 +4077,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "operations",
       "tooltip": {
@@ -3993,7 +4123,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 81
       },
       "id": 48,
       "panels": [],
@@ -4020,7 +4150,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 81
+        "y": 82
       },
       "id": 32,
       "legend": {
@@ -4093,6 +4223,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "gossip events and state",
       "tooltip": {
@@ -4142,7 +4273,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 81
+        "y": 82
       },
       "id": 15,
       "legend": {
@@ -4174,6 +4305,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "gossip decode errors",
       "tooltip": {
@@ -4234,6 +4366,7 @@
         "query": "graphite",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
@@ -4241,6 +4374,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -4252,6 +4386,7 @@
         "refresh": 1,
         "refresh_on_load": false,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -4262,8 +4397,12 @@
       {
         "allFormat": "glob",
         "allValue": null,
-        "current": {},
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -4275,6 +4414,7 @@
         "refresh": 1,
         "refresh_on_load": false,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -266,6 +266,9 @@ mode = single
 min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
+# GOGC value to use when node is not ready.  Defaults to GOGC
+# you can use this to set a more aggressive, latency-inducing GC behavior when the node is initializing and hungry for extra memory
+# gc-percent-not-ready = 100
 
 ## SWIM clustering settings ##
 # only relevant when using cluster mode 'multi'

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -266,6 +266,9 @@ mode = single
 min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
+# GOGC value to use when node is not ready.  Defaults to GOGC
+# you can use this to set a more aggressive, latency-inducing GC behavior when the node is initializing and hungry for extra memory
+# gc-percent-not-ready = 100
 
 ## SWIM clustering settings ##
 # only relevant when using cluster mode 'multi'

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -266,6 +266,9 @@ mode = single
 min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
+# GOGC value to use when node is not ready.  Defaults to GOGC
+# you can use this to set a more aggressive, latency-inducing GC behavior when the node is initializing and hungry for extra memory
+# gc-percent-not-ready = 100
 
 ## SWIM clustering settings ##
 # only relevant when using cluster mode 'multi'

--- a/docs/config.md
+++ b/docs/config.md
@@ -322,6 +322,9 @@ mode = single
 min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
+# GOGC value to use when node is not ready.  Defaults to GOGC
+# you can use this to set a more aggressive, latency-inducing GC behavior when the node is initializing and hungry for extra memory
+# gc-percent-not-ready = 100
 ```
 
 ## SWIM clustering settings ##

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -228,6 +228,8 @@ the number of bytes currently obtained from the system by the process.  This is 
 a gauge of currently allocated (within the runtime) memory.
 * `memory.gc.cpu_fraction`:  
 how much cpu is consumed by the GC across process lifetime, in pro-mille
+* `memory.gc.gogc`:  
+the current GOGC value (derived from the GOGC environment variable)
 * `memory.gc.heap_objects`:  
 how many objects are allocated on the heap, it's a key indicator for GC workload
 * `memory.gc.last_duration`:  

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -269,6 +269,9 @@ mode = single
 min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
+# GOGC value to use when node is not ready.  Defaults to GOGC
+# you can use this to set a more aggressive, latency-inducing GC behavior when the node is initializing and hungry for extra memory
+# gc-percent-not-ready = 100
 
 ## SWIM clustering settings ##
 # only relevant when using cluster mode 'multi'

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -266,6 +266,9 @@ mode = single
 min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
+# GOGC value to use when node is not ready.  Defaults to GOGC
+# you can use this to set a more aggressive, latency-inducing GC behavior when the node is initializing and hungry for extra memory
+# gc-percent-not-ready = 100
 
 ## SWIM clustering settings ##
 # only relevant when using cluster mode 'multi'

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -266,6 +266,9 @@ mode = single
 min-available-shards = 0
 # How long to wait before aborting http requests to cluster peers and returning a http 503 service unavailable
 http-timeout = 60s
+# GOGC value to use when node is not ready.  Defaults to GOGC
+# you can use this to set a more aggressive, latency-inducing GC behavior when the node is initializing and hungry for extra memory
+# gc-percent-not-ready = 100
 
 ## SWIM clustering settings ##
 # only relevant when using cluster mode 'multi'

--- a/stats/memory_reporter.go
+++ b/stats/memory_reporter.go
@@ -1,11 +1,14 @@
 package stats
 
 import (
+	"os"
 	"runtime"
+	"strconv"
 	"time"
 )
 
 // MemoryReporter sources memory stats from the runtime and reports them
+// It also reports gcPercent based on the GOGC environment variable
 type MemoryReporter struct {
 	mem           runtime.MemStats
 	gcCyclesTotal uint32
@@ -15,8 +18,27 @@ func NewMemoryReporter() *MemoryReporter {
 	return registry.getOrAdd("memory", &MemoryReporter{}).(*MemoryReporter)
 }
 
+func getGcPercent() int {
+	// follow standard runtime:
+	// unparseable or not set -> 100
+	// "off" -> -1
+	gogc := os.Getenv("GOGC")
+	if gogc == "" {
+		return 100
+	}
+	if gogc == "off" {
+		return -1
+	}
+	val, err := strconv.Atoi(gogc)
+	if err != nil {
+		return 100
+	}
+	return val
+}
+
 func (m *MemoryReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	runtime.ReadMemStats(&m.mem)
+	gcPercent := getGcPercent()
 
 	// metric memory.total_bytes_allocated is a counter of total number of bytes allocated during process lifetime
 	buf = WriteUint64(buf, prefix, []byte("total_bytes_allocated.counter64"), m.mem.TotalAlloc, now)
@@ -42,6 +64,9 @@ func (m *MemoryReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byt
 		buf = WriteUint64(buf, prefix, []byte("gc.last_duration.gauge64"), m.mem.PauseNs[(m.mem.NumGC+255)%256], now)
 		m.gcCyclesTotal = m.mem.NumGC
 	}
+
+	// metric memory.gc.gogc is the current GOGC value (derived from the GOGC environment variable)
+	buf = WriteInt32(buf, prefix, []byte("gc.gogc.sgauge32"), int32(gcPercent), now)
 
 	return buf
 }

--- a/stats/write.go
+++ b/stats/write.go
@@ -34,3 +34,13 @@ func WriteUint64(buf, prefix, key []byte, val uint64, now time.Time) []byte {
 	buf = strconv.AppendInt(buf, now.Unix(), 10)
 	return append(buf, '\n')
 }
+
+func WriteInt32(buf, prefix, key []byte, val int32, now time.Time) []byte {
+	buf = append(buf, prefix...)
+	buf = append(buf, key...)
+	buf = append(buf, ' ')
+	buf = strconv.AppendInt(buf, int64(val), 10)
+	buf = append(buf, ' ')
+	buf = strconv.AppendInt(buf, now.Unix(), 10)
+	return append(buf, '\n')
+}


### PR DESCRIPTION
This is a cleaned up version of #1171 
See that PR for more information and rationale.

I have tested it like so:
```
cd docker/docker-dev-custom-cfg-kafka
docker-compose up --force-recreate -V
# wait til ready...
fakemetrics backfill --kafka-mdm-addr localhost:9092 --offset 5h --period 10s --speedup 100 --mpo 20000
```
after that completes, restart MT with gc-percent-not-ready settings that gradually go down.
Here's the tested settings:
```
100
50
20
10
```
i always restarted right at the change of a minute.
if i were to do this again, i would restart a few seconds after the minute change, to give it a chance to save all chunks. currently there's some missing data, but only after the instance stabilized so it doesn't really get in the way of the analysis.

snapshots:
https://snapshot.raintank.io/dashboard/snapshot/FoSdCguE9qi4eBXMZv3xxnRVW3EolcaN
https://snapshot.raintank.io/dashboard/snapshot/HsqiUL4vMEFFYf9oJDhLwve3Ibw5X248

I also used this patch:
```
diff --git a/cluster/node.go b/cluster/node.go
index 43bde4ee..940fded7 100644
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -131,11 +131,14 @@ func (n HTTPNode) IsLocal() bool {
 // readyStateGCHandler adjusts the gcPercent value based on the node ready state
 func (n HTTPNode) readyStateGCHandler() {
        if gcPercent == gcPercentNotReady {
+               log.Infof("HANDLER. prio:%d, state:%q, total ready:%t. keeping stock GOGC", n.Priority, n.State, n.IsReady())
                return
        }
        if n.IsReady() {
+               log.Infof("HANDLER. prio:%d, state:%q, total ready:%t -> setting gc percent %d", n.Priority, n.State, true, gcPercent)
                debug.SetGCPercent(gcPercent)
        } else {
+               log.Infof("HANDLER. prio:%d, state:%q, total ready:%t -> setting gc percent %d", n.Priority, n.State, false, gcPercentNotReady)
                debug.SetGCPercent(gcPercentNotReady)
        }
 }
```

here's the output of the last run:
```
2018-12-29 12:39:19.039 [INFO] HANDLER. prio:0, state:"NodeNotReady", total ready:false -> setting gc percent 10
2018-12-29 12:39:19.040 [INFO] HANDLER. prio:0, state:"NodeReady", total ready:true -> setting gc percent 100
2018-12-29 12:39:29.040 [INFO] HANDLER. prio:4357775, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:39:39.040 [INFO] HANDLER. prio:130, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:39:49.043 [INFO] HANDLER. prio:121, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:39:59.042 [INFO] HANDLER. prio:103, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:40:09.040 [INFO] HANDLER. prio:112, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:40:19.050 [INFO] HANDLER. prio:85, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:40:29.040 [INFO] HANDLER. prio:79, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:40:39.040 [INFO] HANDLER. prio:62, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:40:49.040 [INFO] HANDLER. prio:47, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:40:59.048 [INFO] HANDLER. prio:37, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:41:09.040 [INFO] HANDLER. prio:26, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:41:19.040 [INFO] HANDLER. prio:16, state:"NodeReady", total ready:false -> setting gc percent 10
2018-12-29 12:41:29.040 [INFO] HANDLER. prio:10, state:"NodeReady", total ready:true -> setting gc percent 100
2018-12-29 12:41:39.040 [INFO] HANDLER. prio:0, state:"NodeReady", total ready:true -> setting gc percent 100
2018-12-29 12:41:49.040 [INFO] HANDLER. prio:1, state:"NodeReady", total ready:true -> setting gc percent 100
```
note that before it starts consuming data it briefly marks itself as ready.
this should not happen on read-only nodes (they use a warm up period) but i suspect this problem may also appear on read nodes if they don't start consuming the kafka backlog in time. and is something to investigate further/separately.
But even for write nodes we don't want this to happen as it means our gogc controls is temporarily not honored.

conclusions as far as this feature
1) it works
2) you can see with each run, cpu usage goes up, GC runs go up, cpu spent in GC goes up, and less memory is needed.
3) in my most extreme run, you trade in cpu 265% -> 440% (66% change), you get a memory reduction from 450MB->280MB (38%). it also comes with an ingestion decrease from 81s to 132s (+63%). 
whether this is worth it, depends. I suspect a milder approach, maybe 50 is good to get started.

note: in real environments i expect the numbers to be different.