### PR TITLE
render response metadata: stats

### DIFF
--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -48,6 +48,7 @@ type GraphiteRender struct {
 	TargetsRails  []string `form:"target[]"` // # Rails/PHP/jQuery common practice format: ?target[]=path.1&target[]=path.2 -> like graphite, we allow this.
 	Format        string   `json:"format" form:"format" binding:"In(,json,msgp,msgpack,pickle)"`
 	NoProxy       bool     `json:"local" form:"local"` //this is set to true by graphite-web when it passes request to cluster servers
+	Meta          bool     `json:"meta" form:"meta"`   // request for meta data, which will be returned as long as the format is compatible (json) and we don't have to go via graphite
 	Process       string   `json:"process" form:"process" binding:"In(,none,stable,any);Default(stable)"`
 }
 

--- a/api/models/graphite_render_meta.go
+++ b/api/models/graphite_render_meta.go
@@ -12,7 +12,7 @@ type ResponseWithMeta struct {
 }
 
 func (rwm ResponseWithMeta) MarshalJSONFast(b []byte) ([]byte, error) {
-	b = append(b, `{"meta-version":"v0.1","meta":`...)
+	b = append(b, `{"version":"v0.1","meta":`...)
 	b, _ = rwm.Meta.MarshalJSONFast(b)
 	b = append(b, `,"series":`...)
 	b, _ = rwm.Series.MarshalJSONFast(b)

--- a/api/models/graphite_render_meta.go
+++ b/api/models/graphite_render_meta.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"strconv"
+	"time"
+)
+
+// ResponseWithMeta is a graphite render response with metadata
+type ResponseWithMeta struct {
+	Meta   RenderMeta
+	Series SeriesByTarget
+}
+
+func (rwm ResponseWithMeta) MarshalJSONFast(b []byte) ([]byte, error) {
+	b = append(b, `{"meta-version":"v0.1","meta":`...)
+	b, _ = rwm.Meta.MarshalJSONFast(b)
+	b = append(b, `,"series":`...)
+	b, _ = rwm.Series.MarshalJSONFast(b)
+	b = append(b, '}')
+	return b, nil
+}
+
+// RenderMeta holds metadata about a render request/response
+type RenderMeta struct {
+	Stats stats
+}
+
+func (rm RenderMeta) MarshalJSONFast(b []byte) ([]byte, error) {
+	b = append(b, `{"stats":`...)
+	b, _ = rm.Stats.MarshalJSONFast(b)
+	b = append(b, '}')
+	return b, nil
+}
+
+type stats struct {
+	ResolveSeriesDuration time.Duration `json:"executeplan.resolve-series.ms"`
+	GetTargetsDuration    time.Duration `json:"executeplan.get-targets.ms"`
+	PrepareSeriesDuration time.Duration `json:"executeplan.prepare-series.ms"`
+	PlanRunDuration       time.Duration `json:"executeplan.plan-run.ms"`
+	SeriesFetch           uint32        `json:"executeplan.series-fetch.count"`
+	PointsFetch           uint32        `json:"executeplan.points-fetch.count"`
+	PointsReturn          uint32        `json:"executeplan.points-return.count"`
+}
+
+func (s stats) MarshalJSONFast(b []byte) ([]byte, error) {
+	b = append(b, `{"executeplan.resolve-series.ms":`...)
+	b = strconv.AppendInt(b, s.ResolveSeriesDuration.Nanoseconds()/1e6, 10)
+	b = append(b, `,"executeplan.get-targets.ms":`...)
+	b = strconv.AppendInt(b, s.GetTargetsDuration.Nanoseconds()/1e6, 10)
+	b = append(b, `,"executeplan.prepare-series.ms":`...)
+	b = strconv.AppendInt(b, s.PrepareSeriesDuration.Nanoseconds()/1e6, 10)
+	b = append(b, `,"executeplan.plan-run.ms":`...)
+	b = strconv.AppendInt(b, s.PlanRunDuration.Nanoseconds()/1e6, 10)
+	b = append(b, `,"executeplan.series-fetch.count":`...)
+	b = strconv.AppendUint(b, uint64(s.SeriesFetch), 10)
+	b = append(b, `,"executeplan.points-fetch.count":`...)
+	b = strconv.AppendUint(b, uint64(s.PointsFetch), 10)
+	b = append(b, `,"executeplan.points-return.count":`...)
+	b = strconv.AppendUint(b, uint64(s.PointsReturn), 10)
+	b = append(b, '}')
+	return b, nil
+}

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -87,8 +87,7 @@ curl -H "X-Org-Id: 12345" --data query=statsd.fakesite.counters.session_start.*.
 
 ## Graphite query api
 
