### PR TITLE
log at least one bigtable mutation error

### DIFF
--- a/store/bigtable/bigtable.go
+++ b/store/bigtable/bigtable.go
@@ -283,7 +283,6 @@ func (s *Store) processWriteQueue(queue chan *mdata.ChunkWriteRequest, meter *st
 				rowKeys = failedRowKeys
 				muts = failedMutations
 				buf = retryBuf
-				
 				chunkSaveFail.Add(len(failedRowKeys))
 				sleepTime := 100 * attempts
 				if sleepTime > 2000 {

--- a/store/bigtable/bigtable.go
+++ b/store/bigtable/bigtable.go
@@ -279,10 +279,11 @@ func (s *Store) processWriteQueue(queue chan *mdata.ChunkWriteRequest, meter *st
 						chunkSaveOk.Inc()
 					}
 				}
+				log.Errorf("btStore: failed to write %d of %d rows. first error: %s", len(failedRowKeys), len(rowKeys), err)
 				rowKeys = failedRowKeys
 				muts = failedMutations
 				buf = retryBuf
-				log.Errorf("btStore: failed to write %d rows. first error: %s", len(failedRowKeys), err)
+				
 				chunkSaveFail.Add(len(failedRowKeys))
 				sleepTime := 100 * attempts
 				if sleepTime > 2000 {


### PR DESCRIPTION
When there were mutation-specific errors in the big table store, we currently can't get the bigtable errors because they don't get logged. This will at least print one error per set of mutations that resulted in one or more errors.