### PR TITLE
remove log-min-dur

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -16,8 +16,6 @@ var (
 	maxPointsPerReqSoft int
 	maxPointsPerReqHard int
 	maxSeriesPerReq     int
-	logMinDurStr        string
-	logMinDur           uint32
 
 	Addr             string
 	UseSSL           bool
@@ -41,8 +39,6 @@ func ConfigSetup() {
 	apiCfg.IntVar(&maxPointsPerReqSoft, "max-points-per-req-soft", 1000000, "lower resolution rollups will be used to try and keep requests below this number of datapoints. (0 disables limit)")
 	apiCfg.IntVar(&maxPointsPerReqHard, "max-points-per-req-hard", 20000000, "limit of number of datapoints a request can return. Requests that exceed this limit will be rejected. (0 disables limit)")
 	apiCfg.IntVar(&maxSeriesPerReq, "max-series-per-req", 250000, "limit of number of series a request can operate on. Requests that exceed this limit will be rejected. (0 disables limit)")
-	apiCfg.StringVar(&logMinDurStr, "log-min-dur", "5min", "only log incoming requests if their timerange is at least this duration. Use 0 to disable")
-
 	apiCfg.StringVar(&Addr, "listen", ":6060", "http listener address.")
 	apiCfg.BoolVar(&UseSSL, "ssl", false, "use HTTPS")
 	apiCfg.BoolVar(&useGzip, "gzip", true, "use GZIP compression of all responses")
@@ -58,8 +54,6 @@ func ConfigSetup() {
 }
 
 func ConfigProcess() {
-	logMinDur = dur.MustParseDuration("log-min-dur", logMinDurStr)
-
 	//validate the addr
 	_, err := net.ResolveTCPAddr("tcp", Addr)
 	if err != nil {

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -192,8 +192,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -192,8 +192,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -192,8 +192,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -192,8 +192,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docs/config.md
+++ b/docs/config.md
@@ -237,8 +237,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://localhost:8080
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -195,8 +195,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://localhost:8080
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -192,8 +192,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -192,8 +192,6 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://localhost:8080
-# only log incoming requests if their timerange is at least this duration. Use 0 to disable
-log-min-dur = 5min
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.


### PR DESCRIPTION
introduced via 929513cd93981c482133223e721d1bf91cf44750 / #174
became obsolete in b3d38316211584802003ce840166807843b2b315 / #575 / 0.7.1-61-gbe64803e

we no longer really log requests ourselves anymore.
i imagine at some point we probably will, at which point we can
re-introduce this setting

(our qa tool `unused` notified that this variable wasn't being read
anywhere)