### PR TITLE
handle duplicate datapoints in a consistent manner

### DIFF
--- a/mdata/reorder_buffer.go
+++ b/mdata/reorder_buffer.go
@@ -39,6 +39,11 @@ func (rob *ReorderBuffer) Add(ts uint32, val float64) ([]schema.Point, bool) {
 	var res []schema.Point
 	oldest := (rob.newest + 1) % uint32(cap(rob.buf))
 	index := (ts / rob.interval) % uint32(cap(rob.buf))
+	if rob.buf[index].Ts == ts {
+		// duplicate datapoint received.
+		metricsTooOld.Inc()
+		return nil, false
+	}
 	if ts > rob.buf[rob.newest].Ts {
 		flushCount := (ts - rob.buf[rob.newest].Ts) / rob.interval
 		if flushCount > uint32(cap(rob.buf)) {


### PR DESCRIPTION
this is awoods' work

fixes #1201

Without the reorder_buffer, MT only persists the first value received for each timestamp. With the re-order buffer we should do the same.