### PR TITLE
remove tilde from name values when indexing tags

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -543,7 +543,7 @@ func (m *UnpartitionedMemoryIdx) indexTags(def *schema.MetricDefinition) {
 		tagValue := tagSplits[1]
 		tags.addTagId(tagName, tagValue, def.Id)
 	}
-	tags.addTagId("name", def.Name, def.Id)
+	tags.addTagId("name", def.NameSanitizedAsTagValue(), def.Id)
 
 	m.defByTagSet.add(def)
 }
@@ -569,7 +569,7 @@ func (m *UnpartitionedMemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDe
 		tags.delTagId(tagName, tagValue, def.Id)
 	}
 
-	tags.delTagId("name", def.Name, def.Id)
+	tags.delTagId("name", def.NameSanitizedAsTagValue(), def.Id)
 
 	m.defByTagSet.del(def)
 
@@ -968,7 +968,7 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 
 		// special case if the tag to complete values for is "name"
 		if tag == "name" {
-			valueMap[def.Name] = struct{}{}
+			valueMap[def.NameSanitizedAsTagValue()] = struct{}{}
 		} else {
 			for _, tag := range def.Tags {
 				if !strings.HasPrefix(tag, tagPrefix) {

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -326,7 +326,7 @@ func (q *TagQueryContext) testByMatch(def *idx.Archive, exprs []kvRe, not bool) 
 EXPRS:
 	for _, e := range exprs {
 		if e.Key == "name" {
-			if e.Regex == nil || e.Regex.MatchString(def.Name) {
+			if e.Regex == nil || e.Regex.MatchString(def.NameSanitizedAsTagValue()) {
 				if not {
 					return false
 				}
@@ -447,7 +447,7 @@ func (q *TagQueryContext) testByFrom(def *idx.Archive) bool {
 func (q *TagQueryContext) testByPrefix(def *idx.Archive, exprs []kv) bool {
 EXPRS:
 	for _, e := range exprs {
-		if e.Key == "name" && strings.HasPrefix(def.Name, e.Value) {
+		if e.Key == "name" && strings.HasPrefix(def.NameSanitizedAsTagValue(), e.Value) {
 			continue EXPRS
 		}
 


### PR DESCRIPTION
I'll wait for this PR to get merged before this can be merged: https://github.com/raintank/schema/pull/31/commits/80d1297fa5ab5fd54343da4e133b9bddbea0b96a

This is related to https://github.com/grafana/grafana/issues/15261
And it is the implementation of https://github.com/graphite-project/graphite-web/pull/2458