### PR TITLE
Added substr and aliasByMetric functions

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -41,7 +41,7 @@ See also:
 | aggregateLine                                                  |              | No         |
 | aggregateWithWildcards                                         |              | No         |
 | alias(seriesList, alias) seriesList                            |              | Stable     |
-| aliasByMetric                                                  |              | No         |
+| aliasByMetric                                                  |              | Stable     |
 | aliasByNode(seriesList, nodeList) seriesList                   | aliasByTags  | Stable     |
 | aliasByTags                                                    |              | No         |
 | aliasQuery                                                     |              | No         |

--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -159,7 +159,7 @@ See also:
 | stacked                                                        |              | No         |
 | stddevSeries(seriesList) series                                |              | Stable     |
 | stdev                                                          |              | No         |
-| substr                                                         |              | No         |
+| substr                                                         |              | Stable     |
 | summarize(seriesList) seriesList                               |              | Stable     |
 | sumSeries(seriesLists) series                                  | sum          | Stable     |
 | sumSeriesWithWildcards                                         |              | No         |

--- a/expr/func_substr.go
+++ b/expr/func_substr.go
@@ -52,7 +52,6 @@ func (s *FuncSubstr) Exec(cache map[Req][]models.Series) ([]models.Series, error
 		}
 
 		serie.Target = name
-		serie.QueryPatt = name
 		out[i] = serie
 		cache[Req{}] = append(cache[Req{}], serie)
 	}

--- a/expr/func_substr.go
+++ b/expr/func_substr.go
@@ -1,0 +1,61 @@
+package expr
+
+import (
+	"strings"
+
+	"github.com/grafana/metrictank/api/models"
+)
+
+type FuncSubstr struct {
+	in    GraphiteFunc
+	start int64
+	stop  int64
+}
+
+func NewSubstr() GraphiteFunc {
+	return &FuncSubstr{}
+}
+
+func (s *FuncSubstr) Signature() ([]Arg, []Arg) {
+	return []Arg{
+		ArgSeriesList{val: &s.in},
+		ArgInt{val: &s.start, opt: true, key: "start"},
+		ArgInt{val: &s.stop, opt: true, key: "stop"},
+	}, []Arg{ArgSeriesList{}}
+}
+
+func (s *FuncSubstr) Context(context Context) Context {
+	return context
+}
+
+func (s *FuncSubstr) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
+	series, err := s.in.Exec(cache)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]models.Series, len(series))
+	for i, serie := range series {
+		out[i] = serie
+		left := strings.LastIndex(serie.Target, "(") + 1
+		right := strings.Index(serie.Target, ")")
+		if right < 0 {
+			right = len(serie.Target) + 1
+		}
+		cleanName := serie.Target[left:right]
+		cleanName = strings.SplitN(cleanName, ",", 2)[0]
+
+		var name string
+		if s.stop == 0 {
+			name = strings.Join(strings.Split(cleanName, ".")[s.start:], ".")
+		} else {
+			name = strings.Join(strings.Split(cleanName, ".")[s.start:s.stop], ".")
+		}
+
+		serie.Target = name
+		serie.QueryPatt = name
+		cache[Req{}] = append(cache[Req{}], serie)
+	}
+
+	return out, nil
+}

