### PR TITLE
Expose new prometheus metric discarded_samples_total

### DIFF
--- a/dashboards/extra/fakemetrics-discarded-samples.json
+++ b/dashboards/extra/fakemetrics-discarded-samples.json
@@ -1,0 +1,456 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "tags": [
+          "metrictank"
+        ],
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": 20,
+  "iteration": 1555334759802,
+  "links": [],
+  "panels": [
+    {
+      "content": "Use `fakemetrics bad` to generate invalid data points.",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 44,
+      "links": [],
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": "",
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "metrictank",
+      "decimals": null,
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 41,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxDataPoints": "",
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 0.5,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "refCount": 0,
+          "refId": "A",
+          "target": "aliasByNode(metrictank.stats.$environment.$instance.tank.metrics_too_old.counter32, 4, 5)"
+        },
+        {
+          "refCount": 0,
+          "refId": "B",
+          "target": "aliasByNode(metrictank.stats.$environment.$instance.tank.add_to_closed_chunk.counter32, 4, 5)"
+        },
+        {
+          "refCount": 0,
+          "refId": "C",
+          "target": "aliasByNode(metrictank.stats.$environment.$instance.input.*.metricdata.invalid.counter32, 4, 5, 6, 7)",
+          "textEditor": false
+        },
+        {
+          "refCount": 0,
+          "refId": "D",
+          "target": "aliasByNode(metrictank.stats.$environment.$instance.input.*.metricpoint.invalid.counter32, 4, 5, 6, 7)",
+          "textEditor": false
+        },
+        {
+          "refCount": 0,
+          "refId": "E",
+          "target": "aliasByNode(metrictank.stats.$environment.$instance.input.*.metricpoint.unknown.counter32, 4, 5, 6, 7)",
+          "textEditor": false
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Metrictank - discarded samples",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 42,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (reason) (metrictank_discarded_samples_total)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ reason }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Prometheus - metrictank_discarded_samples_total",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "metrictank",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 39,
+      "isNew": true,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "refId": "A",
+          "target": "some.id.of.a.metric.*",
+          "textEditor": true
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "data",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "datasource": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "graphite",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {
+          "text": "docker-dev-custom-cfg-kafka",
+          "value": "docker-dev-custom-cfg-kafka"
+        },
+        "datasource": "$datasource",
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "environment",
+        "options": [],
+        "query": "metrictank.stats.*",
+        "refresh": 1,
+        "refresh_on_load": false,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "$datasource",
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "multiFormat": "glob",
+        "name": "instance",
+        "options": [],
+        "query": "metrictank.stats.$environment.*",
+        "refresh": 1,
+        "refresh_on_load": false,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "timezone": "utc",
+  "title": "Fakemetrics - discarded samples",
+  "uid": "rABS_bgZk",
+  "version": 34
+}

--- a/dashboards/extra/fakemetrics-discarded-samples.json
+++ b/dashboards/extra/fakemetrics-discarded-samples.json
@@ -47,7 +47,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "metrictank",
-      "decimals": null,
+      "decimals": 0,
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -133,7 +133,7 @@
       },
       "yaxes": [
         {
-          "decimals": null,
+          "decimals": 0,
           "format": "none",
           "label": null,
           "logBase": 1,
@@ -161,6 +161,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "decimals": 0,
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -185,8 +186,8 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
-      "pointradius": 2,
-      "points": false,
+      "pointradius": 1,
+      "points": true,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -223,6 +224,7 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "none",
           "label": null,
           "logBase": 1,
@@ -452,5 +454,5 @@
   "timezone": "utc",
   "title": "Fakemetrics - discarded samples",
   "uid": "rABS_bgZk",
-  "version": 34
+  "version": 1
 }

--- a/input/input.go
+++ b/input/input.go
@@ -117,6 +117,8 @@ func (in DefaultHandler) ProcessMetricData(md *schema.MetricData, partition int3
 			reason = invalidMtype
 		case schema.ErrInvalidTagFormat:
 			reason = invalidTagFormat
+		default:
+			reason = "unknown"
 		}
 		mdata.PromDiscardedSamples.WithLabelValues(reason, strconv.Itoa(md.OrgId)).Inc()
 

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"sync"
 	"time"
 
@@ -413,18 +414,19 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 
 		if err == nil {
 			if len(res) == 0 {
-			a.lastWrite = uint32(time.Now().Unix())
+				a.lastWrite = uint32(time.Now().Unix())
 			} else {
-		for _, p := range res {
-			a.add(p.Ts, p.Val)
-		}
-	}
+				for _, p := range res {
+					a.add(p.Ts, p.Val)
+				}
+			}
 		} else {
 			var reason string
 			switch err {
 			case errMetricsTooOld:
 				reason = sampleOutOfOrder
 			}
+			PromDiscardedSamples.WithLabelValues(reason, strconv.Itoa(int(a.key.MKey.Org))).Inc()
 		}
 	}
 }
