### PR TITLE
remove deprecated tool unused

### DIFF
--- a/scripts/qa/unused.sh
+++ b/scripts/qa/unused.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 
-# runs the tools varcheck, structcheck and deadcode
+# runs the tools staticcheck, varcheck, structcheck and deadcode
 # see their websites for more info.
 
 # find the dir we exist within...
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # and cd into root project dir
 cd ${DIR}/../..
+go get -u honnef.co/go/tools/cmd/staticcheck
 go get -u github.com/opennota/check/cmd/varcheck
 go get -u github.com/opennota/check/cmd/structcheck
 # for https://github.com/remyoudompheng/go-misc/pull/14
 go get -u github.com/Dieterbe/go-misc/deadcode
 
 ret=0
+
+echo "## running staticcheck"
+staticcheck -checks U1000 ./...
+r=$?
+[ $r -gt $ret ] && ret=$r
 
 echo "## running varcheck"
 varcheck ./...

--- a/scripts/qa/unused.sh
+++ b/scripts/qa/unused.sh
@@ -1,24 +1,18 @@
 #!/bin/bash
 
-# runs the tools unused, varcheck and structcheck
+# runs the tools varcheck, structcheck and deadcode
 # see their websites for more info.
 
 # find the dir we exist within...
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # and cd into root project dir
 cd ${DIR}/../..
-go get -u honnef.co/go/tools/cmd/unused
 go get -u github.com/opennota/check/cmd/varcheck
 go get -u github.com/opennota/check/cmd/structcheck
 # for https://github.com/remyoudompheng/go-misc/pull/14
 go get -u github.com/Dieterbe/go-misc/deadcode
 
 ret=0
-
-echo "## running unused"
-unused ./...
-r=$?
-[ $r -gt $ret ] && ret=$r
 
 echo "## running varcheck"
 varcheck ./...


### PR DESCRIPTION
The tool `honnef.co/go/tools/cmd/unused` no longer exists, so the failure to retrieve it is currently blocking the CI pipeline.
We should probably start using the tool `honnef.co/go/tools/cmd/staticcheck` instead. Since this adds a lot of additional checks, many of which we'll need to either decide to ignore or fix what they are warning about in the code, i think this should be a separate PR to do it properly.