### PR TITLE
Add absolute function

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -36,7 +36,7 @@ See also:
 
 | Function name and signature                                    | Alias        | Metrictank |
 | -------------------------------------------------------------- | ------------ | ---------- |
-| absolute                                                       |              | No         |
+| absolute                                                       |              | Stable     |
 | aggregate                                                      |              | No         |
 | aggregateLine                                                  |              | No         |
 | aggregateWithWildcards                                         |              | No         |

--- a/expr/func_absolute.go
+++ b/expr/func_absolute.go
@@ -34,8 +34,8 @@ func (s *FuncAbsolute) Exec(cache map[Req][]models.Series) ([]models.Series, err
 	out := make([]models.Series, len(series))
 	for i, serie := range series {
 		transformed := &out[i]
-		transformed.Target = fmt.Sprintf("absolutes(%s)", serie.Target)
-		transformed.QueryPatt = fmt.Sprintf("absolutes(%s)", serie.QueryPatt)
+		transformed.Target = fmt.Sprintf("absolute(%s)", serie.Target)
+		transformed.QueryPatt = fmt.Sprintf("absolute(%s)", serie.QueryPatt)
 		transformed.Tags = make(map[string]string, len(serie.Tags)+1)
 		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
 		transformed.Interval = serie.Interval
@@ -45,7 +45,7 @@ func (s *FuncAbsolute) Exec(cache map[Req][]models.Series) ([]models.Series, err
 		for k, v := range serie.Tags {
 			transformed.Tags[k] = v
 		}
-		transformed.Tags["absolutes"] = "1"
+		transformed.Tags["absolute"] = "1"
 		for _, p := range serie.Datapoints {
 			p.Val = math.Abs(p.Val)
 			transformed.Datapoints = append(transformed.Datapoints, p)

--- a/expr/func_absolute.go
+++ b/expr/func_absolute.go
@@ -1,0 +1,57 @@
+package expr
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/raintank/schema"
+)
+
+type FuncAbsolute struct {
+	in GraphiteFunc
+}
+
+func NewAbsolute() GraphiteFunc {
+	return &FuncAbsolute{}
+}
+
+func (s *FuncAbsolute) Signature() ([]Arg, []Arg) {
+	return []Arg{
+		ArgSeriesList{val: &s.in}}, []Arg{ArgSeriesList{}}
+}
+
+func (s *FuncAbsolute) Context(context Context) Context {
+	return context
+}
+
+func (s *FuncAbsolute) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
+	series, err := s.in.Exec(cache)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]models.Series, len(series))
+	for i, serie := range series {
+		transformed := &out[i]
+		transformed.Target = fmt.Sprintf("absolutes(%s)", serie.Target)
+		transformed.QueryPatt = fmt.Sprintf("absolutes(%s)", serie.QueryPatt)
+		transformed.Tags = make(map[string]string, len(serie.Tags)+1)
+		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
+		transformed.Interval = serie.Interval
+		transformed.Consolidator = serie.Consolidator
+		transformed.QueryCons = serie.QueryCons
+
+		for k, v := range serie.Tags {
+			transformed.Tags[k] = v
+		}
+		transformed.Tags["absolutes"] = "1"
+		for _, p := range serie.Datapoints {
+			p.Val = math.Abs(p.Val)
+			transformed.Datapoints = append(transformed.Datapoints, p)
+		}
+		cache[Req{}] = append(cache[Req{}], *transformed)
+	}
+
+	return out, nil
+}