@@ -465,12 +467,14 @@ func (a *AggMetric) add(ts uint32, val float64) {
 			// if we've already 'finished' the chunk, it means it has the end-of-stream marker and any new points behind it wouldn't be read by an iterator
 			// you should monitor this metric closely, it indicates that maybe your GC settings don't match how you actually send data (too late)
 			addToClosedChunk.Inc()
+			PromDiscardedSamples.WithLabelValues(receivedTooLate, strconv.Itoa(int(a.key.MKey.Org))).Inc()
 			return
 		}
 
 		if err := currentChunk.Push(ts, val); err != nil {
 			log.Debugf("AM: failed to add metric to chunk for %s. %s", a.key, err)
 			metricsTooOld.Inc()
+			PromDiscardedSamples.WithLabelValues(sampleOutOfOrder, strconv.Itoa(int(a.key.MKey.Org))).Inc()
 			return
 		}
 		totalPoints.Inc()
@@ -482,6 +486,7 @@ func (a *AggMetric) add(ts uint32, val float64) {
 	} else if t0 < currentChunk.Series.T0 {
 		log.Debugf("AM: Point at %d has t0 %d, goes back into previous chunk. CurrentChunk t0: %d, LastTs: %d", ts, t0, currentChunk.Series.T0, currentChunk.Series.T)
 		metricsTooOld.Inc()
+		PromDiscardedSamples.WithLabelValues(sampleOutOfOrder, strconv.Itoa(int(a.key.MKey.Org))).Inc()
 		return
 	} else {
 		// Data belongs in a new chunk.

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -425,6 +425,8 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 			switch err {
 			case errMetricsTooOld:
 				reason = sampleOutOfOrder
+			default:
+				reason = "unknown"
 			}
 			PromDiscardedSamples.WithLabelValues(reason, strconv.Itoa(int(a.key.MKey.Org))).Inc()
 		}

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -425,6 +425,7 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 			switch err {
 			case errMetricsTooOld:
 				reason = sampleOutOfOrder
+				metricsTooOld.Inc()
 			default:
 				reason = "unknown"
 			}

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -423,7 +423,7 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 		} else {
 			var reason string
 			switch err {
-			case errMetricsTooOld:
+			case errMetricTooOld:
 				reason = sampleOutOfOrder
 				metricsTooOld.Inc()
 			default:

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -15,6 +15,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	discardReasonLabel = "reason"
+
+	sampleOutOfOrder = "sample-out-of-order"
+	receivedTooLate  = "received-too-late"
+)
+
 var (
 	// metric tank.chunk_operations.create is a counter of how many chunks are created
 	chunkCreate = stats.NewCounter32("tank.chunk_operations.create")
@@ -74,6 +81,12 @@ var (
 		Name:      "metrics_active",
 		Help:      "Current # of active metrics",
 	}, []string{"org"})
+
+	PromDiscardedSamples = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "metrictank",
+		Name:      "discarded_samples_total",
+		Help:      "Total # of samples that were discarded",
+	}, []string{discardReasonLabel, "org"})
 )
 
 func ConfigSetup() {

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -82,7 +82,7 @@ var (
 		Help:      "Current # of active metrics",
 	}, []string{"org"})
 
