### PR TITLE
improve kafka-mdm stats/priority

### DIFF
--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -351,7 +351,7 @@ func (k *KafkaMdm) Stop() {
 }
 
 func (k *KafkaMdm) trackStats(topic string, partition int32) {
-	ticker := time.NewTicker(time.Second * 5)
+	ticker := time.NewTicker(time.Second)
 	kafkaStats := kafkaStats[partition]
 	for {
 		select {
@@ -375,7 +375,7 @@ func (k *KafkaMdm) trackStats(topic string, partition int32) {
 
 func (k *KafkaMdm) MaintainPriority() {
 	go func() {
-		ticker := time.NewTicker(time.Second * 10)
+		ticker := time.NewTicker(time.Second)
 		for {
 			select {
 			case <-k.shutdown:

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -60,7 +60,7 @@ var consumerMaxWaitTime time.Duration
 var consumerMaxProcessingTime time.Duration
 var netMaxOpenRequests int
 var offsetDuration time.Duration
-var kafkaStats map[int32]*KafkaStats
+var kafkaStats map[int32]KafkaStats
 
 func ConfigSetup() {
 	inKafkaMdm := flag.NewFlagSet("kafka-mdm-in", flag.ExitOnError)
@@ -159,24 +159,24 @@ func ConfigProcess(instance string) {
 	}
 
 	// initialize our offset metrics
-	kafkaStats = make(map[int32]*KafkaStats)
+	kafkaStats = make(map[int32]KafkaStats)
 	for _, part := range partitions {
-		kafkaStats[part] = &KafkaStats{
+		kafkaStats[part] = KafkaStats{
 			// metric input.kafka-mdm.partition.%d.offset is the current offset for the partition (%d) that we have consumed.
-			offset: *stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.offset", part)),
+			offset: stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.offset", part)),
 			// metric input.kafka-mdm.partition.%d.log_size is the current size of the kafka partition (%d), aka the newest available offset.
-			logSize: *stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.log_size", part)),
+			logSize: stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.log_size", part)),
 			// metric input.kafka-mdm.partition.%d.lag is how many messages (metrics) there are in the kafka partition (%d) that we have not yet consumed.
-			lag: *stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.lag", part)),
+			lag: stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.lag", part)),
 		}
 	}
 }
 
 // KafkaStats is a set of per-partition stats to track the health of our consumer
 type KafkaStats struct {
-	offset  stats.Gauge64
-	logSize stats.Gauge64
-	lag     stats.Gauge64
+	offset  *stats.Gauge64
+	logSize *stats.Gauge64
+	lag     *stats.Gauge64
 }
 
 func New() *KafkaMdm {

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -252,8 +252,6 @@ func (k *KafkaMdm) tryGetOffset(topic string, partition int32, offset int64, att
 func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset int64) {
 	defer k.wg.Done()
 
-	kafkaStats := kafkaStats[partition]
-
 	// determine the pos of the topic and the initial offset of our consumer
 	newest, err := k.tryGetOffset(topic, partition, sarama.OffsetNewest, 7, time.Second*10)
 	if err != nil {
@@ -272,6 +270,7 @@ func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset
 		}
 	}
 
+	kafkaStats := kafkaStats[partition]
 	kafkaStats.Offset.Set(int(currentOffset))
 	kafkaStats.LogSize.Set(int(newest))
 	kafkaStats.Lag.Set(int(newest - currentOffset))

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -260,7 +260,7 @@ func (k *KafkaMdm) tryGetOffset(topic string, partition int32, offset int64, att
 	return val, err
 }
 
-// this will continually consume from the topic until k.shutdown is triggered.
+// consumePartition consumes from the topic until k.shutdown is triggered.
 func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset int64) {
 	defer k.wg.Done()
 

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -60,7 +60,7 @@ var consumerMaxWaitTime time.Duration
 var consumerMaxProcessingTime time.Duration
 var netMaxOpenRequests int
 var offsetDuration time.Duration
-var kafkaStats map[int32]KafkaStats
+var kafkaStats map[int32]*KafkaStats
 
 func ConfigSetup() {
 	inKafkaMdm := flag.NewFlagSet("kafka-mdm-in", flag.ExitOnError)
@@ -159,24 +159,24 @@ func ConfigProcess(instance string) {
 	}
 
 	// initialize our offset metrics
-	kafkaStats = make(map[int32]KafkaStats)
+	kafkaStats = make(map[int32]*KafkaStats)
 	for _, part := range partitions {
-		kafkaStats[part] = KafkaStats{
-			// metric input.kafka-mdm.partition.%d.offset is the current offset for the partition (%d) that we have consumed.
-			offset: stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.offset", part)),
-			// metric input.kafka-mdm.partition.%d.log_size is the current size of the kafka partition (%d), aka the newest available offset.
-			logSize: stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.log_size", part)),
-			// metric input.kafka-mdm.partition.%d.lag is how many messages (metrics) there are in the kafka partition (%d) that we have not yet consumed.
-			lag: stats.NewGauge64(fmt.Sprintf("input.kafka-mdm.partition.%d.lag", part)),
-		}
+		ks := KafkaStats{}
+		// metric input.kafka-mdm.partition.%d.offset is the current offset for the partition (%d) that we have consumed.
+		stats.NewGauge64Existing(fmt.Sprintf("input.kafka-mdm.partition.%d.offset", part), &ks.offset)
+		// metric input.kafka-mdm.partition.%d.log_size is the current size of the kafka partition (%d), aka the newest available offset.
+		stats.NewGauge64Existing(fmt.Sprintf("input.kafka-mdm.partition.%d.log_size", part), &ks.logSize)
+		// metric input.kafka-mdm.partition.%d.lag is how many messages (metrics) there are in the kafka partition (%d) that we have not yet consumed.
+		stats.NewGauge64Existing(fmt.Sprintf("input.kafka-mdm.partition.%d.lag", part), &ks.lag)
+		kafkaStats[part] = &ks
 	}
 }
 
 // KafkaStats is a set of per-partition stats to track the health of our consumer
 type KafkaStats struct {
-	offset  *stats.Gauge64
-	logSize *stats.Gauge64
-	lag     *stats.Gauge64
+	offset  stats.Gauge64
+	logSize stats.Gauge64
+	lag     stats.Gauge64
 }
 
 func New() *KafkaMdm {

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -356,6 +356,7 @@ func (k *KafkaMdm) trackStats(topic string, partition int32) {
 	for {
 		select {
 		case <-k.shutdown:
+			ticker.Stop()
 			return
 		case ts := <-ticker.C:
 			currentOffset := int64(kafkaStats.offset.Peek())
@@ -379,6 +380,7 @@ func (k *KafkaMdm) MaintainPriority() {
 		for {
 			select {
 			case <-k.shutdown:
+				ticker.Stop()
 				return
 			case <-ticker.C:
 				cluster.Manager.SetPriority(k.lagMonitor.Metric())

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -12,10 +12,6 @@ func NewGauge64(name string) *Gauge64 {
 	return registry.getOrAdd(name, &u).(*Gauge64)
 }
 
-func NewGauge64Existing(name string, g *Gauge64) *Gauge64 {
-	return registry.getOrAdd(name, g).(*Gauge64)
-}
-
 func (g *Gauge64) Inc() {
 	atomic.AddUint64((*uint64)(g), 1)
 }

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -5,28 +5,31 @@ import (
 	"time"
 )
 
-type Gauge64 struct {
-	val uint64
-}
+type Gauge64 uint64
 
 func NewGauge64(name string) *Gauge64 {
-	return registry.getOrAdd(name, &Gauge64{}).(*Gauge64)
+	u := Gauge64(0)
+	return registry.getOrAdd(name, &u).(*Gauge64)
+}
+
+func NewGauge64Existing(name string, g *Gauge64) *Gauge64 {
+	return registry.getOrAdd(name, g).(*Gauge64)
 }
 
 func (g *Gauge64) Inc() {
-	atomic.AddUint64(&g.val, 1)
+	atomic.AddUint64((*uint64)(g), 1)
 }
 
 func (g *Gauge64) Dec() {
-	atomic.AddUint64(&g.val, ^uint64(0))
+	atomic.AddUint64((*uint64)(g), ^uint64(0))
 }
 
 func (g *Gauge64) AddUint64(val uint64) {
-	atomic.AddUint64(&g.val, val)
+	atomic.AddUint64((*uint64)(g), val)
 }
 
 func (g *Gauge64) DecUint64(val uint64) {
-	atomic.AddUint64(&g.val, ^uint64(val-1))
+	atomic.AddUint64((*uint64)(g), ^uint64(val-1))
 }
 
 func (g *Gauge64) Add(val int) {
@@ -42,19 +45,19 @@ func (g *Gauge64) Add(val int) {
 }
 
 func (g *Gauge64) Set(val int) {
-	atomic.StoreUint64(&g.val, uint64(val))
+	atomic.StoreUint64((*uint64)(g), uint64(val))
 }
 
 func (g *Gauge64) SetUint64(val uint64) {
-	atomic.StoreUint64(&g.val, val)
+	atomic.StoreUint64((*uint64)(g), val)
 }
 
 func (g *Gauge64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
-	val := atomic.LoadUint64(&g.val)
+	val := atomic.LoadUint64((*uint64)(g))
 	buf = WriteUint64(buf, prefix, []byte("gauge64"), val, now)
 	return buf
 }
 
-func (c *Gauge64) Peek() uint64 {
-	return atomic.LoadUint64(&c.val)
+func (g *Gauge64) Peek() uint64 {
+	return atomic.LoadUint64((*uint64)(g))
 }

--- a/stats/kafka.go
+++ b/stats/kafka.go
@@ -1,0 +1,29 @@
+package stats
+
+import "strconv"
+
+// Kafka tracks the health of a consumer
+type Kafka map[int32]*KafkaPartition
+
+func NewKafka(prefix string, partitions []int32) Kafka {
+	k := make(map[int32]*KafkaPartition)
+	for _, part := range partitions {
+		k[part] = NewKafkaPartition(prefix + ".partition." + strconv.Itoa(int(part)))
+	}
+	return k
+}
+
+// KafkaPartition tracks the health of a partition consumer
+type KafkaPartition struct {
+	Offset  Gauge64
+	LogSize Gauge64
+	Lag     Gauge64
+}
+
+func NewKafkaPartition(prefix string) *KafkaPartition {
+	k := KafkaPartition{}
+	registry.getOrAdd(prefix+".offset", &k.Offset)
+	registry.getOrAdd(prefix+".log_size", &k.LogSize)
+	registry.getOrAdd(prefix+".lag", &k.Lag)
+	return &k
+}


### PR DESCRIPTION
cleaning up the code a bit in prep for #1022 
 
* refactor stats a bit
* separate ingestion and stats tracking into two separate loops so they can't block each other. fix #1113 
* do stats updates more frequently

TODO: same for metricpersist (maybe in a separate PR)