### PR TITLE
handle consolidateBy in a more graphite like way

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -666,7 +666,6 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 					var cons consolidation.Consolidator
 					consReq := r.Cons
 					if consReq == 0 {
-						// unless the user overrode the consolidation to use via a consolidateBy
 						// we will use the primary method dictated by the storage-aggregations rules
 						// note:
 						// * we can't just let the expr library take care of normalization, as we may have to fetch targets
@@ -675,6 +674,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 						fn := mdata.Aggregations.Get(archive.AggId).AggregationMethod[0]
 						cons = consolidation.Consolidator(fn) // we use the same number assignments so we can cast them
 					} else {
+						// user specified a runtime consolidation function via consolidateBy()
 						// get the consolidation method of the most appropriate rollup based on the consolidation method
 						// requested by the user.  e.g. if the user requested 'min' but we only have 'avg' and 'sum' rollups,
 						// use 'avg'.

--- a/api/models/request.go
+++ b/api/models/request.go
@@ -23,7 +23,7 @@ type Req struct {
 	MaxPoints    uint32                     `json:"maxPoints"`
 	RawInterval  uint32                     `json:"rawInterval"`  // the interval of the raw metric before any consolidation
 	Consolidator consolidation.Consolidator `json:"consolidator"` // consolidation method for rollup archive and normalization. (not runtime consolidation)
-	// requested consolidation method: either same as Consolidator, or 0 (meaning use configured default)
+	// requested consolidation method. could be 0 (meaning use configured default)
 	// we need to make this differentiation to tie back to the original request (and we can't just fill in the concrete consolidation in the request,
 	// because one request may result in multiple series with different consolidators)
 	ConsReq  consolidation.Consolidator `json:"consolidator_req"`


### PR DESCRIPTION
- treat consolidateBy() as a hint for rollup selection.  If we dont
  have a rollup that matches the requested ConsolidateBy, then we
  use the most appropriate rollup from what is available.
- fixes #1067