### PR TITLE
Added cumulative function

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -61,7 +61,7 @@ See also:
 | consolidateBy(seriesList, func) seriesList                     |              | Stable     |
 | constantLine                                                   |              | No         |
 | countSeries(seriesLists) series                                |              | Stable     |
-| cumulative                                                     |              | No         |
+| cumulative                                                     |              | Stable     |
 | currentAbove                                                   |              | No         |
 | currentBelow                                                   |              | No         |
 | dashed                                                         |              | No         |

--- a/expr/func_consolidateby.go
+++ b/expr/func_consolidateby.go
@@ -16,7 +16,18 @@ func NewConsolidateBy() GraphiteFunc {
 	return &FuncConsolidateBy{}
 }
 
+func NewConsolidateByConstructor(by string) func() GraphiteFunc {
+	return func() GraphiteFunc {
+		return &FuncConsolidateBy{by: by}
+	}
+}
+
 func (s *FuncConsolidateBy) Signature() ([]Arg, []Arg) {
+	if s.by != "" {
+		return []Arg{
+			ArgSeriesList{val: &s.in},
+		}, []Arg{ArgSeriesList{}}
+	}
 	return []Arg{
 		ArgSeriesList{val: &s.in},
 		ArgString{val: &s.by, validator: []Validator{IsConsolFunc}},

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -58,6 +58,7 @@ func init() {
 		"averageSeries":         {NewAggregateConstructor("average", crossSeriesAvg), true},
 		"consolidateBy":         {NewConsolidateBy, true},
 		"countSeries":           {NewCountSeries, true},
+		"cumulative":            {NewConsolidateByConstructor("sum"), true},
 		"derivative":            {NewDerivative, true},
 		"diffSeries":            {NewAggregateConstructor("diff", crossSeriesDiff), true},
 		"divideSeries":          {NewDivideSeries, true},


### PR DESCRIPTION
Native implementation of cumulative() Graphite function. (http://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.cumulative)

This is essentially an alias of consolidateBy('sum')