### PR TITLE
don't issue requests that don't apply to query nodes, and if they do receive them, don't crash

### DIFF
--- a/api/ccache.go
+++ b/api/ccache.go
@@ -27,6 +27,12 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 		}
 	}
 
+	// nothing to do on query nodes. they don't have any data in their chunk cache
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewJson(code, res, ""))
+		return
+	}
+
 	fullFlush := false
 	for _, pattern := range req.Patterns {
 		if pattern == "**" {

--- a/api/ccache.go
+++ b/api/ccache.go
@@ -27,7 +27,7 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 		}
 	}
 
-	// nothing to do on query nodes. they don't have any data in their chunk cache
+	// nothing to do on query nodes. they have no index or chunk cache
 	if s.MetricIndex == nil {
 		response.Write(ctx, response.NewJson(code, res, ""))
 		return

--- a/api/ccache.go
+++ b/api/ccache.go
@@ -91,7 +91,7 @@ func (s *Server) ccacheDeletePropagate(ctx context.Context, req *models.CCacheDe
 	// we never want to propagate more than once to avoid loops
 	req.Propagate = false
 
-	peers := cluster.Manager.MemberList()
+	peers := cluster.Manager.MemberList(false, false)
 	peerResults := make(map[string]models.CCacheDeleteResp)
 	var mu sync.Mutex
 	var wg sync.WaitGroup

--- a/api/ccache.go
+++ b/api/ccache.go
@@ -91,7 +91,7 @@ func (s *Server) ccacheDeletePropagate(ctx context.Context, req *models.CCacheDe
 	// we never want to propagate more than once to avoid loops
 	req.Propagate = false
 
-	peers := cluster.Manager.MemberList(false, false)
+	peers := cluster.Manager.MemberList(false, true)
 	peerResults := make(map[string]models.CCacheDeleteResp)
 	var mu sync.Mutex
 	var wg sync.WaitGroup

--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -183,7 +183,7 @@ func TestMetricDeleteWithErrorInPropagation(t *testing.T) {
 
 	respEncoded := response.NewJson(500, resp, "")
 	buf, _ := respEncoded.Body()
-	manager.Peers = append(manager.Peers, cluster.NewMockNode(false, "0", buf))
+	manager.Peers = append(manager.Peers, cluster.NewMockNode(false, "0", []int32{0}, buf))
 
 	// define how many series/archives are going to get deleted by this server
 	delSeries := 1
@@ -244,7 +244,7 @@ func TestMetricDeletePropagation(t *testing.T) {
 		expectedDeletedArchives += resp.DeletedArchives
 		respEncoded := response.NewJson(200, resp, "")
 		buf, _ := respEncoded.Body()
-		manager.Peers = append(manager.Peers, cluster.NewMockNode(false, peer, buf))
+		manager.Peers = append(manager.Peers, cluster.NewMockNode(false, peer, []int32{0}, buf))
 	}
 
 	// define how many series/archives are going to get deleted by this server

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -114,6 +114,12 @@ func (s *Server) postClusterMembers(ctx *middleware.Context, req models.ClusterM
 func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 	resp := models.NewIndexFindResp()
 
+	// query nodes don't own any data
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(200, resp))
+		return
+	}
+
 	for _, pattern := range req.Patterns {
 		nodes, err := s.MetricIndex.Find(req.OrgId, pattern, req.From)
 		if err != nil {
@@ -126,6 +132,13 @@ func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 }
 
 func (s *Server) indexTagDetails(ctx *middleware.Context, req models.IndexTagDetails) {
+
+	// query nodes don't own any data
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(200, &models.IndexTagDetailsResp{}))
+		return
+	}
+
 	values, err := s.MetricIndex.TagDetails(req.OrgId, req.Tag, req.Filter, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
@@ -135,6 +148,13 @@ func (s *Server) indexTagDetails(ctx *middleware.Context, req models.IndexTagDet
 }
 
 func (s *Server) indexTags(ctx *middleware.Context, req models.IndexTags) {
+
+	// query nodes don't own any data
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(200, &models.IndexTagsResp{}))
+		return
+	}
+
 	tags, err := s.MetricIndex.Tags(req.OrgId, req.Filter, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
@@ -144,6 +164,13 @@ func (s *Server) indexTags(ctx *middleware.Context, req models.IndexTags) {
 }
 
 func (s *Server) indexAutoCompleteTags(ctx *middleware.Context, req models.IndexAutoCompleteTags) {
+
+	// query nodes don't own any data
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(200, models.StringList(nil)))
+		return
+	}
+
 	tags, err := s.MetricIndex.FindTags(req.OrgId, req.Prefix, req.Expr, req.From, req.Limit)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
@@ -153,6 +180,13 @@ func (s *Server) indexAutoCompleteTags(ctx *middleware.Context, req models.Index
 }
 
 func (s *Server) indexAutoCompleteTagValues(ctx *middleware.Context, req models.IndexAutoCompleteTagValues) {
+
+	// query nodes don't own any data
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(200, models.StringList(nil)))
+		return
+	}
+
 	tags, err := s.MetricIndex.FindTagValues(req.OrgId, req.Tag, req.Prefix, req.Expr, req.From, req.Limit)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
@@ -162,19 +196,34 @@ func (s *Server) indexAutoCompleteTagValues(ctx *middleware.Context, req models.
 }
 
 func (s *Server) indexTagDelSeries(ctx *middleware.Context, request models.IndexTagDelSeries) {
+
+	res := models.IndexTagDelSeriesResp{}
+
+	// nothing to do on query nodes.
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(200, res))
+		return
+	}
+
 	deleted, err := s.MetricIndex.DeleteTagged(request.OrgId, request.Paths)
 	if err != nil {
 		response.Write(ctx, response.WrapErrorForTagDB(err))
 		return
 	}
 
-	res := models.IndexTagDelSeriesResp{}
 	res.Count = len(deleted)
 
 	response.Write(ctx, response.NewMsgp(200, res))
 }
 
 func (s *Server) indexFindByTag(ctx *middleware.Context, req models.IndexFindByTag) {
+
+	// query nodes don't own any data.
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(200, &models.IndexFindByTagResp{}))
+		return
+	}
+
 	metrics, err := s.MetricIndex.FindByTag(req.OrgId, req.Expr, req.From)
 	if err != nil {
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
@@ -185,6 +234,13 @@ func (s *Server) indexFindByTag(ctx *middleware.Context, req models.IndexFindByT
 
 // IndexGet returns a msgp encoded schema.MetricDefinition
 func (s *Server) indexGet(ctx *middleware.Context, req models.IndexGet) {
+
+	// query nodes don't own any data.
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgp(404, nil))
+		return
+	}
+
 	def, ok := s.MetricIndex.Get(req.MKey)
 	if !ok {
 		response.Write(ctx, response.NewError(http.StatusNotFound, "Not Found"))
@@ -196,6 +252,13 @@ func (s *Server) indexGet(ctx *middleware.Context, req models.IndexGet) {
 
 // IndexList returns msgp encoded schema.MetricDefinition's
 func (s *Server) indexList(ctx *middleware.Context, req models.IndexList) {
+
+	// query nodes don't own any data.
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewMsgpArray(200, nil))
+		return
+	}
+
 	defs := s.MetricIndex.List(req.OrgId)
 	resp := make([]msgp.Marshaler, len(defs))
 	for i := range defs {
@@ -218,6 +281,12 @@ func (s *Server) getData(ctx *middleware.Context, request models.GetData) {
 }
 
 func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
+
+	// nothing to do on query nodes.
+	if s.MetricIndex == nil {
+		return
+	}
+
 	defs, err := s.MetricIndex.Delete(req.OrgId, req.Query)
 	if err != nil {
 		// errors can only be caused by bad request.

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -70,7 +70,7 @@ func (s *Server) getClusterStatus(ctx *middleware.Context) {
 	status := models.ClusterStatus{
 		ClusterName: cluster.ClusterName,
 		NodeName:    cluster.Manager.ThisNode().GetName(),
-		Members:     cluster.Manager.MemberList(),
+		Members:     cluster.Manager.MemberList(false, false),
 	}
 	response.Write(ctx, response.NewJson(200, status, ""))
 }
@@ -79,7 +79,7 @@ func (s *Server) postClusterMembers(ctx *middleware.Context, req models.ClusterM
 	memberNames := make(map[string]struct{})
 	var toJoin []string
 
-	for _, memberNode := range cluster.Manager.MemberList() {
+	for _, memberNode := range cluster.Manager.MemberList(false, false) {
 		memberNames[memberNode.GetName()] = struct{}{}
 	}
 
@@ -317,7 +317,7 @@ func (s *Server) peerQuery(ctx context.Context, data cluster.Traceable, name, pa
 	var err error
 
 	if allPeers {
-		peers = cluster.Manager.MemberList()
+		peers = cluster.Manager.MemberList(false, false)
 	} else {
 		peers, err = cluster.MembersForQuery()
 		if err != nil {

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -463,6 +463,12 @@ func (s *Server) itersToPoints(ctx *requestContext, iters []tsz.Iter) []schema.P
 func (s *Server) getSeriesAggMetrics(ctx *requestContext) (mdata.Result, error) {
 	_, span := tracing.NewSpan(ctx.ctx, s.Tracer, "getSeriesAggMetrics")
 	defer span.Finish()
+
+	// this is a query node that for some reason received a request
+	if s.MemoryStore == nil {
+		return mdata.Result{}, nil
+	}
+
 	metric, ok := s.MemoryStore.Get(ctx.AMKey.MKey)
 	if !ok {
 		return mdata.Result{
@@ -480,6 +486,12 @@ func (s *Server) getSeriesAggMetrics(ctx *requestContext) (mdata.Result, error) 
 
 // will only fetch until until, but uses ctx.To for debug logging
 func (s *Server) getSeriesCachedStore(ctx *requestContext, until uint32) ([]tsz.Iter, error) {
+
+	// this is a query node that for some reason received a data request
+	if s.BackendStore == nil {
+		return nil, nil
+	}
+
 	var iters []tsz.Iter
 	var prevts uint32
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -513,7 +513,7 @@ func findTreejson(query string, nodes []idx.Node) models.SeriesTree {
 }
 
 func (s *Server) metricsDelete(ctx *middleware.Context, req models.MetricsDelete) {
-	peers := cluster.Manager.MemberList()
+	peers := cluster.Manager.MemberList(false, false)
 	peers = append(peers, cluster.Manager.ThisNode())
 	log.Debugf("HTTP metricsDelete for %v across %d instances", req.Query, len(peers))
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1115,7 +1115,7 @@ func (s *Server) graphiteTagDelSeries(ctx *middleware.Context, request models.Gr
 	}
 
 	data := models.IndexTagDelSeries{OrgId: ctx.OrgId, Paths: request.Paths}
-	responses, err := s.peerQuery(ctx.Req.Context(), data, "clusterTagDelSeries,", "/index/tags/delSeries", true) // note: needlessl hits query nodes with no data, but can be cleaned later
+	responses, err := s.peerQuery(ctx.Req.Context(), data, "clusterTagDelSeries,", "/index/tags/delSeries")
 	if err != nil {
 		response.Write(ctx, response.WrapErrorForTagDB(err))
 		return

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -513,7 +513,7 @@ func findTreejson(query string, nodes []idx.Node) models.SeriesTree {
 }
 
 func (s *Server) metricsDelete(ctx *middleware.Context, req models.MetricsDelete) {
-	peers := cluster.Manager.MemberList(false, false)
+	peers := cluster.Manager.MemberList(false, true)
 	peers = append(peers, cluster.Manager.ThisNode())
 	log.Debugf("HTTP metricsDelete for %v across %d instances", req.Query, len(peers))
 
@@ -1115,7 +1115,7 @@ func (s *Server) graphiteTagDelSeries(ctx *middleware.Context, request models.Gr
 	}
 
 	data := models.IndexTagDelSeries{OrgId: ctx.OrgId, Paths: request.Paths}
-	responses, err := s.peerQuery(ctx.Req.Context(), data, "clusterTagDelSeries,", "/index/tags/delSeries", true)
+	responses, err := s.peerQuery(ctx.Req.Context(), data, "clusterTagDelSeries,", "/index/tags/delSeries", true) // note: needlessl hits query nodes with no data, but can be cleaned later
 	if err != nil {
 		response.Write(ctx, response.WrapErrorForTagDB(err))
 		return

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -87,8 +87,8 @@ func MembersForQuery() ([]Node, error) {
 		}
 	}
 
-	for _, member := range Manager.MemberList() {
-		if !member.IsReady() || member.GetName() == thisNode.GetName() {
+	for _, member := range Manager.MemberList(true, true) {
+		if member.GetName() == thisNode.GetName() {
 			continue
 		}
 		for _, part := range member.GetPartitions() {
@@ -159,7 +159,7 @@ LOOP:
 // keyed by the first (lowest) partition of their shard group
 func MembersForSpeculativeQuery() (map[int32][]Node, error) {
 	thisNode := Manager.ThisNode()
-	allNodes := Manager.MemberList()
+	allNodes := Manager.MemberList(true, true)
 	membersMap := make(map[int32][]Node)
 
 	// If we are running in dev mode, just return thisNode
@@ -172,13 +172,7 @@ func MembersForSpeculativeQuery() (map[int32][]Node, error) {
 
 	// store the available nodes for each partition group
 	for _, member := range allNodes {
-		if !member.IsReady() {
-			continue
-		}
 		partitions := member.GetPartitions()
-		if len(partitions) == 0 {
-			continue
-		}
 		memberStartPartition := partitions[0]
 
 		if _, ok := membersMap[memberStartPartition]; !ok {

--- a/cluster/if.go
+++ b/cluster/if.go
@@ -9,6 +9,7 @@ type Node interface {
 	IsReady() bool
 	GetPartitions() []int32
 	GetPriority() int
+	HasData() bool
 	Post(context.Context, string, string, Traceable) ([]byte, error)
 	GetName() string
 }

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -27,6 +27,10 @@ func (n *MockNode) GetPartitions() []int32 {
 	return n.partitions
 }
 
+func (n *MockNode) HasData() bool {
+	return len(n.partitions) > 0
+}
+
 func (n *MockNode) GetPriority() int {
 	return n.priority
 }
@@ -55,8 +59,18 @@ type MockClusterManager struct {
 	partitions []int32
 }
 
-func (c *MockClusterManager) MemberList() []Node {
-	return mockToIf(c.Peers)
+func (c *MockClusterManager) MemberList(isReady, hasData bool) []Node {
+	var out []Node
+	for _, p := range c.Peers {
+		if isReady && !p.IsReady() {
+			continue
+		}
+		if hasData && !p.HasData() {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 func (c *MockClusterManager) ThisNode() Node {
@@ -97,12 +111,4 @@ func InitMock() *MockClusterManager {
 	manager := &MockClusterManager{}
 	Manager = manager
 	return manager
-}
-
-func mockToIf(in []*MockNode) []Node {
-	out := make([]Node, len(in))
-	for i, m := range in {
-		out[i] = m
-	}
-	return out
 }

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -43,9 +43,10 @@ func (n *MockNode) GetName() string {
 	return n.name
 }
 
-func NewMockNode(isLocal bool, name string, postResponse []byte) *MockNode {
+func NewMockNode(isLocal bool, name string, partitions []int32, postResponse []byte) *MockNode {
 	return &MockNode{
 		isLocal:      isLocal,
+		partitions:   partitions,
 		name:         name,
 		postResponse: postResponse,
 	}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -180,6 +180,10 @@ func (n HTTPNode) GetPartitions() []int32 {
 	return n.Partitions
 }
 
+func (n HTTPNode) HasData() bool {
+	return len(n.Partitions) > 0
+}
+
 func (n HTTPNode) IsLocal() bool {
 	return n.local
 }

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -296,13 +296,19 @@ func main() {
 	/***********************************
 		Initialize the Chunk Cache
 	***********************************/
-	ccache := cache.NewCCache()
-	ccache.SetTracer(tracer)
+	var ccache *cache.CCache
+	if inputEnabled {
+		ccache = cache.NewCCache()
+		ccache.SetTracer(tracer)
+	}
 
 	/***********************************
 		Initialize our MemoryStore
 	***********************************/
-	metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, chunkMaxStale, metricMaxStale, gcInterval)
+
+	if inputEnabled {
+		metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, chunkMaxStale, metricMaxStale, gcInterval)
+	}
 
 	/***********************************
 		Initialize our Inputs


### PR DESCRIPTION
fix #1293 
tested with docker-cluster-query
```
curl -v -s -i http://localhost:6061/metrics/delete -d "query=foo.bar.*"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 6061 (#0)
> POST /metrics/delete HTTP/1.1
> Host: localhost:6061
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Length: 15
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 15 out of 15 bytes
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Content-Type: application/json
Content-Type: application/json
< Date: Thu, 25 Apr 2019 19:19:15 GMT
Date: Thu, 25 Apr 2019 19:19:15 GMT
< Server: Caddy
Server: Caddy
< Trace-Id: 77f0002c62c7ce6a
Trace-Id: 77f0002c62c7ce6a
< Vary: Accept-Encoding
Vary: Accept-Encoding
< Content-Length: 17
Content-Length: 17

< 
* Connection #0 to host localhost left intact
{"deletedDefs":0}* Closing connection 0
```
```
metrictank-q0_1  | [Macaron] 2019-04-25 19:19:15: Started POST /metrics/delete for 172.19.0.1
metrictank2_1    | [Macaron] 2019-04-25 19:19:15: Started POST /index/delete for 172.19.0.15
metrictank0_1    | [Macaron] 2019-04-25 19:19:15: Started POST /index/delete for 172.19.0.15
metrictank1_1    | [Macaron] 2019-04-25 19:19:15: Started POST /index/delete for 172.19.0.15
metrictank3_1    | [Macaron] 2019-04-25 19:19:15: Started POST /index/delete for 172.19.0.15
metrictank0_1    | [Macaron] 2019-04-25 19:19:15: Completed /index/delete 200 OK in 595.024µs
metrictank3_1    | [Macaron] 2019-04-25 19:19:15: Completed /index/delete 200 OK in 843.7µs
metrictank1_1    | [Macaron] 2019-04-25 19:19:15: Completed /index/delete 200 OK in 480.244µs
metrictank-q0_1  | [Macaron] 2019-04-25 19:19:15: Completed /metrics/delete 200 OK in 2.436699ms
metrictank2_1    | [Macaron] 2019-04-25 19:19:15: Completed /index/delete 200 OK in 753.214µs
```


```
curl -v -s -i http://localhost:6061/metrics/delete -d "query=some.id.of.a.metric.1*"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 6061 (#0)
> POST /metrics/delete HTTP/1.1
> Host: localhost:6061
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Length: 28
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 28 out of 28 bytes
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Content-Type: application/json
Content-Type: application/json
< Date: Thu, 25 Apr 2019 19:20:18 GMT
Date: Thu, 25 Apr 2019 19:20:18 GMT
< Server: Caddy
Server: Caddy
< Trace-Id: 372447439ff27ee9
Trace-Id: 372447439ff27ee9
< Vary: Accept-Encoding
Vary: Accept-Encoding
< Content-Length: 19
Content-Length: 19

< 
* Connection #0 to host localhost left intact
{"deletedDefs":224}* Closing connection 0
```
```
metrictank-q0_1  | [Macaron] 2019-04-25 19:20:18: Started POST /metrics/delete for 172.19.0.1
metrictank3_1    | [Macaron] 2019-04-25 19:20:18: Started POST /index/delete for 172.19.0.15
metrictank0_1    | [Macaron] 2019-04-25 19:20:18: Started POST /index/delete for 172.19.0.15
metrictank2_1    | [Macaron] 2019-04-25 19:20:18: Started POST /index/delete for 172.19.0.15
metrictank1_1    | [Macaron] 2019-04-25 19:20:18: Started POST /index/delete for 172.19.0.15
metrictank1_1    | [Macaron] 2019-04-25 19:20:18: Completed /index/delete 200 OK in 36.641483ms
metrictank3_1    | [Macaron] 2019-04-25 19:20:18: Completed /index/delete 200 OK in 45.013004ms
metrictank2_1    | [Macaron] 2019-04-25 19:20:18: Completed /index/delete 200 OK in 47.188199ms
metrictank0_1    | [Macaron] 2019-04-25 19:20:18: Completed /index/delete 200 OK in 49.311407ms
metrictank-q0_1  | [Macaron] 2019-04-25 19:20:18: Completed /metrics/delete 200 OK in 51.236528ms
```