### PR TITLE
add findCache for memoryIdx

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -382,6 +382,17 @@
   revision = "9b4c5fa5b10a683339a270d664474b9f4aee62fc"
 
 [[projects]]
+  digest = "1:52094d0f8bdf831d1a2401e9b6fee5795fdc0b2a2d1f8bb1980834c289e79129"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = "NUT"
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
+
+[[projects]]
   branch = "master"
   digest = "1:5dda4b99e405ae36407a21de1292b4b8c9f640c3cdf28b9ff6bf1187cd94396b"
   name = "github.com/hashicorp/memberlist"
@@ -1036,6 +1047,7 @@
     "github.com/golang/snappy",
     "github.com/grafana/globalconf",
     "github.com/hailocab/go-hostpool",
+    "github.com/hashicorp/golang-lru",
     "github.com/hashicorp/memberlist",
     "github.com/kisielk/og-rek",
     "github.com/kisielk/whisper-go/whisper",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -154,3 +154,7 @@ unused-packages = true
 [[override]]
   name = "golang.org/x/net"
   revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
+
+[[constraint]]
+  name = "github.com/hashicorp/golang-lru"
+  version = "0.5.1"

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -396,6 +396,8 @@ rules-file = /etc/metrictank/index-rules.conf
 max-prune-lock-time = 100ms
 # use separate indexes per partition
 partitioned = false
+# number of find expressions to cache
+find-cache-size = 1000
 
 ### Bigtable index
 [bigtable-idx]

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -398,6 +398,10 @@ max-prune-lock-time = 100ms
 partitioned = false
 # number of find expressions to cache
 find-cache-size = 1000
+# size of queue for invalidating findCache entries.
+find-cache-invalidate-queue = 100
+# amount of time to disable the findCache when the invalidate queue fills up
+find-cache-backoff = 60s
 
 ### Bigtable index
 [bigtable-idx]

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -396,6 +396,8 @@ rules-file = /etc/metrictank/index-rules.conf
 max-prune-lock-time = 100ms
 # use separate indexes per partition
 partitioned = false
+# number of find expressions to cache
+find-cache-size = 1000
 
 ### Bigtable index
 [bigtable-idx]

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -398,6 +398,10 @@ max-prune-lock-time = 100ms
 partitioned = false
 # number of find expressions to cache
 find-cache-size = 1000
+# size of queue for invalidating findCache entries.
+find-cache-invalidate-queue = 100
+# amount of time to disable the findCache when the invalidate queue fills up
+find-cache-backoff = 60s
 
 ### Bigtable index
 [bigtable-idx]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -396,6 +396,8 @@ rules-file = /etc/metrictank/index-rules.conf
 max-prune-lock-time = 100ms
 # use separate indexes per partition
 partitioned = false
+# number of find expressions to cache
+find-cache-size = 1000
 
 ### Bigtable index
 [bigtable-idx]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -398,6 +398,10 @@ max-prune-lock-time = 100ms
 partitioned = false
 # number of find expressions to cache
 find-cache-size = 1000
+# size of queue for invalidating findCache entries.
+find-cache-invalidate-queue = 100
+# amount of time to disable the findCache when the invalidate queue fills up
+find-cache-backoff = 60s
 
 ### Bigtable index
 [bigtable-idx]

--- a/docs/config.md
+++ b/docs/config.md
@@ -463,6 +463,8 @@ rules-file = /etc/metrictank/index-rules.conf
 max-prune-lock-time = 100ms
 # use separate indexes per partition
 partitioned = false
+# number of find expressions to cache
+find-cache-size = 1000
 ```
 
 ### Bigtable index

--- a/docs/config.md
+++ b/docs/config.md
@@ -465,6 +465,10 @@ max-prune-lock-time = 100ms
 partitioned = false
 # number of find expressions to cache
 find-cache-size = 1000
+# size of queue for invalidating findCache entries.
+find-cache-invalidate-queue = 100
+# amount of time to disable the findCache when the invalidate queue fills up
+find-cache-backoff = 60s
 ```
 
 ### Bigtable index

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -181,6 +181,8 @@ number of series that have been excluded from responses due to their lastUpdate 
 * `idx.memory.find`:  
 the duration of memory idx find
 * `idx.memory.find-cache.hit`:  
+a counter of findCache hits
+* `idx.memory.find-cache.miss`:  
 a counter of findCache misses
 * `idx.memory.get`:  
 the duration of a get of one metric in the memory idx

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -180,6 +180,8 @@ the duration of a delete of one or more metrics from the memory idx
 number of series that have been excluded from responses due to their lastUpdate property
 * `idx.memory.find`:  
 the duration of memory idx find
