### PR TITLE
change ChunkWriteRequests to make them marshalable

### DIFF
--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -553,7 +553,8 @@ func TestGetSeriesCachedStore(t *testing.T) {
 				// populate cache and store according to pattern definition
 				var prevts uint32
 				for i := 0; i < len(tc.Pattern); i++ {
-					itgen, err := chunk.NewIterGen(chunks[i].Series.T0, 0, chunks[i].Encode(span))
+					encodedChunk := chunks[i].Encode(span)
+					itgen, err := chunk.NewIterGen(chunks[i].Series.T0, 0, encodedChunk)
 					if err != nil {
 						t.Fatalf("NewIterGen error: %s", err)
 					}
@@ -561,7 +562,7 @@ func TestGetSeriesCachedStore(t *testing.T) {
 						c.Add(metric, prevts, itgen)
 					}
 					if pattern[i] == 's' || pattern[i] == 'b' {
-						cwr := mdata.NewChunkWriteRequest(nil, metric, &chunks[i], 0, span, time.Now())
+						cwr := mdata.NewChunkWriteRequest(func() {}, metric, 0, chunks[i].Series.T0, encodedChunk, time.Now())
 						store.Add(&cwr)
 					}
 					prevts = chunks[i].Series.T0

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -80,16 +80,21 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 }
 
 // Sync the saved state of a chunk by its T0.
-func (a *AggMetric) SyncChunkSaveState(ts uint32) {
-	a.Lock()
-	defer a.Unlock()
-	if ts > a.lastSaveFinish {
-		a.lastSaveFinish = ts
+func (a *AggMetric) SyncChunkSaveState(ts uint32, sendPersist bool) ChunkSaveCallback {
+	return func() {
+		a.Lock()
+		defer a.Unlock()
+		if ts > a.lastSaveFinish {
+			a.lastSaveFinish = ts
+		}
+		if ts > a.lastSaveStart {
+			a.lastSaveStart = ts
+		}
+		log.Debugf("AM: metric %s at chunk T0=%d has been saved.", a.key, ts)
+		if sendPersist {
+			SendPersistMessage(a.key.String(), ts)
+		}
 	}
-	if ts > a.lastSaveStart {
-		a.lastSaveStart = ts
-	}
-	log.Debugf("AM: metric %s at chunk T0=%d has been saved.", a.key, ts)
 }
 
 // Sync the saved state of a chunk by its T0.
@@ -104,27 +109,27 @@ func (a *AggMetric) SyncAggregatedChunkSaveState(ts uint32, consolidator consoli
 				panic("avg consolidator has no matching Archive(). you need sum and cnt")
 			case consolidation.Cnt:
 				if a.cntMetric != nil {
-					a.cntMetric.SyncChunkSaveState(ts)
+					a.cntMetric.SyncChunkSaveState(ts, false)()
 				}
 				return
 			case consolidation.Min:
 				if a.minMetric != nil {
-					a.minMetric.SyncChunkSaveState(ts)
+					a.minMetric.SyncChunkSaveState(ts, false)()
 				}
 				return
 			case consolidation.Max:
 				if a.maxMetric != nil {
-					a.maxMetric.SyncChunkSaveState(ts)
+					a.maxMetric.SyncChunkSaveState(ts, false)()
 				}
 				return
 			case consolidation.Sum:
 				if a.sumMetric != nil {
-					a.sumMetric.SyncChunkSaveState(ts)
+					a.sumMetric.SyncChunkSaveState(ts, false)()
 				}
 				return
 			case consolidation.Lst:
 				if a.lstMetric != nil {
-					a.lstMetric.SyncChunkSaveState(ts)
+					a.lstMetric.SyncChunkSaveState(ts, false)()
 				}
 				return
 			default:
@@ -356,10 +361,8 @@ func (a *AggMetric) persist(pos int) {
 	// create an array of chunks that need to be sent to the writeQueue.
 	pending := make([]*ChunkWriteRequest, 1)
 	// add the current chunk to the list of chunks to send to the writeQueue
-	cwr := NewChunkWriteRequest(func() {
-		a.SyncChunkSaveState(chunk.Series.T0)
-		SendPersistMessage(a.key.String(), chunk.Series.T0)
-	},
+	cwr := NewChunkWriteRequest(
+		a.SyncChunkSaveState(chunk.Series.T0, true),
 		a.key,
 		a.ttl,
 		chunk.Series.T0,
@@ -378,10 +381,8 @@ func (a *AggMetric) persist(pos int) {
 	previousChunk := a.chunks[previousPos]
 	for (previousChunk.Series.T0 < chunk.Series.T0) && (a.lastSaveStart < previousChunk.Series.T0) {
 		log.Debugf("AM: persist(): old chunk needs saving. Adding %s:%d to writeQueue", a.key, previousChunk.Series.T0)
-		cwr := NewChunkWriteRequest(func() {
-			a.SyncChunkSaveState(previousChunk.Series.T0)
-			SendPersistMessage(a.key.String(), previousChunk.Series.T0)
-		},
+		cwr := NewChunkWriteRequest(
+			a.SyncChunkSaveState(previousChunk.Series.T0, true),
 			a.key,
 			a.ttl,
 			previousChunk.Series.T0,

--- a/mdata/cwr.go
+++ b/mdata/cwr.go
@@ -3,21 +3,20 @@ package mdata
 import (
 	"time"
 
-	"github.com/grafana/metrictank/mdata/chunk"
 	"github.com/raintank/schema"
 )
 
 // ChunkWriteRequest is a request to write a chunk into a store
 type ChunkWriteRequest struct {
-	Metric    *AggMetric
+	Callback  func()
 	Key       schema.AMKey
-	Chunk     *chunk.Chunk
 	TTL       uint32
-	Span      uint32
+	T0        uint32
+	Data      []byte
 	Timestamp time.Time
 }
 
 // NewChunkWriteRequest creates a new ChunkWriteRequest
-func NewChunkWriteRequest(metric *AggMetric, key schema.AMKey, chunk *chunk.Chunk, ttl, span uint32, ts time.Time) ChunkWriteRequest {
-	return ChunkWriteRequest{metric, key, chunk, ttl, span, ts}
+func NewChunkWriteRequest(callback func(), key schema.AMKey, ttl, t0 uint32, data []byte, ts time.Time) ChunkWriteRequest {
+	return ChunkWriteRequest{callback, key, ttl, t0, data, ts}
 }

--- a/mdata/cwr.go
+++ b/mdata/cwr.go
@@ -6,9 +6,11 @@ import (
 	"github.com/raintank/schema"
 )
 
+type ChunkSaveCallback func()
+
 // ChunkWriteRequest is a request to write a chunk into a store
 type ChunkWriteRequest struct {
-	Callback  func()
+	Callback  ChunkSaveCallback
 	Key       schema.AMKey
 	TTL       uint32
 	T0        uint32

--- a/mdata/notifier.go
+++ b/mdata/notifier.go
@@ -101,7 +101,7 @@ func (dn DefaultNotifierHandler) Handle(data []byte) {
 				aggSpan := amkey.Archive.Span()
 				agg.(*AggMetric).SyncAggregatedChunkSaveState(c.T0, consolidator, aggSpan)
 			} else {
-				agg.(*AggMetric).SyncChunkSaveState(c.T0)
+				agg.(*AggMetric).SyncChunkSaveState(c.T0, false)()
 			}
 		}
 	} else {

--- a/mdata/store_mock.go
+++ b/mdata/store_mock.go
@@ -40,7 +40,7 @@ func (c *MockStore) Items() int {
 func (c *MockStore) Add(cwr *ChunkWriteRequest) {
 	if !c.Drop {
 		intervalHint := cwr.Key.Archive.Span()
-		itgen, err := chunk.NewIterGen(cwr.Chunk.Series.T0, intervalHint, cwr.Chunk.Encode(cwr.Span))
+		itgen, err := chunk.NewIterGen(cwr.T0, intervalHint, cwr.Data)
 		if err != nil {
 			panic(err)
 		}

--- a/store/bigtable/bigtable.go
+++ b/store/bigtable/bigtable.go
@@ -268,7 +268,9 @@ func (s *Store) processWriteQueue(queue chan *mdata.ChunkWriteRequest, meter *st
 						failedMutations = append(failedMutations, muts[i])
 						retryBuf = append(retryBuf, buf[i])
 					} else {
-						buf[i].Callback()
+						if buf[i].Callback != nil {
+							buf[i].Callback()
+						}
 						log.Debugf("btStore: save complete. %s:%d %v", buf[i].Key, buf[i].T0, buf[i].Data)
 						chunkSaveOk.Inc()
 					}
@@ -289,7 +291,9 @@ func (s *Store) processWriteQueue(queue chan *mdata.ChunkWriteRequest, meter *st
 				chunkSaveOk.Add(len(rowKeys))
 				log.Debugf("btStore: %d chunks saved to bigtable.", len(rowKeys))
 				for _, cwr := range buf {
-					cwr.Callback()
+					if cwr.Callback != nil {
+						cwr.Callback()
+					}
 					log.Debugf("btStore: save complete. %s:%d %v", cwr.Key.String(), cwr.T0, cwr.Data)
 				}
 			}

--- a/store/cassandra/cassandra.go
+++ b/store/cassandra/cassandra.go
@@ -312,28 +312,26 @@ func (c *CassandraStore) processWriteQueue(queue chan *mdata.ChunkWriteRequest, 
 			meter.Value(len(queue))
 		case cwr := <-queue:
 			meter.Value(len(queue))
-			log.Debugf("CS: starting to save %s:%d %v", cwr.Key, cwr.Chunk.Series.T0, cwr.Chunk)
+			keyStr := cwr.Key.String()
+			log.Debugf("CS: starting to save %s:%d %v", keyStr, cwr.T0, cwr.Data)
 			//log how long the chunk waited in the queue before we attempted to save to cassandra
 			cassPutWaitDuration.Value(time.Now().Sub(cwr.Timestamp))
 
-			buf := cwr.Chunk.Encode(cwr.Span)
-			chunkSizeAtSave.Value(len(buf))
+			chunkSizeAtSave.Value(len(cwr.Data))
 			success := false
 			attempts := 0
-			keyStr := cwr.Key.String()
 			for !success {
-				err := c.insertChunk(keyStr, cwr.Chunk.Series.T0, cwr.TTL, buf)
+				err := c.insertChunk(keyStr, cwr.T0, cwr.TTL, cwr.Data)
 
 				if err == nil {
 					success = true
-					cwr.Metric.SyncChunkSaveState(cwr.Chunk.Series.T0)
-					mdata.SendPersistMessage(keyStr, cwr.Chunk.Series.T0)
-					log.Debugf("CS: save complete. %s:%d %v", keyStr, cwr.Chunk.Series.T0, cwr.Chunk)
+					cwr.Callback()
+					log.Debugf("CS: save complete. %s:%d %v", keyStr, cwr.T0, cwr.Data)
 					chunkSaveOk.Inc()
 				} else {
 					errmetrics.Inc(err)
 					if (attempts % 20) == 0 {
-						log.Warnf("CS: failed to save chunk to cassandra after %d attempts. %v, %s", attempts+1, cwr.Chunk, err)
+						log.Warnf("CS: failed to save chunk to cassandra after %d attempts. %v, %s", attempts+1, cwr.Data, err)
 					}
 					chunkSaveFail.Inc()
 					sleepTime := 100 * attempts

--- a/store/cassandra/cassandra.go
+++ b/store/cassandra/cassandra.go
@@ -325,7 +325,9 @@ func (c *CassandraStore) processWriteQueue(queue chan *mdata.ChunkWriteRequest, 
 
 				if err == nil {
 					success = true
-					cwr.Callback()
+					if cwr.Callback != nil {
+						cwr.Callback()
+					}
 					log.Debugf("CS: save complete. %s:%d %v", keyStr, cwr.T0, cwr.Data)
 					chunkSaveOk.Inc()
 				} else {


### PR DESCRIPTION
this changes the chunk write requests so the logic in the stores is less
coupled with the mdata package. it uses a callback function that gets
assigned by the instantiator of the chunk write request to decouple
them.
it also makes the chunk write requests marshalable so we can transfer
them over the wire. this is useful for the whisper importer utility,
because then it can simply transmit the chunk write requests from the
reader to the writer.