### PR TITLE
Add CodeLingo Tenet to remove unnecessary parentheses

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,4 +1,34 @@
+funcs:
+  - name: removeParen
+    type: resolver
+    body: |
+      function(parenExpr) {
+        parenExpr = parenExpr.replace("(","")
+        parenExpr = parenExpr.replace(")","")
+        return parenExpr
+      }
 tenets:
-- import: codelingo/go
-- import: codelingo/effective-go
-- import: codelingo/code-review-comments
+  - import: codelingo/go
+  - import: codelingo/effective-go
+  - import: codelingo/code-review-comments
+
+  - name: unnecessary-parentheses
+    flows:
+      codelingo/docs:
+        title: Unnecessary Parentheses
+        body: |
+          Avoid sunnecessary parentheses to make your code easier to read.
+      codelingo/review:
+        comment: Avoid sunnecessary parentheses to make your code easier to read.
+      codelingo/rewrite:
+    query: |
+      import codelingo/ast/go
+      
+      @review comment
+      @rewrite --replace "{{removeParen(raw1)}}"
+      go.paren_expr(depth = any):
+        raw as raw1
+        any_of:
+          go.basic_lit
+          go.ident
+          go.index_expr

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -357,7 +357,7 @@ func (m *UnpartitionedMemoryIdx) UpdateArchive(archive idx.Archive) {
 	if _, ok := m.defById[archive.Id]; !ok {
 		return
 	}
-	*(m.defById[archive.Id]) = archive
+	*m.defById[archive.Id] = archive
 }
 
 // indexTags reads the tags of a given metric definition and creates the


### PR DESCRIPTION
Add a CodeLingo Tenet to protect the repo from future instances of unnecessary parentheses fixed in [this PR #959](https://github.com/grafana/metrictank/pull/959/commits/970e18eee05929097ac53afb01a4c0e107f2315b). Use the Tenet to find and fix several missed cases of the issue in the codebase.

This Tenet was generated in 10 minutes using CodeLingo. See https://discuss.codelingo.io/t/grafana-unnecessary-parentheses/111 for a discussion on the process.