### PR TITLE
Dashboard tweaks

### DIFF
--- a/dashboards/main/metrictank.json
+++ b/dashboards/main/metrictank.json
@@ -4459,7 +4459,7 @@
     ],
     "type": "timepicker"
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Metrictank",
   "uid": "tQW3QShiz",
   "version": 5

--- a/dashboards/main/metrictank.json
+++ b/dashboards/main/metrictank.json
@@ -1907,7 +1907,7 @@
         },
         {
           "refId": "F",
-          "target": "alias(averageSeries(metrictank.stats.$environment.$instance.api.mem.to_iter.latency.mean.gauge32), 'mem to iter')",
+          "target": "alias(averageSeries(metrictank.stats.$environment.$instance.mem.to_iter.latency.mean.gauge32), 'mem to iter')",
           "textEditor": false
         },
         {


### PR DESCRIPTION
* use utc timezone
This is what GrafanaLabs prefers (?) so everyone else will just have to deal with the new default

* reapply mem.to_iter fix