--- a/expr/func_absolute_test.go
+++ b/expr/func_absolute_test.go
@@ -1,0 +1,124 @@
+package expr
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/test"
+	"github.com/raintank/schema"
+)
+
+func getNewAbsolute(in []models.Series) *FuncAbsolute {
+	f := NewAbsolute()
+	ps := f.(*FuncAbsolute)
+	ps.in = NewMock(in)
+	return ps
+}
+
+var random = []schema.Point{
+	{Val: 0, Ts: 10},
+	{Val: -10, Ts: 20},
+	{Val: 5.5, Ts: 30},
+	{Val: math.NaN(), Ts: 40},
+	{Val: -math.MaxFloat64, Ts: 50},
+	{Val: -1234567890, Ts: 60},
+	{Val: math.MaxFloat64, Ts: 70},
+}
+
+var randomAbsolute = []schema.Point{
+	{Val: 0, Ts: 10},
+	{Val: 10, Ts: 20},
+	{Val: 5.5, Ts: 30},
+	{Val: math.NaN(), Ts: 40},
+	{Val: math.MaxFloat64, Ts: 50},
+	{Val: 1234567890, Ts: 60},
+	{Val: math.MaxFloat64, Ts: 70},
+}
+
+func TestAbsoluteRandom(t *testing.T) {
+	f := getNewAbsolute(
+		[]models.Series{
+			{
+				Interval:   10,
+				QueryPatt:  "random",
+				Target:     "rand",
+				Datapoints: getCopy(random),
+			},
+		},
+	)
+	out := []models.Series{
+		{
+			Interval:   10,
+			QueryPatt:  "absolute(random)",
+			Target:     "absolute(rand)",
+			Datapoints: getCopy(randomAbsolute),
+		},
+	}
+
+	got, err := f.Exec(make(map[Req][]models.Series))
+	if err := equalOutput(out, got, nil, err); err != nil {
+		t.Fatal(err)
+	}
+}
+func BenchmarkAbsolute10k_1NoNulls(b *testing.B) {
+	benchmarkAbsolute(b, 1, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkAbsolute10k_10NoNulls(b *testing.B) {
+	benchmarkAbsolute(b, 10, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkAbsolute10k_100NoNulls(b *testing.B) {
+	benchmarkAbsolute(b, 100, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkAbsolute10k_1000NoNulls(b *testing.B) {
+	benchmarkAbsolute(b, 1000, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkAbsolute10k_1SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 1, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkAbsolute10k_10SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 10, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkAbsolute10k_100SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 100, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkAbsolute10k_1000SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 1000, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkAbsolute10k_1AllSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkAbsolute10k_10AllSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 10, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkAbsolute10k_100AllSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 100, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkAbsolute10k_1000AllSeriesHalfNulls(b *testing.B) {
+	benchmarkAbsolute(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func benchmarkAbsolute(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var input []models.Series
+	for i := 0; i < numSeries; i++ {
+		series := models.Series{
+			QueryPatt: strconv.Itoa(i),
+		}
+		if i%2 == 0 {
+			series.Datapoints = fn0()
+		} else {
+			series.Datapoints = fn1()
+		}
+		input = append(input, series)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewAbsolute()
+		f.(*FuncAbsolute).in = NewMock(input)
+		got, err := f.Exec(make(map[Req][]models.Series))
+		if err != nil {
+			b.Fatalf("%s", err)
+		}
+		results = got
+	}
+}

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -48,6 +48,7 @@ var funcs map[string]funcDef
 func init() {
 	// keys must be sorted alphabetically. but functions with aliases can go together, in which case they are sorted by the first of their aliases
 	funcs = map[string]funcDef{
+		"absolute":              {NewAbsolute, false},
 		"alias":                 {NewAlias, true},
 		"aliasByTags":           {NewAliasByNode, true},
 		"aliasByNode":           {NewAliasByNode, true},

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -48,7 +48,7 @@ var funcs map[string]funcDef
 func init() {
 	// keys must be sorted alphabetically. but functions with aliases can go together, in which case they are sorted by the first of their aliases
 	funcs = map[string]funcDef{
-		"absolute":              {NewAbsolute, false},
+		"absolute":              {NewAbsolute, true},
 		"alias":                 {NewAlias, true},
 		"aliasByTags":           {NewAliasByNode, true},
 		"aliasByNode":           {NewAliasByNode, true},


### PR DESCRIPTION
Native implementation of absolute() Graphite function. (http://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.absolute)

Speed improvement:
```
---------- Native targets/absolute.json Latencies ----------
Mean: 6.219059ms
50th percentile: 5.131637ms
95th percentile: 12.810392ms
99th percentile: 19.082978ms
Max: 28.004244ms
Success: 100%
Errors: []

---------- Graphite (Python) targets/absolute.json Latencies ----------
Mean: 21.843168ms
50th percentile: 20.08863ms
95th percentile: 30.953993ms
99th percentile: 46.838977ms
Max: 249.920044ms

Success: 100%
Errors: []

---------- Speed Improvement ----------
Mean: x3.5
50th percentile: x3.9
95th percentile: x2.4
99th percentile: x2.5
Max: x8.9
```
