### PR TITLE
make sure cancel always gets called

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1049,6 +1049,7 @@ func (s *Server) graphiteTagFindSeries(ctx *middleware.Context, request models.G
 func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions []string, from int64, maxSeries int) ([]Series, error) {
 	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions, From: from}
 	newCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	responseChan, errorChan := s.peerQuerySpeculativeChan(newCtx, data, "clusterFindByTag", "/index/find_by_tag")
 
 	var allSeries []Series
@@ -1057,13 +1058,11 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		resp := models.IndexFindByTagResp{}
 		_, err := resp.UnmarshalMsg(r.buf)
 		if err != nil {
-			cancel()
 			return nil, err
 		}
 
 		// 0 disables the check, so only check if maxSeriesPerReq > 0
 		if maxSeriesPerReq > 0 && len(resp.Metrics)+len(allSeries) > maxSeries {
-			cancel()
 			return nil,
 				response.NewError(
 					http.StatusRequestEntityTooLarge,


### PR DESCRIPTION
I tested the find by tag calls in a local docker env to make sure everything is still working fine