--- a/expr/func_substr.go
+++ b/expr/func_substr.go
@@ -36,11 +36,10 @@ func (s *FuncSubstr) Exec(cache map[Req][]models.Series) ([]models.Series, error
 
 	out := make([]models.Series, len(series))
 	for i, serie := range series {
-		out[i] = serie
 		left := strings.LastIndex(serie.Target, "(") + 1
 		right := strings.Index(serie.Target, ")")
 		if right < 0 {
-			right = len(serie.Target) + 1
+			right = len(serie.Target)
 		}
 		cleanName := serie.Target[left:right]
 		cleanName = strings.SplitN(cleanName, ",", 2)[0]
@@ -54,6 +53,7 @@ func (s *FuncSubstr) Exec(cache map[Req][]models.Series) ([]models.Series, error
 
 		serie.Target = name
 		serie.QueryPatt = name
+		out[i] = serie
 		cache[Req{}] = append(cache[Req{}], serie)
 	}
 

--- a/expr/func_substr_test.go
+++ b/expr/func_substr_test.go
@@ -1,0 +1,192 @@
+package expr
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/test"
+	"github.com/raintank/schema"
+)
+
+func getNewSubstr(in []models.Series, start, stop int64) *FuncSubstr {
+	f := NewSubstr()
+	s := f.(*FuncSubstr)
+	s.in = NewMock(in)
+	s.start = start
+	s.stop = stop
+	return s
+}
+
+func TestSubstrNoArgs(t *testing.T) {
+	f := getNewSubstr(
+		[]models.Series{
+			{
+				Interval:   10,
+				QueryPatt:  "a.b.c.d.*",
+				Target:     "a.b.c.d.e",
+				Datapoints: getCopy(a),
+			},
+		},
+		0,
+		0,
+	)
+	out := []models.Series{
+		{
+			Interval:   10,
+			QueryPatt:  "a.b.c.d.*",
+			Target:     "a.b.c.d.e",
+			Datapoints: getCopy(a),
+		},
+	}
+
+	got, err := f.Exec(make(map[Req][]models.Series))
+	if err := equalOutput(out, got, nil, err); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSubstrStart(t *testing.T) {
+	f := getNewSubstr(
+		[]models.Series{
+			{
+				Interval:   10,
+				QueryPatt:  "a.b.c.d.*",
+				Target:     "a.b.c.d.e",
+				Datapoints: getCopy(a),
+			},
+		},
+		2,
+		0,
+	)
+	out := []models.Series{
+		{
+			Interval:   10,
+			QueryPatt:  "a.b.c.d.*",
+			Target:     "c.d.e",
+			Datapoints: getCopy(a),
+		},
+	}
+
+	got, err := f.Exec(make(map[Req][]models.Series))
+	if err := equalOutput(out, got, nil, err); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSubstrStartStop(t *testing.T) {
+	f := getNewSubstr(
+		[]models.Series{
+			{
+				Interval:   10,
+				QueryPatt:  "a.b.c.d.*",
+				Target:     "a.b.c.d.e",
+				Datapoints: getCopy(a),
+			},
+		},
+		2,
+		4,
+	)
+	out := []models.Series{
+		{
+			Interval:   10,
+			QueryPatt:  "a.b.c.d.*",
+			Target:     "c.d",
+			Datapoints: getCopy(a),
+		},
+	}
+
+	got, err := f.Exec(make(map[Req][]models.Series))
+	if err := equalOutput(out, got, nil, err); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSubstrWithFuncs(t *testing.T) {
+	f := getNewSubstr(
+		[]models.Series{
+			{
+				Interval:   10,
+				QueryPatt:  "foo(bar(a.b.c.d.*,foo))",
+				Target:     "foo(bar(a.b.c.d.e,foo))",
+				Datapoints: getCopy(a),
+			},
+		},
+		2,
+		4,
+	)
+	out := []models.Series{
+		{
+			Interval:   10,
+			QueryPatt:  "foo(bar(a.b.c.d.*,foo))",
+			Target:     "c.d",
+			Datapoints: getCopy(a),
+		},
+	}
+
+	got, err := f.Exec(make(map[Req][]models.Series))
+	if err := equalOutput(out, got, nil, err); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func BenchmarkSubstr10k_1NoNulls(b *testing.B) {
+	benchmarkSubstr(b, 1, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkSubstr10k_10NoNulls(b *testing.B) {
+	benchmarkSubstr(b, 10, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkSubstr10k_100NoNulls(b *testing.B) {
+	benchmarkSubstr(b, 100, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkSubstr10k_1000NoNulls(b *testing.B) {
+	benchmarkSubstr(b, 1000, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkSubstr10k_1SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 1, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkSubstr10k_10SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 10, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkSubstr10k_100SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 100, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkSubstr10k_1000SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 1000, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkSubstr10k_1AllSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkSubstr10k_10AllSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 10, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkSubstr10k_100AllSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 100, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkSubstr10k_1000AllSeriesHalfNulls(b *testing.B) {
+	benchmarkSubstr(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func benchmarkSubstr(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var input []models.Series
+	for i := 0; i < numSeries; i++ {
+		series := models.Series{
+			QueryPatt: strconv.Itoa(i),
+		}
+		if i%2 == 0 {
+			series.Datapoints = fn0()
+		} else {
+			series.Datapoints = fn1()
+		}
+		input = append(input, series)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewSubstr()
+		f.(*FuncSubstr).in = NewMock(input)
+		got, err := f.Exec(make(map[Req][]models.Series))
+		if err != nil {
+			b.Fatalf("%s", err)
+		}
+		results = got
+	}
+}

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -105,7 +105,7 @@ func init() {
 		"sortByName":            {NewSortByName, true},
 		"sortByTotal":           {NewSortByConstructor("sum", true), true},
 		"stddevSeries":          {NewAggregateConstructor("stddev", crossSeriesStddev), true},
-		"substr":                {NewSubstr, false},
+		"substr":                {NewSubstr, true},
 		"sum":                   {NewAggregateConstructor("sum", crossSeriesSum), true},
 		"sumSeries":             {NewAggregateConstructor("sum", crossSeriesSum), true},
 		"summarize":             {NewSummarize, true},

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -51,6 +51,7 @@ func init() {
 		"absolute":              {NewAbsolute, true},
 		"alias":                 {NewAlias, true},
 		"aliasByTags":           {NewAliasByNode, true},
+		"aliasByMetric":         {NewAliasByMetric, true},
 		"aliasByNode":           {NewAliasByNode, true},
 		"aliasSub":              {NewAliasSub, true},
 		"asPercent":             {NewAsPercent, true},

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -105,6 +105,7 @@ func init() {
 		"sortByName":            {NewSortByName, true},
 		"sortByTotal":           {NewSortByConstructor("sum", true), true},
 		"stddevSeries":          {NewAggregateConstructor("stddev", crossSeriesStddev), true},
+		"substr":                {NewSubstr, false},
 		"sum":                   {NewAggregateConstructor("sum", crossSeriesSum), true},
 		"sumSeries":             {NewAggregateConstructor("sum", crossSeriesSum), true},
 		"summarize":             {NewSummarize, true},


### PR DESCRIPTION
Native implementation of [substr()](http://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.substr) and [aliasByMetric()](http://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.aliasByMetric) Graphite functions. 