### PR TITLE
[WIP and BLOCKED] Added Tilt support to all docker stacks

### DIFF
--- a/docker/docker-chaos/Tiltfile
+++ b/docker/docker-chaos/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-cluster-query/Tiltfile
+++ b/docker/docker-cluster-query/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-cluster/Tiltfile
+++ b/docker/docker-cluster/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-cosmosdb/Tiltfile
+++ b/docker/docker-cosmosdb/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-dev-bigtable/Tiltfile
+++ b/docker/docker-dev-bigtable/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-dev-custom-cfg-kafka/Tiltfile
+++ b/docker/docker-dev-custom-cfg-kafka/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-dev-custom-cfg-kafka/Tiltfile
+++ b/docker/docker-dev-custom-cfg-kafka/Tiltfile
@@ -1,1 +1,13 @@
 docker_compose("./docker-compose.yml")
+
+# FIXME: would not be so complex if our Dockerfile did not rely on an external script (build_docker.sh) to copy the right binaries
+# It could then become docker_build('grafana/metrictank', '../../scripts/')
+# Additionally docker_build would not be needed at all if https://github.com/windmilleng/tilt/issues/1638 was implemented
+custom_build('grafana/metrictank',
+            'mkdir -p ../../scripts/build/ && cp ../../build/* ../../scripts/build/ && docker build -t $EXPECTED_REF ../../scripts/',
+            deps=['../../build/'],
+            live_update = [
+                # because /usr/bin/metrictank is a mount (specified in docker-compose.yml) we cannot overwrite it
+                sync('../../build/', '/tmp/'),
+                restart_container()
+])

--- a/docker/docker-dev-debug/Tiltfile
+++ b/docker/docker-dev-debug/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-dev-scylla/Tiltfile
+++ b/docker/docker-dev-scylla/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-dev/Tiltfile
+++ b/docker/docker-dev/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/docker/docker-standard/Tiltfile
+++ b/docker/docker-standard/Tiltfile
@@ -1,0 +1,1 @@
+docker_compose("./docker-compose.yml")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,9 +18,6 @@ BUILDDIR=$(pwd)/build
 # Make dir
 mkdir -p $BUILDDIR
 
-# Clean build bin dir
-rm -rf $BUILDDIR/*
-
 # disable cgo
 export CGO_ENABLED=0
 


### PR DESCRIPTION
Added Tilt (https://tilt.dev/) support to all docker stacks.
After having installed Tilt, for example with `curl -L https://github.com/windmilleng/tilt/releases/download/v0.8.4/tilt.0.8.4.linux.x86_64.tar.gz | tar -xzv tilt && mv tilt $GOPATH/bin/tilt`, go into a docker stack directory and do `tilt up` to see the magic unfold.