### PR TITLE
Guard high hitting log statements to prevent unnecessary allocs

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -296,7 +296,9 @@ func (m *UnpartitionedMemoryIdx) Update(point schema.MetricPoint, partition int3
 
 	existing, ok := m.defById[point.MKey]
 	if ok {
-		log.Debugf("memory-idx: metricDef with id %v already in index", point.MKey)
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("memory-idx: metricDef with id %v already in index", point.MKey)
+		}
 
 		bumpLastUpdate(&existing.LastUpdate, int64(point.Time))
 
@@ -320,7 +322,9 @@ func (m *UnpartitionedMemoryIdx) AddOrUpdate(mkey schema.MKey, data *schema.Metr
 
 	existing, ok := m.defById[mkey]
 	if ok {
-		log.Debugf("memory-idx: metricDef with id %s already in index.", mkey)
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("memory-idx: metricDef with id %s already in index.", mkey)
+		}
 		bumpLastUpdate(&existing.LastUpdate, data.Time)
 		oldPart := atomic.SwapInt32(&existing.Partition, partition)
 		statUpdate.Inc()

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -293,7 +293,9 @@ func (k *KafkaMdm) consumePartition(topic string, partition int32, currentOffset
 				k.cancel()
 				return
 			}
-			log.Debugf("kafkamdm: received message: Topic %s, Partition: %d, Offset: %d, Key: %x", msg.Topic, msg.Partition, msg.Offset, msg.Key)
+			if log.IsLevelEnabled(log.DebugLevel) {
+				log.Debugf("kafkamdm: received message: Topic %s, Partition: %d, Offset: %d, Key: %x", msg.Topic, msg.Partition, msg.Offset, msg.Key)
+			}
 			k.handleMsg(msg.Value, partition)
 			kafkaStats.Offset.Set(int(msg.Offset))
 		case <-k.shutdown:

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -467,7 +467,10 @@ func (a *AggMetric) add(ts uint32, val float64) {
 		}
 		totalPoints.Inc()
 		a.lastWrite = uint32(time.Now().Unix())
-		log.Debugf("AM: %s Add(): pushed new value to last chunk: %v", a.key, a.chunks[0])
+
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("AM: %s Add(): pushed new value to last chunk: %v", a.key, a.chunks[0])
+		}
 	} else if t0 < currentChunk.Series.T0 {
 		log.Debugf("AM: Point at %d has t0 %d, goes back into previous chunk. CurrentChunk t0: %d, LastTs: %d", ts, t0, currentChunk.Series.T0, currentChunk.Series.T)
 		metricsTooOld.Inc()


### PR DESCRIPTION
I noticed that some debug log statements caused considerable allocations in our Metrictank instances. This PR just places guards around them. the "orig" heaps are from a build of master at commit `9d43801b9fd676f66cd0eab92a0f2b068201fa37`

[profiles.tar.gz](https://github.com/grafana/metrictank/files/3045092/profiles.tar.gz)

From these profiles, we can see the effect of these allocations:

```
$ go tool pprof --lines --alloc_objects --base orig.heap1 --hide vendor orig
.heap2

(pprof) top10
Active filters:
   hide=vendor
Showing nodes accounting for 1342221, 45.03% of 2980646 total
Dropped 37 nodes (cum <= 14903)
Showing top 10 nodes out of 17
      flat  flat%   sum%        cum   cum%
    802833 26.93% 26.93%     802833 26.93%  github.com/grafana/metrictank/input/kafkamdm.(*KafkaMdm).consumePartition input/kafkamdm/kafkamdm.go:296
    212998  7.15% 34.08%     212998  7.15%  github.com/grafana/metrictank/idx/memory.(*UnpartitionedMemoryIdx).Update idx/memory/memory.go:299
    180229  6.05% 40.13%     180229  6.05%  github.com/grafana/metrictank/mdata.(*AggMetric).add mdata/aggmetric.go:470
     44214  1.48% 41.61%      44214  1.48%  github.com/grafana/metrictank/idx/cassandra.(*CasIdx).processWriteQueue idx/cassandra/cassandra.go:516
     32768  1.10% 42.71%      32768  1.10%  github.com/grafana/metrictank/idx/cassandra.(*CasIdx).processWriteQueue idx/cassandra/cassandra.go:508
     16385  0.55% 43.26%      16385  0.55%  github.com/grafana/metrictank/mdata.(*AggMetric).add mdata/aggmetric.go:442
     16384  0.55% 43.81%      16384  0.55%  github.com/grafana/metrictank/idx/cassandra.(*CasIdx).updateCassandra idx/cassandra/cassandra.go:319
     16384  0.55% 44.36%      16384  0.55%  github.com/grafana/metrictank/input/kafkamdm.(*KafkaMdm).handleMsg input/kafkamdm/kafkamdm.go:321
     16384  0.55% 44.91%      16384  0.55%  github.com/grafana/metrictank/mdata.(*AggMetric).add mdata/aggmetric.go:464
      3642  0.12% 45.03%       9787  0.33%  github.com/grafana/metrictank/idx/cassandra.(*CasIdx).processWriteQueue idx/cassandra/cassandra.go:506
```

The top 3 are log statements, hit for every ingested datapoint and account for `40%`(!!!) of all allocated objects (more, even, than sarama does). The go compiler escape analysis reveals that these lines cause the arguments to escape to the heap, so they result in allocations when called.

Simply wrapping the lines in if statements means this cost is only paid when debug is enabled.

```
$ go tool pprof --lines --alloc_objects --base ifd.heap1 --hide vendor ifd.heap2
(pprof) top10
Active filters:
   hide=vendor
Showing nodes accounting for 172763, 24.62% of 701738 total
Dropped 7 nodes (cum <= 3508)
Showing top 10 nodes out of 18
      flat  flat%   sum%        cum   cum%
     65538  9.34%  9.34%      65538  9.34%  github.com/grafana/metrictank/mdata.(*AggMetric).add mdata/aggmetric.go:470
     65537  9.34% 18.68%      65537  9.34%  github.com/grafana/metrictank/mdata/chunk/tsz.(*bstream).writeByte mdata/chunk/tsz/bstream.go:67
     20856  2.97% 21.65%      20856  2.97%  github.com/grafana/metrictank/mdata.NewAggMetric mdata/aggmetric.go:56
     19662  2.80% 24.45%      19662  2.80%  github.com/grafana/metrictank/mdata/chunk.NewFirst mdata/chunk/chunk.go:31
      1170  0.17% 24.62%       1170  0.17%  github.com/grafana/metrictank/idx/cassandra.(*CasIdx).processWriteQueue idx/cassandra/cassandra.go:516
         0     0% 24.62%      20856  2.97%  github.com/grafana/metrictank/input.DefaultHandler.ProcessMetricPoint input/input.go:81
         0     0% 24.62%     150737 21.48%  github.com/grafana/metrictank/input.DefaultHandler.ProcessMetricPoint input/input.go:82
         0     0% 24.62%     171593 24.45%  github.com/grafana/metrictank/input/kafkamdm.(*KafkaMdm).consumePartition input/kafkamdm/kafkamdm.go:299
         0     0% 24.62%     171593 24.45%  github.com/grafana/metrictank/input/kafkamdm.(*KafkaMdm).handleMsg input/kafkamdm/kafkamdm.go:318
         0     0% 24.62%     150737 21.48%  github.com/grafana/metrictank/mdata.(*AggMetric).Add mdata/aggmetric.go:409
```