### PR TITLE
reset timer in writeQueue core loop

### DIFF
--- a/idx/memory/write_queue.go
+++ b/idx/memory/write_queue.go
@@ -93,6 +93,7 @@ func (wq *WriteQueue) loop() {
 			wq.Lock()
 			wq.flush()
 			wq.Unlock()
+			timer.Reset(wq.maxDelay)
 		case <-wq.shutdown:
 			wq.Lock()
 			wq.flush()


### PR DESCRIPTION
if the timer is not reset after firing we will run into a deadlock
when a event is received in wq.flushed