### PR TITLE
WIP: add concurrency limits on find requests

### DIFF
--- a/api/ccache.go
+++ b/api/ccache.go
@@ -17,9 +17,9 @@ import (
 func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) {
 	res := models.CCacheDeleteResp{}
 	code := http.StatusOK
-
+	reqCtx := ctx.Req.Context()
 	if req.Propagate {
-		res.Peers = s.ccacheDeletePropagate(ctx.Req.Context(), &req)
+		res.Peers = s.ccacheDeletePropagate(reqCtx, &req)
 		for _, peer := range res.Peers {
 			if peer.Errors > 0 {
 				code = http.StatusInternalServerError
@@ -48,7 +48,7 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 		var toClear []idx.Node
 		if len(req.Patterns) > 0 {
 			for _, pattern := range req.Patterns {
-				nodes, err := s.MetricIndex.Find(req.OrgId, pattern, 0)
+				nodes, err := s.MetricIndex.Find(reqCtx, req.OrgId, pattern, 0)
 				if err != nil {
 					if res.Errors == 0 {
 						res.FirstError = err.Error()

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -122,7 +122,7 @@ func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 	}
 
 	for _, pattern := range req.Patterns {
-		nodes, err := s.MetricIndex.Find(req.OrgId, pattern, req.From)
+		nodes, err := s.MetricIndex.Find(ctx.Req.Context(), req.OrgId, pattern, req.From)
 		if err != nil {
 			response.Write(ctx, response.WrapError(err))
 			return

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -1,6 +1,7 @@
 package cassandra
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"reflect"
@@ -340,7 +341,7 @@ func TestFind(t *testing.T) {
 
 	Convey("When listing root nodes", t, func() {
 		Convey("root nodes for orgId 1", func() {
-			nodes, err := ix.Find(1, "*", 0)
+			nodes, err := ix.Find(context.Background(), 1, "*", 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 2)
 			So(nodes[0].Path, ShouldBeIn, "metric", "foo")
@@ -348,7 +349,7 @@ func TestFind(t *testing.T) {
 			So(nodes[0].Leaf, ShouldBeFalse)
 		})
 		Convey("root nodes for orgId 2", func() {
-			nodes, err := ix.Find(2, "*", 0)
+			nodes, err := ix.Find(context.Background(), 2, "*", 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 1)
 			So(nodes[0].Path, ShouldEqual, "metric")
@@ -357,7 +358,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with GLOB", t, func() {
-		nodes, err := ix.Find(2, "metric.{f*,demo}.*", 0)
+		nodes, err := ix.Find(context.Background(), 2, "metric.{f*,demo}.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 10)
 		for _, n := range nodes {
@@ -366,7 +367,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with multiple wildcards", t, func() {
-		nodes, err := ix.Find(1, "*.*", 0)
+		nodes, err := ix.Find(context.Background(), 1, "*.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 2)
 		for _, n := range nodes {
@@ -375,24 +376,24 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching nodes not in public series", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.*", 0)
+		nodes, err := ix.Find(context.Background(), 1, "foo.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 		Convey("When searching for specific series", func() {
-			found, err := ix.Find(1, nodes[0].Path, 0)
+			found, err := ix.Find(context.Background(), 1, nodes[0].Path, 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 1)
 			So(found[0].Path, ShouldEqual, nodes[0].Path)
 		})
 		Convey("When searching nodes that are children of a leaf", func() {
-			found, err := ix.Find(1, nodes[0].Path+".*", 0)
+			found, err := ix.Find(context.Background(), 1, nodes[0].Path+".*", 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 0)
 		})
 	})
 
 	Convey("When searching with multiple wildcards mixed leaf/branch", t, func() {
-		nodes, err := ix.Find(1, "*.demo.*", 0)
+		nodes, err := ix.Find(context.Background(), 1, "*.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 15)
 		for _, n := range nodes {
@@ -405,13 +406,13 @@ func TestFind(t *testing.T) {
 		}
 	})
 	Convey("When searching nodes for unknown orgId", t, func() {
-		nodes, err := ix.Find(4, "foo.demo.*", 0)
+		nodes, err := ix.Find(context.Background(), 4, "foo.demo.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
 
 	Convey("When searching nodes that don't exist", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.blah.*", 0)
+		nodes, err := ix.Find(context.Background(), 1, "foo.demo.blah.*", 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -3,6 +3,7 @@
 package idx
 
 import (
+	"context"
 	"time"
 
 	"github.com/raintank/schema"
@@ -82,7 +83,7 @@ type MetricIndex interface {
 	// * orgId describes the org to search in (public data in orgIdPublic is automatically included)
 	// * pattern is handled like graphite does. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
 	// * from is a unix timestamp. series not updated since then are excluded.
-	Find(orgId uint32, pattern string, from int64) ([]Node, error)
+	Find(ctx context.Context, orgId uint32, pattern string, from int64) ([]Node, error)
 
 	// List returns all Archives for the passed OrgId and the public orgId
 	List(orgId uint32) []Archive

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -777,7 +778,7 @@ func benchmarkTagsWithoutFromNorFilter(b *testing.B) {
 func ixFind(b *testing.B, org uint32, q int) {
 	b.Helper()
 
-	nodes, err := ix.Find(org, queries[q].Pattern, 0)
+	nodes, err := ix.Find(context.Background(), org, queries[q].Pattern, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -172,13 +172,13 @@ func (p *PartitionedMemoryIdx) Delete(orgId uint32, pattern string) ([]idx.Archi
 // * orgId describes the org to search in (public data in orgIdPublic is automatically included)
 // * pattern is handled like graphite does. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
 // * from is a unix timestamp. series not updated since then are excluded.
-func (p *PartitionedMemoryIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, error) {
-	g, _ := errgroup.WithContext(context.Background())
+func (p *PartitionedMemoryIdx) Find(ctx context.Context, orgId uint32, pattern string, from int64) ([]idx.Node, error) {
+	g, groupCtx := errgroup.WithContext(ctx)
 	resultChan := make(chan []idx.Node)
 	for _, m := range p.Partition {
 		m := m
 		g.Go(func() error {
-			found, err := m.Find(orgId, pattern, from)
+			found, err := m.Find(groupCtx, orgId, pattern, from)
 			if err != nil {
 				return err
 			}

--- a/idx/memory/write_queue_test.go
+++ b/idx/memory/write_queue_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestWriteQueue(t *testing.T) {
 		ix.AddOrUpdate(mkey, data, getPartition(data))
 	}
 
-	nodes, err := ix.Find(1, "some.metric.*", 0)
+	nodes, err := ix.Find(context.Background(), 1, "some.metric.*", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +56,7 @@ func TestWriteQueue(t *testing.T) {
 	mkey, _ := schema.MKeyFromString(data.Id)
 	ix.AddOrUpdate(mkey, data, getPartition(data))
 
-	nodes, err = ix.Find(1, "some.metric.*", 0)
+	nodes, err = ix.Find(context.Background(), 1, "some.metric.*", 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Adds a max-concurrent-finds config option and code to limit
  the number of Finds() that can be running at any one time.
- Find() and findMaybeCached() functions have been refactored
  to avoid concurrency limits being applied to queries that
  are served from the findCache.