+* `idx.memory.find-cache.hit`:  
+a counter of findCache misses
 * `idx.memory.get`:  
 the duration of a get of one metric in the memory idx
 * `idx.memory.list`:  

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -50,6 +50,7 @@ func (c *FindCache) Get(orgId uint32, pattern string) ([]*Node, bool) {
 	}
 	nodes, ok := cache.Get(pattern)
 	if !ok {
+		findCacheMiss.Inc()
 		return nil, ok
 	}
 	findCacheHit.Inc()

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -46,7 +46,7 @@ func (c *FindCache) Get(orgId uint32, pattern string) ([]*Node, bool) {
 	c.RUnlock()
 	if !ok {
 		findCacheMiss.Inc()
-		return nil, false
+		return nil, ok
 	}
 	nodes, ok := cache.Get(pattern)
 	if !ok {

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -144,7 +144,7 @@ func (c *FindCache) InvalidateFor(orgId uint32, path string) {
 	for {
 		branch := path[:pos]
 		// add as child of parent branch
-		tree.Items[path[:prevPos]].Children = []string{branch}
+		tree.Items[path[:prevPos]].Children = []string{branch[prevPos+1:]}
 
 		// create this branch/leaf
 		tree.Items[branch] = &Node{
@@ -166,7 +166,7 @@ func (c *FindCache) InvalidateFor(orgId uint32, path string) {
 	for _, k := range cache.Keys() {
 		matches, err := find(tree, k.(string))
 		if err != nil {
-			log.Errorf("memory-idx: checking if new series matches expressions in findCache. series=%s expr=%s", path, k)
+			log.Errorf("memory-idx: checking if new series matches expressions in findCache. series=%s expr=%s err=%s", path, k, err)
 			continue
 		}
 		if len(matches) > 0 {

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -1,0 +1,122 @@
+package memory
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/grafana/metrictank/stats"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/raintank/schema"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// metric idx.memory.find-cache.hit is a counter of findCache hits
+	findCacheHit = stats.NewCounterRate32("idx.memory.find-cache.hit")
+	// metric idx.memory.find-cache.hit is a counter of findCache misses
+	findCacheMiss = stats.NewCounterRate32("idx.memory.find-cache.miss")
+)
+
+type FindCache struct {
+	cache map[uint32]*lru.Cache
+	size  int
+	sync.RWMutex
+}
+
+func NewFindCache(size int) *FindCache {
+	return &FindCache{
+		cache: make(map[uint32]*lru.Cache),
+		size:  size,
+	}
+}
+
+func (c *FindCache) Get(orgId uint32, pattern string) ([]*Node, bool) {
+	c.RLock()
+	cache, ok := c.cache[orgId]
+	c.RUnlock()
+	if !ok {
+		findCacheMiss.Inc()
+		return nil, false
+	}
+	nodes, ok := cache.Get(pattern)
+	if !ok {
+		return nil, ok
+	}
+	findCacheHit.Inc()
+	return nodes.([]*Node), ok
+}
+
+func (c *FindCache) Add(orgId uint32, pattern string, nodes []*Node) {
+	c.RLock()
+	cache, ok := c.cache[orgId]
+	c.RUnlock()
+	var err error
+	if !ok {
+		cache, err = lru.New(c.size)
+		if err != nil {
+			log.Errorf("memory-idx: findCache failed to create lru. err=%s", err)
+			return
+		}
+		c.Lock()
+		c.cache[orgId] = cache
+		c.Unlock()
+	}
+	cache.Add(pattern, nodes)
+}
+
+func (c *FindCache) Purge(orgId uint32) {
+	c.RLock()
+	cache, ok := c.cache[orgId]
+	c.RUnlock()
+	if !ok {
+		return
+	}
+	cache.Purge()
+}
+
+func (c *FindCache) InvalidateFor(orgId uint32, path string) {
+	c.RLock()
+	cache, ok := c.cache[orgId]
+	c.RUnlock()
+	if !ok || cache.Len() < 1 {
+		return
+	}
+	tree := &Tree{
+		Items: map[string]*Node{
+			"": &Node{
+				Path:     "",
+				Children: make([]string, 0),
+				Defs:     make([]schema.MKey, 0),
+			},
+		},
+	}
+	pos := strings.Index(path, ".")
+	prevPos := 0
+	for {
+		branch := path[:pos]
+		// add as child of parent branch
+		tree.Items[path[:prevPos]].Children = []string{branch}
+
+		// create this branch/leaf
+		tree.Items[branch] = &Node{
+			Path: branch,
+		}
+		if branch == path {
+			tree.Items[branch].Defs = []schema.MKey{{}}
+			break
+		}
+		prevPos = pos
+		pos = pos + strings.Index(path[pos+1:], ".")
+	}
+
+	for _, k := range cache.Keys() {
+		matches, err := find(tree, k.(string))
+		if err != nil {
+			log.Errorf("memory-idx: checking if new series matches expressions in findCache. series=%s expr=%s", path, k)
+			continue
+		}
+		if len(matches) > 0 {
+			cache.Remove(k)
+		}
+	}
+}

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -83,7 +83,7 @@ func (c *FindCache) InvalidateFor(orgId uint32, path string) {
 	}
 	tree := &Tree{
 		Items: map[string]*Node{
-			"": &Node{
+			"": {
 				Path:     "",
 				Children: make([]string, 0),
 				Defs:     make([]schema.MKey, 0),

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -14,7 +14,7 @@ import (
 var (
 	// metric idx.memory.find-cache.hit is a counter of findCache hits
 	findCacheHit = stats.NewCounterRate32("idx.memory.find-cache.hit")
-	// metric idx.memory.find-cache.hit is a counter of findCache misses
+	// metric idx.memory.find-cache.miss is a counter of findCache misses
 	findCacheMiss = stats.NewCounterRate32("idx.memory.find-cache.miss")
 
 	findCacheSize            = 1000

--- a/idx/memory/find_cache_test.go
+++ b/idx/memory/find_cache_test.go
@@ -26,7 +26,7 @@ func TestTreeFromPath(t *testing.T) {
 
 func TestFindCache(t *testing.T) {
 	Convey("when findCache is empty", t, func() {
-		c := NewFindCache(10, 1, time.Second)
+		c := NewFindCache(10, 1, time.Second*2)
 		Convey("0 results should be returned", func() {
 			result, ok := c.Get(1, "foo.bar.*")
 			So(ok, ShouldBeFalse)
@@ -54,8 +54,8 @@ func TestFindCache(t *testing.T) {
 			})
 			Convey("when findCache invalidation falls behind", func() {
 				var wg sync.WaitGroup
-				for i := 0; i < 20; i++ {
-					wg.Add(1)
+				wg.Add(10)
+				for i := 0; i < 10; i++ {
 					go func() {
 						c.InvalidateFor(1, "foo.baz.foo.a.b.c.d.e.f.g.h")
 						wg.Done()
@@ -72,7 +72,7 @@ func TestFindCache(t *testing.T) {
 					So(result, ShouldHaveLength, 0)
 				})
 				Convey("when adding to cache after backoff time", func() {
-					time.Sleep(time.Millisecond * 1500)
+					time.Sleep(time.Millisecond * 2500)
 					c.Add(1, "foo.*.*", results)
 					So(len(c.cache), ShouldEqual, 1)
 					result, ok := c.Get(1, "foo.*.*")

--- a/idx/memory/find_cache_test.go
+++ b/idx/memory/find_cache_test.go
@@ -1,0 +1,86 @@
+package memory
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTreeFromPath(t *testing.T) {
+	path := "foo.bar.baz"
+	Convey("when treeFromPath is given a path", t, func() {
+		tree := treeFromPath(path)
+		So(len(tree.Items), ShouldEqual, 4)
+		So(tree.Items[""], ShouldNotBeNil)
+		So(tree.Items[""].Leaf(), ShouldBeFalse)
+		So(tree.Items["foo"], ShouldNotBeNil)
+		So(tree.Items["foo"].Leaf(), ShouldBeFalse)
+		So(tree.Items["foo.bar"], ShouldNotBeNil)
+		So(tree.Items["foo.bar"].Leaf(), ShouldBeFalse)
+		So(tree.Items["foo.bar.baz"], ShouldNotBeNil)
+		So(tree.Items["foo.bar.baz"].Leaf(), ShouldBeTrue)
+	})
+}
+
+func TestFindCache(t *testing.T) {
+	Convey("when findCache is empty", t, func() {
+		c := NewFindCache(10, 1, time.Second)
+		Convey("0 results should be returned", func() {
+			result, ok := c.Get(1, "foo.bar.*")
+			So(ok, ShouldBeFalse)
+			So(result, ShouldHaveLength, 0)
+		})
+		Convey("when adding entries to the cache", func() {
+			pattern := "foo.bar.*"
+			results, err := find(treeFromPath("foo.bar.foo"), pattern)
+			So(err, ShouldBeNil)
+			So(results, ShouldHaveLength, 1)
+			c.Add(1, "foo.bar.*", results)
+			So(c.cache[1].Len(), ShouldEqual, 1)
+			Convey("when getting cached pattern", func() {
+				result, ok := c.Get(1, "foo.bar.*")
+				So(ok, ShouldBeTrue)
+				So(result, ShouldHaveLength, 1)
+				Convey("After invalidating path that matches pattern", func() {
+					c.InvalidateFor(1, "foo.bar.baz")
+					So(c.cache[1].Len(), ShouldEqual, 0)
+				})
+				Convey("After invalidating path that doesnt matche cached pattern", func() {
+					c.InvalidateFor(1, "foo.foo.baz")
+					So(c.cache[1].Len(), ShouldEqual, 1)
+				})
+			})
+			Convey("when findCache invalidation falls behind", func() {
+				var wg sync.WaitGroup
+				for i := 0; i < 20; i++ {
+					wg.Add(1)
+					go func() {
+						c.InvalidateFor(1, "foo.baz.foo.a.b.c.d.e.f.g.h")
+						wg.Done()
+					}()
+				}
+				wg.Wait()
+
+				So(len(c.cache), ShouldEqual, 0)
+				Convey("when adding to cache in backoff", func() {
+					c.Add(1, "foo.*.*", results)
+					So(len(c.cache), ShouldEqual, 0)
+					result, ok := c.Get(1, "foo.*.*")
+					So(ok, ShouldBeFalse)
+					So(result, ShouldHaveLength, 0)
+				})
+				Convey("when adding to cache after backoff time", func() {
+					time.Sleep(time.Millisecond * 1500)
+					c.Add(1, "foo.*.*", results)
+					So(len(c.cache), ShouldEqual, 1)
+					result, ok := c.Get(1, "foo.*.*")
+					So(ok, ShouldBeTrue)
+					So(result, ShouldHaveLength, 1)
+				})
+			})
+		})
+	})
+
+}

--- a/idx/memory/find_cache_test.go
+++ b/idx/memory/find_cache_test.go
@@ -53,6 +53,10 @@ func TestFindCache(t *testing.T) {
 				})
 			})
 			Convey("when findCache invalidation falls behind", func() {
+				c.Add(1, "foo.{a,b,c}*.*", results)
+				c.Add(1, "foo.{a,b,e}*.*", results)
+				c.Add(1, "foo.{a,b,f}*.*", results)
+				c.Lock()
 				var wg sync.WaitGroup
 				wg.Add(10)
 				for i := 0; i < 10; i++ {
@@ -61,6 +65,7 @@ func TestFindCache(t *testing.T) {
 						wg.Done()
 					}()
 				}
+				c.Unlock()
 				wg.Wait()
 
 				So(len(c.cache), ShouldEqual, 0)

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -100,6 +100,7 @@ type MemoryIndex interface {
 	UpdateArchive(idx.Archive)
 	add(*schema.MetricDefinition) idx.Archive
 	idsByTagQuery(uint32, TagQuery) IdSet
+	PurgeFindCache()
 }
 
 func New() MemoryIndex {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1445,7 +1445,13 @@ ORGS:
 			tl.Add(time.Since(lockStart))
 			pruned = append(pruned, defs...)
 		}
-		m.findCache.Purge(org)
+		if len(paths) > findCacheInvalidateQueue {
+			m.findCache.Purge(org)
+		} else {
+			for path := range paths {
+				m.findCache.InvalidateFor(org, path)
+			}
+		}
 	}
 
 	statMetricsActive.Set(len(m.defById))

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1222,8 +1222,12 @@ func (m *UnpartitionedMemoryIdx) Delete(orgId uint32, pattern string) ([]idx.Arc
 
 	statMetricsActive.Set(len(m.defById))
 	statDeleteDuration.Value(time.Since(pre))
-	if len(deletedDefs) > 0 {
+	if len(deletedDefs) > findCacheInvalidateQueue {
 		m.findCache.Purge(orgId)
+	} else {
+		for _, d := range deletedDefs {
+			m.findCache.InvalidateFor(orgId, d.NameWithTags())
+		}
 	}
 	return deletedDefs, nil
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -56,6 +56,7 @@ var (
 	indexRulesFile      string
 	IndexRules          conf.IndexRules
 	Partitioned         bool
+	findCacheSize       = 1000
 )
 
 func ConfigSetup() {
@@ -65,6 +66,7 @@ func ConfigSetup() {
 	memoryIdx.BoolVar(&Partitioned, "partitioned", false, "use separate indexes per partition")
 	memoryIdx.IntVar(&TagQueryWorkers, "tag-query-workers", 50, "number of workers to spin up to evaluate tag queries")
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
+	memoryIdx.IntVar(&findCacheSize, "find-cache-size", 1000, "number of find expressions to cache")
 	memoryIdx.StringVar(&indexRulesFile, "rules-file", "/etc/metrictank/index-rules.conf", "path to index-rules.conf file")
 	memoryIdx.StringVar(&maxPruneLockTimeStr, "max-prune-lock-time", "100ms", "Maximum duration each second a prune job can lock the index.")
 	globalconf.Register("memory-idx", memoryIdx, flag.ExitOnError)
@@ -233,6 +235,8 @@ type UnpartitionedMemoryIdx struct {
 	// used by tag index
 	defByTagSet defByTagSet
 	tags        map[uint32]TagIndex // by orgId
+
+	findCache *FindCache
 }
 
 func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
@@ -241,6 +245,7 @@ func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
 		defByTagSet: make(defByTagSet),
 		tree:        make(map[uint32]*Tree),
 		tags:        make(map[uint32]TagIndex),
+		findCache:   NewFindCache(findCacheSize),
 	}
 }
 
@@ -452,6 +457,11 @@ func (m *UnpartitionedMemoryIdx) add(def *schema.MetricDefinition) idx.Archive {
 		}
 		return *archive
 	}
+
+	// invalidate any findCache items that match this series name
+	defer func() {
+		go m.findCache.InvalidateFor(def.OrgId, path)
+	}()
 
 	//first check to see if a tree has been created for this OrgId
 	tree, ok := m.tree[def.OrgId]
@@ -943,18 +953,36 @@ func (m *UnpartitionedMemoryIdx) idsByTagQuery(orgId uint32, query TagQuery) IdS
 
 func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, error) {
 	pre := time.Now()
+	var matchedNodes []*Node
+	var err error
 	m.RLock()
 	defer m.RUnlock()
-	matchedNodes, err := m.find(orgId, pattern)
-	if err != nil {
-		return nil, err
+	tree, ok := m.tree[orgId]
+	if !ok {
+		log.Debugf("memory-idx: orgId %d has no metrics indexed.", orgId)
+	} else {
+		matchedNodes, ok = m.findCache.Get(orgId, pattern)
+		if !ok {
+			matchedNodes, err = find(tree, pattern)
+			if err != nil {
+				return nil, err
+			}
+			m.findCache.Add(orgId, pattern, matchedNodes)
+		}
 	}
 	if orgId != idx.OrgIdPublic && idx.OrgIdPublic > 0 {
-		publicNodes, err := m.find(idx.OrgIdPublic, pattern)
-		if err != nil {
-			return nil, err
+		tree, ok = m.tree[idx.OrgIdPublic]
+		if ok {
+			publicNodes, ok := m.findCache.Get(idx.OrgIdPublic, pattern)
+			if !ok {
+				publicNodes, err = find(tree, pattern)
+				if err != nil {
+					return nil, err
+				}
+				m.findCache.Add(idx.OrgIdPublic, pattern, publicNodes)
+			}
+			matchedNodes = append(matchedNodes, publicNodes...)
 		}
-		matchedNodes = append(matchedNodes, publicNodes...)
 	}
 	log.Debugf("memory-idx: %d nodes matching pattern %s found", len(matchedNodes), pattern)
 	results := make([]idx.Node, 0)
@@ -997,14 +1025,8 @@ func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from int64) 
 	return results, nil
 }
 
-// find returns all Nodes matching the pattern for the given orgId
-func (m *UnpartitionedMemoryIdx) find(orgId uint32, pattern string) ([]*Node, error) {
-	tree, ok := m.tree[orgId]
-	if !ok {
-		log.Debugf("memory-idx: orgId %d has no metrics indexed.", orgId)
-		return nil, nil
-	}
-
+// find returns all Nodes matching the pattern for the given tree
+func find(tree *Tree, pattern string) ([]*Node, error) {
 	var nodes []string
 	if strings.Index(pattern, ";") == -1 {
 		nodes = strings.Split(pattern, ".")
@@ -1031,17 +1053,17 @@ func (m *UnpartitionedMemoryIdx) find(orgId uint32, pattern string) ([]*Node, er
 	if pos != 0 {
 		branch = strings.Join(nodes[:pos], ".")
 	}
-	log.Debugf("memory-idx: starting search at orgId %d, node %q", orgId, branch)
+	log.Debugf("memory-idx: starting search at node %q", branch)
 	startNode, ok := tree.Items[branch]
 
 	if !ok {
-		log.Debugf("memory-idx: branch %q does not exist in the index for orgId %d", branch, orgId)
+		log.Debugf("memory-idx: branch %q does not exist in the index", branch)
 		return nil, nil
 	}
 
 	if startNode == nil {
 		corruptIndex.Inc()
-		log.Errorf("memory-idx: startNode is nil. org=%d,patt=%q,pos=%d,branch=%q", orgId, pattern, pos, branch)
+		log.Errorf("memory-idx: startNode is nil. patt=%q,pos=%d,branch=%q", pattern, pos, branch)
 		return nil, errors.NewInternal("hit an empty path in the index")
 	}
 
@@ -1072,7 +1094,7 @@ func (m *UnpartitionedMemoryIdx) find(orgId uint32, pattern string) ([]*Node, er
 				grandChild := tree.Items[newBranch]
 				if grandChild == nil {
 					corruptIndex.Inc()
-					log.Errorf("memory-idx: grandChild is nil. org=%d,patt=%q,i=%d,pos=%d,p=%q,path=%q", orgId, pattern, i, pos, p, newBranch)
+					log.Errorf("memory-idx: grandChild is nil. patt=%q,i=%d,pos=%d,p=%q,path=%q", pattern, i, pos, p, newBranch)
 					return nil, errors.NewInternal("hit an empty path in the index")
 				}
 
@@ -1180,7 +1202,11 @@ func (m *UnpartitionedMemoryIdx) Delete(orgId uint32, pattern string) ([]idx.Arc
 	pre := time.Now()
 	m.Lock()
 	defer m.Unlock()
-	found, err := m.find(orgId, pattern)
+	tree, ok := m.tree[orgId]
+	if !ok {
+		return nil, nil
+	}
+	found, err := find(tree, pattern)
 	if err != nil {
 		return nil, err
 	}
@@ -1192,7 +1218,9 @@ func (m *UnpartitionedMemoryIdx) Delete(orgId uint32, pattern string) ([]idx.Arc
 
 	statMetricsActive.Set(len(m.defById))
 	statDeleteDuration.Value(time.Since(pre))
-
+	if len(deletedDefs) > 0 {
+		m.findCache.Purge(orgId)
+	}
 	return deletedDefs, nil
 }
 
@@ -1411,8 +1439,8 @@ ORGS:
 			m.Unlock()
 			tl.Add(time.Since(lockStart))
 			pruned = append(pruned, defs...)
-
 		}
+		m.findCache.Purge(org)
 	}
 
 	statMetricsActive.Set(len(m.defById))

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -47,15 +47,18 @@ var (
 	// metric idx.metrics_active is the number of currently known metrics in the index
 	statMetricsActive = stats.NewGauge32("idx.metrics_active")
 
-	Enabled             bool
-	matchCacheSize      int
-	maxPruneLockTime    = time.Millisecond * 100
-	maxPruneLockTimeStr string
-	TagSupport          bool
-	TagQueryWorkers     int // number of workers to spin up when evaluation tag expressions
-	indexRulesFile      string
-	IndexRules          conf.IndexRules
-	Partitioned         bool
+	Enabled                  bool
+	matchCacheSize           int
+	maxPruneLockTime         = time.Millisecond * 100
+	maxPruneLockTimeStr      string
+	TagSupport               bool
+	TagQueryWorkers          int // number of workers to spin up when evaluation tag expressions
+	indexRulesFile           string
+	IndexRules               conf.IndexRules
+	Partitioned              bool
+	findCacheSize            = 1000
+	findCacheInvalidateQueue = 100
+	findCacheBackoff         = time.Minute
 )
 
 func ConfigSetup() {
@@ -247,7 +250,7 @@ func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
 		defByTagSet: make(defByTagSet),
 		tree:        make(map[uint32]*Tree),
 		tags:        make(map[uint32]TagIndex),
-		findCache:   NewFindCache(findCacheSize),
+		findCache:   NewFindCache(findCacheSize, findCacheInvalidateQueue, findCacheBackoff),
 	}
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -56,7 +56,6 @@ var (
 	indexRulesFile      string
 	IndexRules          conf.IndexRules
 	Partitioned         bool
-	findCacheSize       = 1000
 )
 
 func ConfigSetup() {
@@ -67,6 +66,8 @@ func ConfigSetup() {
 	memoryIdx.IntVar(&TagQueryWorkers, "tag-query-workers", 50, "number of workers to spin up to evaluate tag queries")
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
 	memoryIdx.IntVar(&findCacheSize, "find-cache-size", 1000, "number of find expressions to cache")
+	memoryIdx.IntVar(&findCacheInvalidateQueue, "find-cache-invalidate-queue", 100, "size of queue for invalidating findCache entries.")
+	memoryIdx.DurationVar(&findCacheBackoff, "find-cache-backoff", time.Minute, "amount of time to disable the findCache when the invalidate queue fills up.")
 	memoryIdx.StringVar(&indexRulesFile, "rules-file", "/etc/metrictank/index-rules.conf", "path to index-rules.conf file")
 	memoryIdx.StringVar(&maxPruneLockTimeStr, "max-prune-lock-time", "100ms", "Maximum duration each second a prune job can lock the index.")
 	globalconf.Register("memory-idx", memoryIdx, flag.ExitOnError)

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -463,7 +463,6 @@ func (m *UnpartitionedMemoryIdx) add(def *schema.MetricDefinition) idx.Archive {
 		return *archive
 	}
 
-	// invalidate any findCache items that match this series name
 	defer func() {
 		go m.findCache.InvalidateFor(def.OrgId, path)
 	}()

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/metrictank/cluster"
 	"github.com/raintank/schema"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -155,6 +156,8 @@ func TestMain(m *testing.M) {
 	TagSupport = true
 	TagQueryWorkers = 5
 	matchCacheSize = 1000
+	// we dont need info logs in the test output
+	log.SetLevel(log.ErrorLevel)
 	os.Exit(m.Run())
 }
 

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -401,6 +401,10 @@ max-prune-lock-time = 100ms
 partitioned = false
 # number of find expressions to cache
 find-cache-size = 1000
+# size of queue for invalidating findCache entries.
+find-cache-invalidate-queue = 100
+# amount of time to disable the findCache when the invalidate queue fills up
+find-cache-backoff = 60s
 
 ### Bigtable index
 [bigtable-idx]

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -399,6 +399,8 @@ rules-file = /etc/metrictank/index-rules.conf
 max-prune-lock-time = 100ms
 # use separate indexes per partition
 partitioned = false
+# number of find expressions to cache
+find-cache-size = 1000
 
 ### Bigtable index
 [bigtable-idx]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -396,6 +396,8 @@ rules-file = /etc/metrictank/index-rules.conf
 max-prune-lock-time = 100ms
 # use separate indexes per partition
 partitioned = false
+# number of find expressions to cache
+find-cache-size = 1000
 
 ### Bigtable index
 [bigtable-idx]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -398,6 +398,10 @@ max-prune-lock-time = 100ms
 partitioned = false
 # number of find expressions to cache
 find-cache-size = 1000
+# size of queue for invalidating findCache entries.
+find-cache-invalidate-queue = 100
+# amount of time to disable the findCache when the invalidate queue fills up
+find-cache-backoff = 60s
 
 ### Bigtable index
 [bigtable-idx]

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -396,6 +396,8 @@ rules-file = /etc/metrictank/index-rules.conf
 max-prune-lock-time = 100ms
 # use separate indexes per partition
 partitioned = false
+# number of find expressions to cache
+find-cache-size = 1000
 
 ### Bigtable index
 [bigtable-idx]

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -398,6 +398,10 @@ max-prune-lock-time = 100ms
 partitioned = false
 # number of find expressions to cache
 find-cache-size = 1000
+# size of queue for invalidating findCache entries.
+find-cache-invalidate-queue = 100
+# amount of time to disable the findCache when the invalidate queue fills up
+find-cache-backoff = 60s
 
 ### Bigtable index
 [bigtable-idx]

--- a/vendor/github.com/hashicorp/golang-lru/2q.go
+++ b/vendor/github.com/hashicorp/golang-lru/2q.go
@@ -1,0 +1,223 @@
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+const (
+	// Default2QRecentRatio is the ratio of the 2Q cache dedicated
+	// to recently added entries that have only been accessed once.
+	Default2QRecentRatio = 0.25
+
+	// Default2QGhostEntries is the default ratio of ghost
+	// entries kept to track entries recently evicted
+	Default2QGhostEntries = 0.50
+)
+
+// TwoQueueCache is a thread-safe fixed size 2Q cache.
+// 2Q is an enhancement over the standard LRU cache
+// in that it tracks both frequently and recently used
+// entries separately. This avoids a burst in access to new
+// entries from evicting frequently used entries. It adds some
+// additional tracking overhead to the standard LRU cache, and is
+// computationally about 2x the cost, and adds some metadata over
+// head. The ARCCache is similar, but does not require setting any
+// parameters.
+type TwoQueueCache struct {
+	size       int
+	recentSize int
+
+	recent      simplelru.LRUCache
+	frequent    simplelru.LRUCache
+	recentEvict simplelru.LRUCache
+	lock        sync.RWMutex
+}
+
+// New2Q creates a new TwoQueueCache using the default
+// values for the parameters.
+func New2Q(size int) (*TwoQueueCache, error) {
+	return New2QParams(size, Default2QRecentRatio, Default2QGhostEntries)
+}
+
+// New2QParams creates a new TwoQueueCache using the provided
+// parameter values.
+func New2QParams(size int, recentRatio float64, ghostRatio float64) (*TwoQueueCache, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid size")
+	}
+	if recentRatio < 0.0 || recentRatio > 1.0 {
+		return nil, fmt.Errorf("invalid recent ratio")
+	}
+	if ghostRatio < 0.0 || ghostRatio > 1.0 {
+		return nil, fmt.Errorf("invalid ghost ratio")
+	}
+
+	// Determine the sub-sizes
+	recentSize := int(float64(size) * recentRatio)
+	evictSize := int(float64(size) * ghostRatio)
+
+	// Allocate the LRUs
+	recent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	frequent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	recentEvict, err := simplelru.NewLRU(evictSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the cache
+	c := &TwoQueueCache{
+		size:        size,
+		recentSize:  recentSize,
+		recent:      recent,
+		frequent:    frequent,
+		recentEvict: recentEvict,
+	}
+	return c, nil
+}
+
+// Get looks up a key's value from the cache.
+func (c *TwoQueueCache) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if this is a frequent value
+	if val, ok := c.frequent.Get(key); ok {
+		return val, ok
+	}
+
+	// If the value is contained in recent, then we
+	// promote it to frequent
+	if val, ok := c.recent.Peek(key); ok {
+		c.recent.Remove(key)
+		c.frequent.Add(key, val)
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+// Add adds a value to the cache.
+func (c *TwoQueueCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is frequently used already,
+	// and just update the value
+	if c.frequent.Contains(key) {
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Check if the value is recently used, and promote
+	// the value into the frequent list
+	if c.recent.Contains(key) {
+		c.recent.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// If the value was recently evicted, add it to the
+	// frequently used list
+	if c.recentEvict.Contains(key) {
+		c.ensureSpace(true)
+		c.recentEvict.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Add to the recently seen list
+	c.ensureSpace(false)
+	c.recent.Add(key, value)
+	return
+}
+
+// ensureSpace is used to ensure we have space in the cache
+func (c *TwoQueueCache) ensureSpace(recentEvict bool) {
+	// If we have space, nothing to do
+	recentLen := c.recent.Len()
+	freqLen := c.frequent.Len()
+	if recentLen+freqLen < c.size {
+		return
+	}
+
+	// If the recent buffer is larger than
+	// the target, evict from there
+	if recentLen > 0 && (recentLen > c.recentSize || (recentLen == c.recentSize && !recentEvict)) {
+		k, _, _ := c.recent.RemoveOldest()
+		c.recentEvict.Add(k, nil)
+		return
+	}
+
+	// Remove from the frequent list otherwise
+	c.frequent.RemoveOldest()
+}
+
+// Len returns the number of items in the cache.
+func (c *TwoQueueCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.recent.Len() + c.frequent.Len()
+}
+
+// Keys returns a slice of the keys in the cache.
+// The frequently used keys are first in the returned slice.
+func (c *TwoQueueCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.frequent.Keys()
+	k2 := c.recent.Keys()
+	return append(k1, k2...)
+}
+
+// Remove removes the provided key from the cache.
+func (c *TwoQueueCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.frequent.Remove(key) {
+		return
+	}
+	if c.recent.Remove(key) {
+		return
+	}
+	if c.recentEvict.Remove(key) {
+		return
+	}
+}
+
+// Purge is used to completely clear the cache.
+func (c *TwoQueueCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.recent.Purge()
+	c.frequent.Purge()
+	c.recentEvict.Purge()
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (c *TwoQueueCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.frequent.Contains(key) || c.recent.Contains(key)
+}
+
+// Peek is used to inspect the cache value of a key
+// without updating recency or frequency.
+func (c *TwoQueueCache) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.frequent.Peek(key); ok {
+		return val, ok
+	}
+	return c.recent.Peek(key)
+}

--- a/vendor/github.com/hashicorp/golang-lru/LICENSE
+++ b/vendor/github.com/hashicorp/golang-lru/LICENSE
@@ -1,0 +1,362 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/hashicorp/golang-lru/arc.go
+++ b/vendor/github.com/hashicorp/golang-lru/arc.go
@@ -1,0 +1,257 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// ARCCache is a thread-safe fixed size Adaptive Replacement Cache (ARC).
+// ARC is an enhancement over the standard LRU cache in that tracks both
+// frequency and recency of use. This avoids a burst in access to new
+// entries from evicting the frequently used older entries. It adds some
+// additional tracking overhead to a standard LRU cache, computationally
+// it is roughly 2x the cost, and the extra memory overhead is linear
+// with the size of the cache. ARC has been patented by IBM, but is
+// similar to the TwoQueueCache (2Q) which requires setting parameters.
+type ARCCache struct {
+	size int // Size is the total capacity of the cache
+	p    int // P is the dynamic preference towards T1 or T2
+
+	t1 simplelru.LRUCache // T1 is the LRU for recently accessed items
+	b1 simplelru.LRUCache // B1 is the LRU for evictions from t1
+
+	t2 simplelru.LRUCache // T2 is the LRU for frequently accessed items
+	b2 simplelru.LRUCache // B2 is the LRU for evictions from t2
+
+	lock sync.RWMutex
+}
+
+// NewARC creates an ARC of the given size
+func NewARC(size int) (*ARCCache, error) {
+	// Create the sub LRUs
+	b1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the ARC
+	c := &ARCCache{
+		size: size,
+		p:    0,
+		t1:   t1,
+		b1:   b1,
+		t2:   t2,
+		b2:   b2,
+	}
+	return c, nil
+}
+
+// Get looks up a key's value from the cache.
+func (c *ARCCache) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// If the value is contained in T1 (recent), then
+	// promote it to T2 (frequent)
+	if val, ok := c.t1.Peek(key); ok {
+		c.t1.Remove(key)
+		c.t2.Add(key, val)
+		return val, ok
+	}
+
+	// Check if the value is contained in T2 (frequent)
+	if val, ok := c.t2.Get(key); ok {
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+// Add adds a value to the cache.
+func (c *ARCCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is contained in T1 (recent), and potentially
+	// promote it to frequent T2
+	if c.t1.Contains(key) {
+		c.t1.Remove(key)
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if the value is already in T2 (frequent) and update it
+	if c.t2.Contains(key) {
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// recently used list
+	if c.b1.Contains(key) {
+		// T1 set is too small, increase P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b2Len > b1Len {
+			delta = b2Len / b1Len
+		}
+		if c.p+delta >= c.size {
+			c.p = c.size
+		} else {
+			c.p += delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(false)
+		}
+
+		// Remove from B1
+		c.b1.Remove(key)
+
+		// Add the key to the frequently used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// frequently used list
+	if c.b2.Contains(key) {
+		// T2 set is too small, decrease P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b1Len > b2Len {
+			delta = b1Len / b2Len
+		}
+		if delta >= c.p {
+			c.p = 0
+		} else {
+			c.p -= delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(true)
+		}
+
+		// Remove from B2
+		c.b2.Remove(key)
+
+		// Add the key to the frequently used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Potentially need to make room in the cache
+	if c.t1.Len()+c.t2.Len() >= c.size {
+		c.replace(false)
+	}
+
+	// Keep the size of the ghost buffers trim
+	if c.b1.Len() > c.size-c.p {
+		c.b1.RemoveOldest()
+	}
+	if c.b2.Len() > c.p {
+		c.b2.RemoveOldest()
+	}
+
+	// Add to the recently seen list
+	c.t1.Add(key, value)
+	return
+}
+
+// replace is used to adaptively evict from either T1 or T2
+// based on the current learned value of P
+func (c *ARCCache) replace(b2ContainsKey bool) {
+	t1Len := c.t1.Len()
+	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
+		k, _, ok := c.t1.RemoveOldest()
+		if ok {
+			c.b1.Add(k, nil)
+		}
+	} else {
+		k, _, ok := c.t2.RemoveOldest()
+		if ok {
+			c.b2.Add(k, nil)
+		}
+	}
+}
+
+// Len returns the number of cached entries
+func (c *ARCCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Len() + c.t2.Len()
+}
+
+// Keys returns all the cached keys
+func (c *ARCCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.t1.Keys()
+	k2 := c.t2.Keys()
+	return append(k1, k2...)
+}
+
+// Remove is used to purge a key from the cache
+func (c *ARCCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.t1.Remove(key) {
+		return
+	}
+	if c.t2.Remove(key) {
+		return
+	}
+	if c.b1.Remove(key) {
+		return
+	}
+	if c.b2.Remove(key) {
+		return
+	}
+}
+
+// Purge is used to clear the cache
+func (c *ARCCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.t1.Purge()
+	c.t2.Purge()
+	c.b1.Purge()
+	c.b2.Purge()
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (c *ARCCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Contains(key) || c.t2.Contains(key)
+}
+
+// Peek is used to inspect the cache value of a key
+// without updating recency or frequency.
+func (c *ARCCache) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.t1.Peek(key); ok {
+		return val, ok
+	}
+	return c.t2.Peek(key)
+}

--- a/vendor/github.com/hashicorp/golang-lru/doc.go
+++ b/vendor/github.com/hashicorp/golang-lru/doc.go
@@ -1,0 +1,21 @@
+// Package lru provides three different LRU caches of varying sophistication.
+//
+// Cache is a simple LRU cache. It is based on the
+// LRU implementation in groupcache:
+// https://github.com/golang/groupcache/tree/master/lru
+//
+// TwoQueueCache tracks frequently used and recently used entries separately.
+// This avoids a burst of accesses from taking out frequently used entries,
+// at the cost of about 2x computational overhead and some extra bookkeeping.
+//
+// ARCCache is an adaptive replacement cache. It tracks recent evictions as
+// well as recent usage in both the frequent and recent caches. Its
+// computational overhead is comparable to TwoQueueCache, but the memory
+// overhead is linear with the size of the cache.
+//
+// ARC has been patented by IBM, so do not use it if that is problematic for
+// your program.
+//
+// All caches in this package take locks while operating, and are therefore
+// thread-safe for consumers.
+package lru

--- a/vendor/github.com/hashicorp/golang-lru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/lru.go
@@ -1,0 +1,116 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	lru  simplelru.LRUCache
+	lock sync.RWMutex
+}
+
+// New creates an LRU of the given size.
+func New(size int) (*Cache, error) {
+	return NewWithEvict(size, nil)
+}
+
+// NewWithEvict constructs a fixed size cache with the given eviction
+// callback.
+func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) (*Cache, error) {
+	lru, err := simplelru.NewLRU(size, simplelru.EvictCallback(onEvicted))
+	if err != nil {
+		return nil, err
+	}
+	c := &Cache{
+		lru: lru,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache.
+func (c *Cache) Purge() {
+	c.lock.Lock()
+	c.lru.Purge()
+	c.lock.Unlock()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *Cache) Add(key, value interface{}) (evicted bool) {
+	c.lock.Lock()
+	evicted = c.lru.Add(key, value)
+	c.lock.Unlock()
+	return evicted
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	value, ok = c.lru.Get(key)
+	c.lock.Unlock()
+	return value, ok
+}
+
+// Contains checks if a key is in the cache, without updating the
+// recent-ness or deleting it for being stale.
+func (c *Cache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	containKey := c.lru.Contains(key)
+	c.lock.RUnlock()
+	return containKey
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *Cache) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.RLock()
+	value, ok = c.lru.Peek(key)
+	c.lock.RUnlock()
+	return value, ok
+}
+
+// ContainsOrAdd checks if a key is in the cache  without updating the
+// recent-ness or deleting it for being stale,  and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evicted bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.lru.Contains(key) {
+		return true, false
+	}
+	evicted = c.lru.Add(key, value)
+	return false, evicted
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key interface{}) {
+	c.lock.Lock()
+	c.lru.Remove(key)
+	c.lock.Unlock()
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	c.lock.Lock()
+	c.lru.RemoveOldest()
+	c.lock.Unlock()
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *Cache) Keys() []interface{} {
+	c.lock.RLock()
+	keys := c.lru.Keys()
+	c.lock.RUnlock()
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	length := c.lru.Len()
+	c.lock.RUnlock()
+	return length
+}

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -1,0 +1,161 @@
+package simplelru
+
+import (
+	"container/list"
+	"errors"
+)
+
+// EvictCallback is used to get a callback when a cache entry is evicted
+type EvictCallback func(key interface{}, value interface{})
+
+// LRU implements a non-thread safe fixed size LRU cache
+type LRU struct {
+	size      int
+	evictList *list.List
+	items     map[interface{}]*list.Element
+	onEvict   EvictCallback
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key   interface{}
+	value interface{}
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c := &LRU{
+		size:      size,
+		evictList: list.New(),
+		items:     make(map[interface{}]*list.Element),
+		onEvict:   onEvict,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache.
+func (c *LRU) Purge() {
+	for k, v := range c.items {
+		if c.onEvict != nil {
+			c.onEvict(k, v.Value.(*entry).value)
+		}
+		delete(c.items, k)
+	}
+	c.evictList.Init()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *LRU) Add(key, value interface{}) (evicted bool) {
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*entry).value = value
+		return false
+	}
+
+	// Add new item
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	evict := c.evictList.Len() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		return ent.Value.(*entry).value, true
+	}
+	return
+}
+
+// Contains checks if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *LRU) Contains(key interface{}) (ok bool) {
+	_, ok = c.items[key]
+	return ok
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+	var ent *list.Element
+	if ent, ok = c.items[key]; ok {
+		return ent.Value.(*entry).value, true
+	}
+	return nil, ok
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU) Remove(key interface{}) (present bool) {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *LRU) RemoveOldest() (key interface{}, value interface{}, ok bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// GetOldest returns the oldest entry
+func (c *LRU) GetOldest() (key interface{}, value interface{}, ok bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *LRU) Keys() []interface{} {
+	keys := make([]interface{}, len(c.items))
+	i := 0
+	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
+		keys[i] = ent.Value.(*entry).key
+		i++
+	}
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *LRU) Len() int {
+	return c.evictList.Len()
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.items, kv.key)
+	if c.onEvict != nil {
+		c.onEvict(kv.key, kv.value)
+	}
+}

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
@@ -1,0 +1,36 @@
+package simplelru
+
+// LRUCache is the interface for simple LRU cache.
+type LRUCache interface {
+	// Adds a value to the cache, returns true if an eviction occurred and
+	// updates the "recently used"-ness of the key.
+	Add(key, value interface{}) bool
+
+	// Returns key's value from the cache and
+	// updates the "recently used"-ness of the key. #value, isFound
+	Get(key interface{}) (value interface{}, ok bool)
+
+	// Check if a key exsists in cache without updating the recent-ness.
+	Contains(key interface{}) (ok bool)
+
+	// Returns key's value without updating the "recently used"-ness of the key.
+	Peek(key interface{}) (value interface{}, ok bool)
+
+	// Removes a key from the cache.
+	Remove(key interface{}) bool
+
+	// Removes the oldest entry from cache.
+	RemoveOldest() (interface{}, interface{}, bool)
+
+	// Returns the oldest entry from the cache. #key, value, isFound
+	GetOldest() (interface{}, interface{}, bool)
+
+	// Returns a slice of the keys in the cache, from oldest to newest.
+	Keys() []interface{}
+
+	// Returns the number of items in the cache.
+	Len() int
+
+	// Clear all cache entries
+	Purge()
+}


### PR DESCRIPTION
Cache patterns and their results in a LRU.
When new defs are added to the index, only cached patterns that match
the new series name are invalidated.  The cache is purged after every
prune task runs and after any call to delete items from the index.