### PR TITLE
make archive table not required for MT startup

### DIFF
--- a/cmd/mt-index-prune/main.go
+++ b/cmd/mt-index-prune/main.go
@@ -110,6 +110,8 @@ func main() {
 	cassIdx := cassandra.New(cassandra.CliConfig)
 	err = cassIdx.InitBare()
 	perror(err)
+	err = cassIdx.EnsureArchiveTableExists(nil)
+	perror(err)
 
 	// we don't want to filter any metric definitions during the loading
 	// so MaxStale is set to 0

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -170,7 +170,7 @@ func (c *CasIdx) InitBare() error {
 }
 
 // EnsureArchiveTableExists checks if the index archive table exists or not. If it does not exist and
-// the create-keyspace flag is true, then it will create it, if it does exist and the create-keyspace
+// the create-keyspace flag is true, then it will create it, if it doesn't exist and the create-keyspace
 // flag is false, then it will return an error. If the table exists then it just returns nil.
 // The index archive table is not required for Metrictank to run, it's only required by the
 // mt-index-prune utility to archive old metrics from the index.

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -119,7 +119,6 @@ func (c *CasIdx) InitBare() error {
 	// read templates
 	schemaKeyspace := util.ReadEntry(c.cfg.schemaFile, "schema_keyspace").(string)
 	schemaTable := util.ReadEntry(c.cfg.schemaFile, "schema_table").(string)
-	schemaArchiveTable := util.ReadEntry(c.cfg.schemaFile, "schema_archive_table").(string)
 
 	// create the keyspace or ensure it exists
 	if c.cfg.createKeyspace {
@@ -133,11 +132,7 @@ func (c *CasIdx) InitBare() error {
 		if err != nil {
 			return fmt.Errorf("failed to initialize cassandra table: %s", err)
 		}
-		log.Info("cassandra-idx: ensuring that table metric_idx_archive exists.")
-		err = tmpSession.Query(fmt.Sprintf(schemaArchiveTable, c.cfg.keyspace)).Exec()
-		if err != nil {
-			return fmt.Errorf("failed to initialize cassandra table: %s", err)
-		}
+		c.EnsureArchiveTableExists(tmpSession)
 	} else {
 		var keyspaceMetadata *gocql.KeyspaceMetadata
 		for attempt := 1; attempt > 0; attempt++ {
@@ -149,9 +144,7 @@ func (c *CasIdx) InitBare() error {
 				log.Warnf("cassandra-idx: cassandra keyspace not found. retrying in 5s. attempt: %d", attempt)
 				time.Sleep(5 * time.Second)
 			} else {
-				_, okIdx := keyspaceMetadata.Tables["metric_idx"]
-				_, okArchive := keyspaceMetadata.Tables["metric_idx_archive"]
-				if okIdx && okArchive {
+				if _, ok := keyspaceMetadata.Tables["metric_idx"]; ok {
 					break
 				} else {
 					if attempt >= 5 {
@@ -173,6 +166,36 @@ func (c *CasIdx) InitBare() error {
 
 	c.session = session
 
+	return nil
+}
+
+func (c *CasIdx) EnsureArchiveTableExists(session *gocql.Session) error {
+	var err error
+	if session == nil {
+		session, err = c.cluster.CreateSession()
+		if err != nil {
+			return fmt.Errorf("failed to create cassandra session: %s", err)
+		}
+	}
+
+	schemaArchiveTable := util.ReadEntry(c.cfg.schemaFile, "schema_archive_table").(string)
+
+	if c.cfg.createKeyspace {
+		log.Info("cassandra-idx: ensuring that table metric_idx_archive exists.")
+		err = session.Query(fmt.Sprintf(schemaArchiveTable, c.cfg.keyspace)).Exec()
+		if err != nil {
+			return fmt.Errorf("failed to initialize cassandra table: %s", err)
+		}
+	} else {
+		var keyspaceMetadata *gocql.KeyspaceMetadata
+		keyspaceMetadata, err = session.KeyspaceMetadata(c.cfg.keyspace)
+		if err != nil {
+			return fmt.Errorf("failed to read cassandra tables: %s", err)
+		}
+		if _, ok := keyspaceMetadata.Tables["metric_idx_archive"]; !ok {
+			return fmt.Errorf("table metric_idx_archive does not exist")
+		}
+	}
 	return nil
 }
 

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -169,6 +169,11 @@ func (c *CasIdx) InitBare() error {
 	return nil
 }
 
+// EnsureArchiveTableExists checks if the index archive table exists or not. If it does not exist and
+// the create-keyspace flag is true, then it will create it, if it does exist and the create-keyspace
+// flag is false, then it will return an error. If the table exists then it just returns nil.
+// The index archive table is not required for Metrictank to run, it's only required by the
+// mt-index-prune utility to archive old metrics from the index.
 func (c *CasIdx) EnsureArchiveTableExists(session *gocql.Session) error {
 	var err error
 	if session == nil {


### PR DESCRIPTION
With this change, on startup MT will still create the `mt_index_archive` table if the `create-keyspace` flag is `true`. But if it is `false` it won't error on startup, because actually that table is not required for it to run, it's only required for the `mt-index-prune` utility.

Fixes: #1234 