### PR TITLE
Make cluster mode configurable

### DIFF
--- a/scripts/k8s/entrypoint.sh
+++ b/scripts/k8s/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 # set cluster PEERs
 if [ ! -z "$LABEL_SELECTOR" ]; then
-	export MT_CLUSTER_MODE=${MT_CLUSTER_MODE:-"shard"}
+	export MT_CLUSTER_MODE=${MT_CLUSTER_MODE:-shard}
 	POD_NAMESPACE=${POD_NAMESPACE:-default}
 	SERVICE_NAME=${SERVICE_NAME:-metrictank}
 	if [ ! -z $KUBERNETES_SERVICE_PORT_HTTP ]; then

--- a/scripts/k8s/entrypoint.sh
+++ b/scripts/k8s/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 # set cluster PEERs
 if [ ! -z "$LABEL_SELECTOR" ]; then
-	export MT_CLUSTER_MODE="shard"
+	export MT_CLUSTER_MODE=${MT_CLUSTER_MODE:-"shard"}
 	POD_NAMESPACE=${POD_NAMESPACE:-default}
 	SERVICE_NAME=${SERVICE_NAME:-metrictank}
 	if [ ! -z $KUBERNETES_SERVICE_PORT_HTTP ]; then


### PR DESCRIPTION
We want to be able to set the cluster mode via the environment, so this change is necessary to prevent that it always gets set to `shard`.