### PR TITLE
Fix timeout command for updated alpine

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.10.0
 MAINTAINER Dieter Plaetinck dieter@grafana.com
 
 RUN apk add -U tzdata

--- a/scripts/dlv/Dockerfile
+++ b/scripts/dlv/Dockerfile
@@ -5,7 +5,7 @@ ENV CGO_ENABLED 0
 RUN apk add --no-cache git
 RUN go get github.com/derekparker/delve/cmd/dlv
 
-FROM alpine
+FROM alpine:3.10.0
 MAINTAINER Dieter Plaetinck dieter@grafana.com
 
 RUN apk add -U tzdata

--- a/scripts/util/wait_for_endpoint.sh
+++ b/scripts/util/wait_for_endpoint.sh
@@ -41,7 +41,7 @@ do
     # connection stays up for $CONN_HOLD seconds.
     if [ $_using_busybox -eq 1 ]
     then
-      timeout -t $CONN_HOLD busybox nc $host $port -e busybox sleep $(( $CONN_HOLD + 1 )) 2>/dev/null
+      timeout $CONN_HOLD busybox nc $host $port -e busybox sleep $(( $CONN_HOLD + 1 )) 2>/dev/null
       retval=$?
 
       # busybox-timeout on alpine returns 0 on timeout

--- a/scripts/util/wait_for_endpoint_debug.sh
+++ b/scripts/util/wait_for_endpoint_debug.sh
@@ -58,7 +58,7 @@ do
     # connection stays up for $CONN_HOLD seconds.
     if [ $_using_busybox -eq 1 ]
     then
-      timeout -t $CONN_HOLD busybox nc $host $port -e busybox sleep $(( $CONN_HOLD + 1 )) 2>/dev/null
+      timeout $CONN_HOLD busybox nc $host $port -e busybox sleep $(( $CONN_HOLD + 1 )) 2>/dev/null
       retval=$?
 
       # busybox-timeout on alpine returns 0 on timeout


### PR DESCRIPTION
Pin alpine to 3.10.0

The `timeout` command was updated recently which was causing our stack tests to fail. This fixes that and pins `alpine` to version `3.10.0`.

Link to the change: https://git.busybox.net/busybox/commit/?h=1_30_stable&id=c9720a761e88e83265b4d75808533cdfbc66075b