### PR TITLE
fix prometheus input plugin resetting its config at startup

### DIFF
--- a/input/prometheus/prometheus.go
+++ b/input/prometheus/prometheus.go
@@ -38,7 +38,6 @@ func (p *prometheusWriteHandler) Name() string {
 
 func (p *prometheusWriteHandler) Start(handler input.Handler, cancel context.CancelFunc) error {
 	p.Handler = handler
-	ConfigSetup()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/write", p.handle)


### PR DESCRIPTION
  During the startup process, the prometheus module is first configured using `prometheus.ConfigSetup()` and `prometheus.ConfigProcess()`, then the Handler is started. The problem is that `ConfigSetup()` is called from `Start()`, which makes the configuration re-initialize to its default values. Removing the call from `Start()` solve the issue.