-This is the early beginning of a graphite-web replacement. It can return JSON, pickle or messagepack output
-This section of the api is **very early stages**.  Your best bet is to use graphite in front of metrictank, for now.
+Graphite-web-like api. It can return JSON, pickle or messagepack output
 
 ```
 GET /render
@@ -104,6 +103,7 @@ POST /render
 * from: see [timespec format](#tspec) (default: 24h ago) (exclusive)
 * to/until : see [timespec format](#tspec)(default: now) (inclusive)
 * format: json, msgp, pickle, or msgpack (default: json)
+* meta: use 'meta=true' to enable metadata in response (performance measurements)
 * process: all, stable, none (default: stable). Controls metrictank's eagerness of fulfilling the request with its built-in processing functions
   (as opposed to proxing to the fallback graphite).
   - all: process request without fallback if we have all the needed functions, even if they are marked unstable (under development)


### PR DESCRIPTION
before / no metadata:
```
http 'http://localhost:6060/render?target=some.id.of.a.metric.11{1,2}*&from=-2s'
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Length: 153
Content-Type: application/json
Date: Wed, 05 Jun 2019 12:49:46 GMT
Server: Caddy
Trace-Id: 6d1226fddba82c27
Vary: Accept-Encoding

[
    {
        "datapoints": [
            [
                49.33625449779532,
                1559738985
            ],
            [
                null,
                1559738986
            ]
        ],
        "tags": {
            "name": "some.id.of.a.metric.111"
        },
        "target": "some.id.of.a.metric.111"
    },
    {
        "datapoints": [
            [
                6.68598274746298,
                1559738985
            ],
            [
                null,
                1559738986
            ]
        ],
        "tags": {
            "name": "some.id.of.a.metric.112"
        },
        "target": "some.id.of.a.metric.112"
    }
]

```

after / with meta=true:
```
http 'http://localhost:6060/render?target=some.id.of.a.metric.11{1,2}*&from=-2s&meta=true'
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Length: 260
Content-Type: application/json
Date: Wed, 05 Jun 2019 12:49:55 GMT
Server: Caddy
Trace-Id: 24c07790dc66a088
Vary: Accept-Encoding

{
    "meta": {
        "stats": {
            "executeplan.get-targets.ms": 0,
            "executeplan.plan-run.ms": 0,
            "executeplan.points-fetch.count": 4,
            "executeplan.points-return.count": 4,
            "executeplan.prepare-series.ms": 0,
            "executeplan.resolve-series.ms": 0,
            "executeplan.series-fetch.count": 2
        }
    },
    "meta-version": "v0.1",
    "series": [
        {
            "datapoints": [
                [
                    51.78374302012603,
                    1559738994
                ],
                [
                    null,
                    1559738995
                ]
            ],
            "tags": {
                "name": "some.id.of.a.metric.111"
            },
            "target": "some.id.of.a.metric.111"
        },
        {
            "datapoints": [
                [
                    25.332878097290962,
                    1559738994
                ],
                [
                    null,
                    1559738995
                ]
            ],
            "tags": {
                "name": "some.id.of.a.metric.112"
            },
            "target": "some.id.of.a.metric.112"
        }
    ]
}

```