### PR TITLE
fix how the kafka offsets get defined in the notifier

### DIFF
--- a/mdata/notifierKafka/notifierKafka.go
+++ b/mdata/notifierKafka/notifierKafka.go
@@ -80,11 +80,8 @@ func (c *NotifierKafka) start() {
 		}
 		startOffset, err := c.client.GetOffset(topic, partition, offsetTime)
 		if err != nil {
-			log.Fatalf("kafka-cluster: failed to get offset %d: %s", offsetTime, err)
-		}
-		if startOffset < 0 {
-			// happens when OffsetOldest or an offsetDuration was used and there is no message in the partition
-			startOffset = 0
+			offsetTime = sarama.OffsetOldest
+			log.Warnf("kafkamdm: failed to get offset %s: %s -> will use oldest instead", offsetDuration, err)
 		}
 		processBacklog.Add(1)
 		go c.consumePartition(topic, partition, startOffset, processBacklog)

--- a/mdata/notifierKafka/notifierKafka.go
+++ b/mdata/notifierKafka/notifierKafka.go
@@ -79,12 +79,13 @@ func (c *NotifierKafka) start() {
 	pre := time.Now()
 	processBacklog := new(sync.WaitGroup)
 
-	// | scenario					| offsetOldest  | offsetNewest | offsetTime
-	// -------------------------------------------------------------------------------------------------------------------------------
-	// | new empty partition		| error	   		| 0			   | error
-	// | new with messages			| 0		   		| validOffset  | validOffset or error if offsetTime is earlier than first message
-	// | existing with messages		| validOffset	| validOffset  | validOffset
-	// | existing with no messages	| error			| validOffset  | error
+	// | scenario                   | offsetOldest  | offsetNewest | offsetTime
+	// ------------------------------------------------------------------------------------------------------------------------------
+	// | new empty partition        | error         | 0            | error
+	// | new with messages          | 0             | validOffset  | validOffset or error if offsetTime is earlier than first message
+	// | existing with messages     | validOffset   | validOffset  | validOffset
+	// | existing with no messages  | error         | validOffset  | error
+	// ------------------------------------------------------------------------------------------------------------------------------
 
 	for _, partition := range partitions {
 		var startOffset int64


### PR DESCRIPTION
Today we saw an issue with an instance crashlooping due to an invalid partition offset. I wasn't able to reproduce the issue & verify this fix yet, but I think it would probably make sense to make this change anyway.

When the offset gets set to `0` as it previously was, doesn't that basically guarantee an error due to an invalid offset?