### PR TITLE
fix leak of find cache routines

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -146,6 +146,7 @@ func (s *Server) Run() {
 
 func (s *Server) Stop() {
 	close(s.shutdown)
+	s.MetricIndex.Stop()
 }
 
 func (s *Server) handleShutdown(l net.Listener) {

--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -38,6 +38,7 @@ func newSrv(delSeries, delArchives int) (*Server, *cache.MockCache) {
 	srv.BindCache(mockCache)
 
 	metricIndex := memory.New()
+	metricIndex.Init()
 	srv.BindMetricIndex(metricIndex)
 	return srv, mockCache
 }
@@ -51,6 +52,8 @@ func TestMetricDeleteWithPattern(t *testing.T) {
 	testId := test.GetMKey(12345)
 
 	srv, cache := newSrv(delSeries, delArchives)
+	defer srv.Stop()
+
 	srv.MetricIndex.AddOrUpdate(
 		testId,
 		&schema.MetricData{
@@ -103,6 +106,7 @@ func TestMetricDeleteWithTags(t *testing.T) {
 	testId := test.GetMKey(12345)
 
 	srv, cache := newSrv(delSeries, delArchives)
+	defer srv.Stop()
 	srv.MetricIndex.AddOrUpdate(
 		testId,
 		&schema.MetricData{
@@ -153,6 +157,7 @@ func TestMetricDeleteFullFlush(t *testing.T) {
 	})
 
 	srv, cache := newSrv(0, 0)
+	defer srv.Stop()
 	ts := httptest.NewServer(srv.Macaron)
 	defer ts.Close()
 
@@ -192,6 +197,7 @@ func TestMetricDeleteWithErrorInPropagation(t *testing.T) {
 	testId := test.GetMKey(12345)
 
 	srv, _ := newSrv(delSeries, delArchives)
+	defer srv.Stop()
 	srv.MetricIndex.AddOrUpdate(
 		testId,
 		&schema.MetricData{
@@ -258,6 +264,7 @@ func TestMetricDeletePropagation(t *testing.T) {
 	expectedDeletedArchives += delArchives
 
 	srv, cache := newSrv(delSeries, delArchives)
+	defer srv.Stop()
 	srv.MetricIndex.AddOrUpdate(
 		testId,
 		&schema.MetricData{

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -212,7 +212,7 @@ func (c *FindCache) forceInvalidation() {
 }
 
 func (c *FindCache) Shutdown() {
-	c.shutdown <- struct{}{}
+	close(c.shutdown)
 }
 
 func (c *FindCache) stats() {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -265,17 +265,19 @@ func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
 		metaTags:       make(map[uint32]metaTagIndex),
 		metaTagRecords: make(map[uint32]metaTagRecords),
 	}
-	if findCacheSize > 0 {
-		m.findCache = NewFindCache(findCacheSize, findCacheInvalidateQueueSize, findCacheInvalidateMaxSize, findCacheInvalidateMaxWait, findCacheBackoffTime)
-	}
 	return &m
 }
 
 func (m *UnpartitionedMemoryIdx) Init() error {
+	if findCacheSize > 0 {
+		m.findCache = NewFindCache(findCacheSize, findCacheInvalidateQueueSize, findCacheInvalidateMaxSize, findCacheInvalidateMaxWait, findCacheBackoffTime)
+	}
 	return nil
 }
 
 func (m *UnpartitionedMemoryIdx) Stop() {
+	m.findCache.Shutdown()
+	m.findCache = nil
 	return
 }
 

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -177,6 +177,7 @@ func InitSmallIndex() {
 		currentIndex = 1
 	} else {
 		ix.PurgeFindCache()
+		ix.Init()
 		return
 	}
 
@@ -224,6 +225,7 @@ func InitLargeIndex() {
 		currentIndex = 2
 	} else {
 		ix.PurgeFindCache()
+		ix.Init()
 		return
 	}
 
@@ -315,6 +317,7 @@ func TestTagDetailsWithoutFilters(t *testing.T) {
 
 func testTagDetailsWithoutFilters(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	expected := make(map[string]uint64)
 	expected["dc0"] = 33600
@@ -331,6 +334,7 @@ func TestTagDetailsWithFrom(t *testing.T) {
 
 func testTagDetailsWithFrom(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	expected := make(map[string]uint64)
 	expected["dc3"] = 2500
@@ -345,6 +349,7 @@ func TestTagDetailsWithFilter(t *testing.T) {
 
 func testTagDetailsWithFilter(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	expected := make(map[string]uint64)
 	expected["dc3"] = 33600
@@ -359,6 +364,7 @@ func TestTagDetailsWithFilterAndFrom(t *testing.T) {
 
 func testTagDetailsWithFilterAndFrom(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	expected := make(map[string]uint64)
 	expected["dc4"] = 25600
@@ -391,6 +397,7 @@ func TestTagKeysWithoutFilters(t *testing.T) {
 
 func testTagKeysWithoutFilters(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	expected := []string{"dc", "host", "device", "cpu", "metric", "direction", "disk", "name"}
 	queryAndCompareTagKeys(t, "", 0, expected)
@@ -402,6 +409,7 @@ func TestTagKeysWithFrom(t *testing.T) {
 
 func testTagKeysWithFrom(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	// disk metrics should all have been added before ts 1000000
 	expected := []string{"dc", "host", "device", "cpu", "metric", "name"}
@@ -414,6 +422,7 @@ func TestTagKeysWithFilter(t *testing.T) {
 
 func testTagKeysWithFilter(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	expected := []string{"dc", "device", "disk", "direction"}
 	queryAndCompareTagKeys(t, "d", 0, expected)
@@ -428,6 +437,7 @@ func TestTagKeysWithFromAndFilter(t *testing.T) {
 
 func testTagKeysWithFromAndFilter(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	expected := []string{"dc", "device"}
 	queryAndCompareTagKeys(t, "d", 100000, expected)
@@ -506,6 +516,7 @@ func TestAutoCompleteTag(t *testing.T) {
 
 func testAutoCompleteTag(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	type testCase struct {
 		prefix string
@@ -612,6 +623,7 @@ func TestAutoCompleteTagValues(t *testing.T) {
 
 func testAutoCompleteTagValues(t *testing.T) {
 	InitSmallIndex()
+	defer ix.Stop()
 
 	type testCase struct {
 		tag    string
@@ -686,6 +698,7 @@ func BenchmarkTagDetailsWithoutFromNorFilter(b *testing.B) {
 
 func benchmarkTagDetailsWithoutFromNorFilter(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -705,6 +718,7 @@ func BenchmarkTagDetailsWithFromAndFilter(b *testing.B) {
 
 func benchmarkTagDetailsWithFromAndFilter(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 
 	filters := []string{"i", ".+rr", ".+t", "interrupt"}
 	expectedCounts := []uint64{158762, 158750, 158737, 158725}
@@ -727,6 +741,7 @@ func BenchmarkTagsWithFromAndFilter(b *testing.B) {
 
 func benchmarkTagsWithFromAndFilter(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 	filters := []string{"d", "di", "c"}
 	expected := [][]string{
 		{"dc", "device", "direction", "disk"},
@@ -749,6 +764,7 @@ func BenchmarkTagsWithoutFromNorFilter(b *testing.B) {
 
 func benchmarkTagsWithoutFromNorFilter(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 	expected := []string{"dc", "device", "direction", "disk", "cpu", "metric", "name", "host"}
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -779,6 +795,7 @@ func BenchmarkFind(b *testing.B) {
 
 func benchmarkFind(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 	queryCount := len(queries)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -806,6 +823,7 @@ func benchmarkConcurrent4Find(b *testing.B) {
 	}()
 
 	InitLargeIndex()
+	defer ix.Stop()
 	queryCount := len(queries)
 	var wg sync.WaitGroup
 	ch := make(chan testQ)
@@ -840,6 +858,7 @@ func benchmarkConcurrent8Find(b *testing.B) {
 		TagSupport = _tagSupport
 	}()
 	InitLargeIndex()
+	defer ix.Stop()
 	queryCount := len(queries)
 	var wg sync.WaitGroup
 	ch := make(chan testQ)
@@ -875,6 +894,7 @@ func benchmarkConcurrentInsertFind(b *testing.B) {
 	}()
 	findCacheInvalidateQueueSize = 10
 	InitLargeIndex()
+	defer ix.Stop()
 	queryCount := len(queries)
 	var wg sync.WaitGroup
 	ch := make(chan testQ)
@@ -950,6 +970,7 @@ func BenchmarkTagFindSimpleIntersect(b *testing.B) {
 
 func benchmarkTagFindSimpleIntersect(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -965,6 +986,7 @@ func BenchmarkTagFindRegexIntersect(b *testing.B) {
 
 func benchmarkTagFindRegexIntersect(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -980,6 +1002,7 @@ func BenchmarkTagFindMatchingAndFiltering(b *testing.B) {
 
 func benchmarkTagFindMatchingAndFiltering(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -995,6 +1018,7 @@ func BenchmarkTagFindMatchingAndFilteringWithRegex(b *testing.B) {
 
 func benchmarkTagFindMatchingAndFilteringWithRegex(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -1041,6 +1065,7 @@ func BenchmarkTagQueryFilterAndIntersect(b *testing.B) {
 
 func benchmarkTagQueryFilterAndIntersect(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 
 	queries := make([]tagQuery, 0)
 	for _, expressions := range permutations([]string{"direction!=~read", "device!=", "host=~host9[0-9]0", "dc=dc1", "disk!=disk1", "metric=disk_time"}) {
@@ -1071,6 +1096,7 @@ func BenchmarkTagQueryFilterAndIntersectOnlyRegex(b *testing.B) {
 
 func benchmarkTagQueryFilterAndIntersectOnlyRegex(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 
 	queries := make([]tagQuery, 0)
 	for _, expressions := range permutations([]string{"metric!=~.*_time$", "dc=~.*0$", "direction=~wri", "host=~host9[0-9]0", "disk!=~disk[5-9]{1}"}) {
@@ -1098,6 +1124,7 @@ func BenchmarkTagQueryKeysByPrefixSimple(b *testing.B) {
 
 func benchmarkTagQueryKeysByPrefixSimple(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 
 	type testCase struct {
 		prefix string
@@ -1127,6 +1154,7 @@ func BenchmarkTagQueryKeysByPrefixExpressions(b *testing.B) {
 
 func benchmarkTagQueryKeysByPrefixExpressions(b *testing.B) {
 	InitLargeIndex()
+	defer ix.Stop()
 
 	type testCase struct {
 		prefix string

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -194,6 +194,7 @@ func testGetAddKey(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	publicSeries := getMetricData(idx.OrgIdPublic, 2, 5, 10, "metric.public", false)
 	org1Series := getMetricData(1, 2, 5, 10, "metric.org1", false)
@@ -256,6 +257,8 @@ func testFind(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
+
 	for _, s := range getMetricData(idx.OrgIdPublic, 2, 5, 10, "metric.demo", false) {
 		s.Time = 10 * 86400
 		mkey, err := schema.MKeyFromString(s.Id)
@@ -407,6 +410,7 @@ func testDelete(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	publicSeries := getMetricData(idx.OrgIdPublic, 2, 5, 10, "metric.public", false)
 	org1Series := getMetricData(1, 2, 5, 10, "metric.org1", false)
@@ -437,6 +441,7 @@ func testDeleteTagged(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	publicSeries := getMetricData(idx.OrgIdPublic, 2, 5, 10, "metric.public", true)
 	org1Series := getMetricData(1, 2, 5, 10, "metric.org1", true)
@@ -482,6 +487,7 @@ func TestDeleteNodeWith100kChildren(t *testing.T) {
 func testDeleteNodeWith100kChildren(t *testing.T) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	var data *schema.MetricData
 	var key string
@@ -531,6 +537,7 @@ func TestMixedBranchLeaf(t *testing.T) {
 func testMixedBranchLeaf(t *testing.T) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	first := &schema.MetricData{
 		Name:     "foo.bar",
@@ -592,6 +599,8 @@ func TestMixedBranchLeafDelete(t *testing.T) {
 func testMixedBranchLeafDelete(t *testing.T) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
+
 	series := []*schema.MetricData{
 		{
 			Name:     "a.b.c",
@@ -698,6 +707,7 @@ func testPruneTaggedSeries(t *testing.T) {
 	}
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	// add old series
 	series := getMetricData(1, 2, 5, 10, "longterm.old", true)
@@ -815,6 +825,7 @@ func testPruneTaggedSeriesWithCollidingTagSets(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	series := getMetricData(1, 2, 1, 10, "metric.bah", true)
 	serie2 := *series[0]
@@ -889,6 +900,7 @@ func testPrune(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	// add old series
 	for _, s := range getSeriesNames(2, 5, "metric.bah") {
@@ -972,6 +984,7 @@ func TestSingleNodeMetric(t *testing.T) {
 func testSingleNodeMetric(t *testing.T) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	data := &schema.MetricData{
 		Name:     "node1",
@@ -1015,6 +1028,7 @@ func testMemoryIndexHeapUsageWithTags(t *testing.T, unique float32, count int) {
 
 	globalMemoryIndex = New()
 	globalMemoryIndex.Init()
+	defer globalMemoryIndex.Stop()
 
 	series := getMetricDataWithCustomTags(1, 2, count, 10, "somekindof.longereven.metricname.butinstead.ofashorterone.bunchofthingsandstuff", unique)
 
@@ -1061,6 +1075,7 @@ func BenchmarkIndexing(b *testing.B) {
 func benchmarkIndexing(b *testing.B) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	var series string
 	var data *schema.MetricData
@@ -1089,6 +1104,7 @@ func BenchmarkDeletes(b *testing.B) {
 func benchmarkDeletes(b *testing.B) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	var data *schema.MetricData
 	var key string
@@ -1119,6 +1135,7 @@ func BenchmarkPrune(b *testing.B) {
 func benchmarkPrune(b *testing.B) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	var data *schema.MetricData
 	var key string
@@ -1156,6 +1173,7 @@ func BenchmarkPruneLongSeriesNames(b *testing.B) {
 func benchmarkPruneLongSeriesNames(b *testing.B) {
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	var data *schema.MetricData
 	var key string
@@ -1207,6 +1225,7 @@ func testMatchSchemaWithTags(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	data := make([]*schema.MetricDefinition, 10)
 	archives := make([]idx.Archive, 10)

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -387,6 +387,7 @@ func testGetByTag(t *testing.T) {
 
 	ix := New()
 	ix.Init()
+	defer ix.Stop()
 
 	idString := "1.000000000000000000000000000000%02x"
 	mds := make([]schema.MetricData, 20)

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -25,6 +25,8 @@ func BenchmarkProcessMetricDataUniqueMetrics(b *testing.B) {
 	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 800, 8000, 0)
 	metricIndex := memory.New()
 	metricIndex.Init()
+	defer metricIndex.Stop()
+
 	in := NewDefaultHandler(aggmetrics, metricIndex, "BenchmarkProcess")
 
 	// timestamps start at 10 and go up from there. (we can't use 0, see AggMetric.Add())
@@ -62,6 +64,7 @@ func BenchmarkProcessMetricDataSameMetric(b *testing.B) {
 	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 800, 8000, 0)
 	metricIndex := memory.New()
 	metricIndex.Init()
+	defer metricIndex.Stop()
 	in := NewDefaultHandler(aggmetrics, metricIndex, "BenchmarkProcess")
 
 	// timestamps start at 10 and go up from there. (we can't use 0, see AggMetric.Add())


### PR DESCRIPTION
fixes a go routine leak

to verify that it works i added a test which runs last in the `idx/memory` package, this test does nothing else than printing the current number of existing go routines. then i once ran all the tests in that package with this fix, and once without (`CGO_ENABLED=1 go test -race -short -test.v github.com/grafana/metrictank/idx/memory --count=1`)

without fix:
```
=== RUN   TestZZZZShowGoRoutines
The current number of go routines is 206
--- PASS: TestZZZZShowGoRoutines (0.00s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
```
with fix:
```
=== RUN   TestZZZZShowGoRoutines
The current number of go routines is 19
--- PASS: TestZZZZShowGoRoutines (0.00s)  
```

fixes: #1340