### PR TITLE
cassandra-idx: load partitions in parallel

### DIFF
--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -364,6 +364,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -364,6 +364,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -364,6 +364,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -364,6 +364,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.

--- a/docs/config.md
+++ b/docs/config.md
@@ -428,6 +428,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -110,6 +110,8 @@ cass config flags:
     	host (hostname and server cert) verification when using SSL (default true)
   -hosts string
     	comma separated list of cassandra addresses in host:port form (default "localhost:9042")
+  -init-load-concurrency int
+    	Number of partitions to load concurrently on startup. (default 1)
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
   -num-conns int
@@ -241,6 +243,8 @@ cass config flags:
     	host (hostname and server cert) verification when using SSL (default true)
   -hosts string
     	comma separated list of cassandra addresses in host:port form (default "localhost:9042")
+  -init-load-concurrency int
+    	Number of partitions to load concurrently on startup. (default 1)
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
   -num-conns int
@@ -787,6 +791,8 @@ cass config flags:
     	host (hostname and server cert) verification when using SSL (default true)
   -hosts string
     	comma separated list of cassandra addresses in host:port form (default "localhost:9042")
+  -init-load-concurrency int
+    	Number of partitions to load concurrently on startup. (default 1)
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
   -num-conns int

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -375,6 +375,7 @@ func (c *CasIdx) Load(defs []schema.MetricDefinition, now time.Time) []schema.Me
 	return c.load(defs, iter, now)
 }
 
+// LoadPartitions appends MetricDefinitions from the given partitions to defs and returns the modified defs, honoring pruning settings relative to now
 func (c *CasIdx) LoadPartitions(partitions []int32, defs []schema.MetricDefinition, now time.Time) []schema.MetricDefinition {
 	placeholders := make([]string, len(partitions))
 	for i, p := range partitions {
@@ -385,6 +386,7 @@ func (c *CasIdx) LoadPartitions(partitions []int32, defs []schema.MetricDefiniti
 	return c.load(defs, iter, now)
 }
 
+// load appends MetricDefinitions from the iterator to defs and returns the modified defs, honoring pruning settings relative to now
 func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, now time.Time) []schema.MetricDefinition {
 	defsByNames := make(map[string][]*schema.MetricDefinition)
 	var id, name, unit, mtype string

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -39,6 +39,7 @@ type IdxConfig struct {
 	numConns                 int
 	protoVer                 int
 	disableInitialHostLookup bool
+	initLoadConcurrency      int
 }
 
 // NewIdxConfig returns IdxConfig with default values set.
@@ -64,6 +65,7 @@ func NewIdxConfig() *IdxConfig {
 		auth:                     false,
 		username:                 "cassandra",
 		password:                 "cassandra",
+		initLoadConcurrency:      1,
 	}
 }
 
@@ -92,6 +94,7 @@ func ConfigSetup() *flag.FlagSet {
 	casIdx.BoolVar(&CliConfig.updateCassIdx, "update-cassandra-index", CliConfig.updateCassIdx, "synchronize index changes to cassandra. not all your nodes need to do this.")
 	casIdx.DurationVar(&CliConfig.updateInterval, "update-interval", CliConfig.updateInterval, "frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates")
 	casIdx.DurationVar(&CliConfig.pruneInterval, "prune-interval", CliConfig.pruneInterval, "Interval at which the index should be checked for stale series.")
+	casIdx.IntVar(&CliConfig.initLoadConcurrency, "init-load-concurrency", CliConfig.initLoadConcurrency, "Number of partitions to load concurrently on startup.")
 	casIdx.IntVar(&CliConfig.protoVer, "protocol-version", CliConfig.protoVer, "cql protocol version to use")
 	casIdx.BoolVar(&CliConfig.createKeyspace, "create-keyspace", CliConfig.createKeyspace, "enable the creation of the index keyspace and tables, only one node needs this")
 	casIdx.StringVar(&CliConfig.schemaFile, "schema-file", CliConfig.schemaFile, "File containing the needed schemas in case database needs initializing")

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -367,6 +367,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -364,6 +364,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -364,6 +364,8 @@ num-conns = 10
 write-queue-size = 100000
 #Interval at which the index should be checked for stale series. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'
 prune-interval = 3h
+# Number of partitions to load concurrently on startup.
+init-load-concurrency = 1
 # synchronize index changes to cassandra. not all your nodes need to do this.
 update-cassandra-index = true
 #frequency at which we should update flush changes to cassandra. only relevant if update-cassandra-index is true. valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. Setting to '0s' will cause instant updates.


### PR DESCRIPTION
Loading the cassandra index takes up to 10 minutes for our nodes.  With the [changes for partitioned index](https://github.com/grafana/metrictank/commit/f4222c0615333d9ec20d1844f14b3dcb0e550073#diff-c6ce4629577f4e064a1d2f636acc0568) it used less memory, but wasn't any faster. This change brings it down to 3 minutes which helps reduce our recovery window when we lose a node (also speeds up our rollouts)