### PR TITLE
Remove ConfigSetup() call during the Prometheus input plugin Start method

### DIFF
--- a/input/prometheus/prometheus.go
+++ b/input/prometheus/prometheus.go
@@ -38,7 +38,6 @@ func (p *prometheusWriteHandler) Name() string {
 
 func (p *prometheusWriteHandler) Start(handler input.Handler, cancel context.CancelFunc) error {
 	p.Handler = handler
-	ConfigSetup()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/write", p.handle)


### PR DESCRIPTION
  During the prometheus plugin initialization code uses the global
variable partitionID pointer instead of a copy of the value.
It means that when the ConfigSetup() is executed the plugin's configuration
structure values are set back to their default i.e. partitionID=0 here.

With this fix the partitionID selection works for the first time.

NB: scylladb was able to handle 15M metrics on a single partition