-	PromDiscardedSamples = prometheus.NewCounterVec(prometheus.CounterOpts{
+	PromDiscardedSamples = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "metrictank",
 		Name:      "discarded_samples_total",
 		Help:      "Total # of samples that were discarded",

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -16,8 +16,6 @@ import (
 )
 
 const (
-	discardReasonLabel = "reason"
-
 	sampleOutOfOrder = "sample-out-of-order"
 	receivedTooLate  = "received-too-late"
 )
@@ -86,7 +84,7 @@ var (
 		Namespace: "metrictank",
 		Name:      "discarded_samples_total",
 		Help:      "Total # of samples that were discarded",
-	}, []string{discardReasonLabel, "org"})
+	}, []string{"reason", "org"})
 )
 
 func ConfigSetup() {

--- a/mdata/init.go
+++ b/mdata/init.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Possible reason labels for Prometheus metric discarded_samples_total
 const (
 	sampleOutOfOrder = "sample-out-of-order"
 	receivedTooLate  = "received-too-late"

--- a/mdata/reorder_buffer.go
+++ b/mdata/reorder_buffer.go
@@ -38,7 +38,6 @@ func (rob *ReorderBuffer) Add(ts uint32, val float64) ([]schema.Point, error) {
 
 	// out of order and too old
 	if rob.buf[rob.newest].Ts != 0 && ts <= rob.buf[rob.newest].Ts-(uint32(cap(rob.buf))*rob.interval) {
-		metricsTooOld.Inc()
 		return nil, errMetricsTooOld
 	}
 

--- a/mdata/reorder_buffer.go
+++ b/mdata/reorder_buffer.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	errMetricsTooOld = errors.New("metrics too old")
+	errMetricTooOld = errors.New("metric too old")
 )
 
 // ReorderBuffer keeps a window of data during which it is ok to send data out of order.
@@ -38,7 +38,7 @@ func (rob *ReorderBuffer) Add(ts uint32, val float64) ([]schema.Point, error) {
 
 	// out of order and too old
 	if rob.buf[rob.newest].Ts != 0 && ts <= rob.buf[rob.newest].Ts-(uint32(cap(rob.buf))*rob.interval) {
-		return nil, errMetricsTooOld
+		return nil, errMetricTooOld
 	}
 
 	var res []schema.Point

--- a/mdata/reorder_buffer_test.go
+++ b/mdata/reorder_buffer_test.go
@@ -14,9 +14,9 @@ func testAddAndGet(t *testing.T, reorderWindow uint32, testData, expectedData []
 	metricsReordered.SetUint32(0)
 	addedCount := uint32(0)
 	for _, point := range testData {
-		addRes, accepted := b.Add(point.Ts, point.Val)
+		addRes, err := b.Add(point.Ts, point.Val)
 		flushed = append(flushed, addRes...)
-		if accepted {
+		if err == nil {
 			addedCount++
 		}
 	}
@@ -217,8 +217,8 @@ func TestROBFlushSortedData(t *testing.T) {
 	buf := NewReorderBuffer(600, 1)
 	metricsTooOld.SetUint32(0)
 	for i := 1100; i < 2100; i++ {
-		flushed, accepted := buf.Add(uint32(i), float64(i))
-		if metricsTooOld.Peek() != 0 || !accepted {
+		flushed, err := buf.Add(uint32(i), float64(i))
+		if metricsTooOld.Peek() != 0 || err != nil {
 			t.Fatalf("Adding failed")
 		}
 		results = append(results, flushed...)
@@ -247,8 +247,8 @@ func TestROBFlushUnsortedData1(t *testing.T) {
 	failedCount := 0
 	metricsTooOld.SetUint32(0)
 	for _, p := range data {
-		flushed, accepted := buf.Add(p.Ts, p.Val)
-		if metricsTooOld.Peek() != 0 || !accepted {
+		flushed, err := buf.Add(p.Ts, p.Val)
+		if metricsTooOld.Peek() != 0 || err != nil {
 			failedCount++
 			metricsTooOld.SetUint32(0)
 		} else {


### PR DESCRIPTION
The metric takes a reason with values among:
- sample-out-of-order
- received-too-late
- invalid-timestamp
- invalid-interval
- invalid-orgID
- invalid-name
- invalid-mtype
- invalid-tag-format
- unknown-point-id

Fixes #1203