### PR TITLE
New flag 'ingest-from'

### DIFF
--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -33,7 +33,7 @@ func newSrv(delSeries, delArchives int) (*Server, *cache.MockCache) {
 	mockCache := cache.NewMockCache()
 	mockCache.DelMetricSeries = delSeries
 	mockCache.DelMetricArchives = delArchives
-	metrics := mdata.NewAggMetrics(store, mockCache, false, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, mockCache, false, 0, 0, 0, 0, 0)
 	srv.BindMemoryStore(metrics)
 	srv.BindCache(mockCache)
 

--- a/api/ccache_test.go
+++ b/api/ccache_test.go
@@ -33,7 +33,7 @@ func newSrv(delSeries, delArchives int) (*Server, *cache.MockCache) {
 	mockCache := cache.NewMockCache()
 	mockCache.DelMetricSeries = delSeries
 	mockCache.DelMetricArchives = delArchives
-	metrics := mdata.NewAggMetrics(store, mockCache, false, 0, 0, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, mockCache, false, nil, 0, 0, 0)
 	srv.BindMemoryStore(metrics)
 	srv.BindCache(mockCache)
 

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -346,7 +346,7 @@ func TestGetSeriesFixed(t *testing.T) {
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, 0))
 
-	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, nil, 0, 0, 0)
 	srv, _ := NewServer()
 	srv.BindBackendStore(store)
 	srv.BindMemoryStore(metrics)
@@ -501,7 +501,7 @@ func TestGetSeriesCachedStore(t *testing.T) {
 	store := mdata.NewMockStore()
 	srv.BindBackendStore(store)
 
-	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, nil, 0, 0, 0)
 	srv.BindMemoryStore(metrics)
 	metric := test.GetAMKey(1)
 
@@ -687,7 +687,7 @@ func TestGetSeriesAggMetrics(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 	store := mdata.NewMockStore()
 
-	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, nil, 0, 0, 0)
 	srv, _ := NewServer()
 	srv.BindBackendStore(store)
 	srv.BindMemoryStore(metrics)

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -346,7 +346,7 @@ func TestGetSeriesFixed(t *testing.T) {
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, 0))
 
-	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0, 0, 0)
 	srv, _ := NewServer()
 	srv.BindBackendStore(store)
 	srv.BindMemoryStore(metrics)
@@ -501,7 +501,7 @@ func TestGetSeriesCachedStore(t *testing.T) {
 	store := mdata.NewMockStore()
 	srv.BindBackendStore(store)
 
-	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0, 0, 0)
 	srv.BindMemoryStore(metrics)
 	metric := test.GetAMKey(1)
 
@@ -687,7 +687,7 @@ func TestGetSeriesAggMetrics(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 	store := mdata.NewMockStore()
 
-	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0)
+	metrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 0, 0, 0)
 	srv, _ := NewServer()
 	srv.BindBackendStore(store)
 	srv.BindMemoryStore(metrics)

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -298,14 +298,12 @@ func main() {
 		Initialize our MemoryStore
 	***********************************/
 
-	ingestFrom := make(map[uint32]int64)
-	ingestFromStrPerOrg := strings.Split(*ingestFromStr, ",")
-	for _, ingestFromStrForOrg := range ingestFromStrPerOrg {
-		ingestFromOrgID, ingestFromTimestamp := util.MustParseIngestFromFlag(ingestFromStrForOrg)
-		if ingestFromTimestamp > 0 {
-			log.Infof("For org %d, will only ingest data for chunks that have a t0 equal or higher to %s", ingestFromOrgID, time.Unix(ingestFromTimestamp, 0))
-		}
-		ingestFrom[ingestFromOrgID] = ingestFromTimestamp
+	ingestFrom, err := util.ParseIngestFromFlags(*ingestFromStr)
+	if err != nil {
+		log.Fatalf("ingest-from: %s", err.Error())
+	}
+	for orgID, timestamp := range ingestFrom {
+		log.Infof("For org %d, will only ingest data for chunks that have a t0 equal or higher to %s", orgID, time.Unix(timestamp, 0))
 	}
 	if inputEnabled {
 		metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, ingestFrom, chunkMaxStale, metricMaxStale, gcInterval)

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -302,8 +302,10 @@ func main() {
 	if ingestAfterTimestamp > 0 {
 		log.Infof("Will only ingest data points for org id %d belonging to chunks starting after %s", ingestAfterOrgID, time.Unix(ingestAfterTimestamp, 0))
 	}
+	ingestAfter := make(map[uint32]int64)
+	ingestAfter[ingestAfterOrgID] = ingestAfterTimestamp
 	if inputEnabled {
-		metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, ingestAfterOrgID, ingestAfterTimestamp, chunkMaxStale, metricMaxStale, gcInterval)
+		metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, ingestAfter, chunkMaxStale, metricMaxStale, gcInterval)
 	}
 
 	/***********************************

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -298,12 +298,15 @@ func main() {
 		Initialize our MemoryStore
 	***********************************/
 
-	ingestAfterOrgID, ingestAfterTimestamp := util.MustParseIngestAfterFlag(*ingestAfterStr)
-	if ingestAfterTimestamp > 0 {
-		log.Infof("Will only ingest data points for org id %d belonging to chunks starting after %s", ingestAfterOrgID, time.Unix(ingestAfterTimestamp, 0))
-	}
 	ingestAfter := make(map[uint32]int64)
-	ingestAfter[ingestAfterOrgID] = ingestAfterTimestamp
+	ingestAfterStrPerOrg := strings.Split(*ingestAfterStr, ",")
+	for _, ingestAfterStrForOrg := range ingestAfterStrPerOrg {
+		ingestAfterOrgID, ingestAfterTimestamp := util.MustParseIngestAfterFlag(ingestAfterStrForOrg)
+		if ingestAfterTimestamp > 0 {
+			log.Infof("Will only ingest data points for org id %d belonging to chunks starting after %s", ingestAfterOrgID, time.Unix(ingestAfterTimestamp, 0))
+		}
+		ingestAfter[ingestAfterOrgID] = ingestAfterTimestamp
+	}
 	if inputEnabled {
 		metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, ingestAfter, chunkMaxStale, metricMaxStale, gcInterval)
 	}

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -60,7 +60,7 @@ var (
 
 	// Data:
 	dropFirstChunk    = flag.Bool("drop-first-chunk", false, "forego persisting of first received (and typically incomplete) chunk")
-	ingestFromStr     = flag.String("ingest-from", "", "only ingest data with timestamps belonging to the chunk starting after the timestamp specified for an org id; syntax: [ORG_ID]:[TIMESTAMP],[ORG_ID]:[TIMESTAMP],...")
+	ingestFromStr     = flag.String("ingest-from", "", "only ingest data with timestamps belonging to the next chunk from the timestamp specified for an org id; syntax: [ORG_ID]:[TIMESTAMP],[ORG_ID]:[TIMESTAMP],...")
 	chunkMaxStaleStr  = flag.String("chunk-max-stale", "1h", "max age for a chunk before to be considered stale and to be persisted to Cassandra.")
 	metricMaxStaleStr = flag.String("metric-max-stale", "3h", "max age for a metric before to be considered stale and to be purged from memory.")
 	gcIntervalStr     = flag.String("gc-interval", "1h", "Interval to run garbage collection job.")

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -60,7 +60,7 @@ var (
 
 	// Data:
 	dropFirstChunk    = flag.Bool("drop-first-chunk", false, "forego persisting of first received (and typically incomplete) chunk")
-	ingestFromStr     = flag.String("ingest-from", "", "only ingest data with timestamps belonging to the next chunk from the timestamp specified for an org id; syntax: [ORG_ID]:[TIMESTAMP],[ORG_ID]:[TIMESTAMP],...")
+	ingestFromStr     = flag.String("ingest-from", "", "only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]")
 	chunkMaxStaleStr  = flag.String("chunk-max-stale", "1h", "max age for a chunk before to be considered stale and to be persisted to Cassandra.")
 	metricMaxStaleStr = flag.String("metric-max-stale", "3h", "max age for a metric before to be considered stale and to be purged from memory.")
 	gcIntervalStr     = flag.String("gc-interval", "1h", "Interval to run garbage collection job.")
@@ -303,7 +303,7 @@ func main() {
 	for _, ingestFromStrForOrg := range ingestFromStrPerOrg {
 		ingestFromOrgID, ingestFromTimestamp := util.MustParseIngestFromFlag(ingestFromStrForOrg)
 		if ingestFromTimestamp > 0 {
-			log.Infof("Will only ingest data points for org id %d belonging to chunks starting after %s", ingestFromOrgID, time.Unix(ingestFromTimestamp, 0))
+			log.Infof("For org %d, will only ingest data for chunks that have a t0 equal or higher to %s", ingestFromOrgID, time.Unix(ingestFromTimestamp, 0))
 		}
 		ingestFrom[ingestFromOrgID] = ingestFromTimestamp
 	}

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -60,7 +60,7 @@ var (
 
 	// Data:
 	dropFirstChunk    = flag.Bool("drop-first-chunk", false, "forego persisting of first received (and typically incomplete) chunk")
-	ingestAfterStr    = flag.String("ingest-after", "", "discards data from an org id received before the next chunk boundary after the specified unix timestamp (in seconds since 1 Jan 1970); syntax: org-id:timestamp")
+	ingestAfterStr    = flag.String("ingest-after", "", "only ingest data with timestamps belonging to the chunk starting after the timestamp specified for an org id; syntax: [ORG_ID]:[TIMESTAMP],[ORG_ID]:[TIMESTAMP],...")
 	chunkMaxStaleStr  = flag.String("chunk-max-stale", "1h", "max age for a chunk before to be considered stale and to be persisted to Cassandra.")
 	metricMaxStaleStr = flag.String("metric-max-stale", "3h", "max age for a metric before to be considered stale and to be purged from memory.")
 	gcIntervalStr     = flag.String("gc-interval", "1h", "Interval to run garbage collection job.")

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -60,7 +60,7 @@ var (
 
 	// Data:
 	dropFirstChunk    = flag.Bool("drop-first-chunk", false, "forego persisting of first received (and typically incomplete) chunk")
-	ingestAfterStr    = flag.String("ingest-after", "", "only ingest data with timestamps belonging to the chunk starting after the timestamp specified for an org id; syntax: [ORG_ID]:[TIMESTAMP],[ORG_ID]:[TIMESTAMP],...")
+	ingestFromStr     = flag.String("ingest-from", "", "only ingest data with timestamps belonging to the chunk starting after the timestamp specified for an org id; syntax: [ORG_ID]:[TIMESTAMP],[ORG_ID]:[TIMESTAMP],...")
 	chunkMaxStaleStr  = flag.String("chunk-max-stale", "1h", "max age for a chunk before to be considered stale and to be persisted to Cassandra.")
 	metricMaxStaleStr = flag.String("metric-max-stale", "3h", "max age for a metric before to be considered stale and to be purged from memory.")
 	gcIntervalStr     = flag.String("gc-interval", "1h", "Interval to run garbage collection job.")
@@ -298,17 +298,17 @@ func main() {
 		Initialize our MemoryStore
 	***********************************/
 
-	ingestAfter := make(map[uint32]int64)
-	ingestAfterStrPerOrg := strings.Split(*ingestAfterStr, ",")
-	for _, ingestAfterStrForOrg := range ingestAfterStrPerOrg {
-		ingestAfterOrgID, ingestAfterTimestamp := util.MustParseIngestAfterFlag(ingestAfterStrForOrg)
-		if ingestAfterTimestamp > 0 {
-			log.Infof("Will only ingest data points for org id %d belonging to chunks starting after %s", ingestAfterOrgID, time.Unix(ingestAfterTimestamp, 0))
+	ingestFrom := make(map[uint32]int64)
+	ingestFromStrPerOrg := strings.Split(*ingestFromStr, ",")
+	for _, ingestFromStrForOrg := range ingestFromStrPerOrg {
+		ingestFromOrgID, ingestFromTimestamp := util.MustParseIngestFromFlag(ingestFromStrForOrg)
+		if ingestFromTimestamp > 0 {
+			log.Infof("Will only ingest data points for org id %d belonging to chunks starting after %s", ingestFromOrgID, time.Unix(ingestFromTimestamp, 0))
 		}
-		ingestAfter[ingestAfterOrgID] = ingestAfterTimestamp
+		ingestFrom[ingestFromOrgID] = ingestFromTimestamp
 	}
 	if inputEnabled {
-		metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, ingestAfter, chunkMaxStale, metricMaxStale, gcInterval)
+		metrics = mdata.NewAggMetrics(store, ccache, *dropFirstChunk, ingestFrom, chunkMaxStale, metricMaxStale, gcInterval)
 	}
 
 	/***********************************

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -9,6 +9,8 @@ instance = default
 
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -9,6 +9,8 @@ instance = default
 
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -9,6 +9,8 @@ instance = default
 
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -9,6 +9,8 @@ instance = default
 
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/docs/config.md
+++ b/docs/config.md
@@ -40,6 +40,8 @@ instance = default
 # see https://github.com/grafana/metrictank/blob/master/docs/memory-server.md for more details
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -195,7 +195,7 @@ func getDefaultHandler(t *testing.T) (DefaultHandler, idx.MetricIndex, func()) {
 	}
 
 	mdata.Schemas = conf.NewSchemas(nil)
-	metrics := mdata.NewAggMetrics(nil, nil, false, 3600, 7200, 3600)
+	metrics := mdata.NewAggMetrics(nil, nil, false, 0, 0, 3600, 7200, 3600)
 	return NewDefaultHandler(metrics, index, "test"), index, reset
 }
 
@@ -207,7 +207,7 @@ func BenchmarkProcessMetricDataUniqueMetrics(b *testing.B) {
 	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, 0))
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 
-	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 800, 8000, 0)
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 800, 8000, 0)
 	metricIndex := memory.New()
 	metricIndex.Init()
 	defer metricIndex.Stop()
@@ -247,7 +247,7 @@ func BenchmarkProcessMetricDataSameMetric(b *testing.B) {
 	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, 0))
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 
-	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 800, 8000, 0)
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 800, 8000, 0)
 	metricIndex := memory.New()
 	metricIndex.Init()
 	defer metricIndex.Stop()

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -195,7 +195,7 @@ func getDefaultHandler(t *testing.T) (DefaultHandler, idx.MetricIndex, func()) {
 	}
 
 	mdata.Schemas = conf.NewSchemas(nil)
-	metrics := mdata.NewAggMetrics(nil, nil, false, 0, 0, 3600, 7200, 3600)
+	metrics := mdata.NewAggMetrics(nil, nil, false, nil, 3600, 7200, 3600)
 	return NewDefaultHandler(metrics, index, "test"), index, reset
 }
 
@@ -207,7 +207,7 @@ func BenchmarkProcessMetricDataUniqueMetrics(b *testing.B) {
 	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, 0))
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 
-	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 800, 8000, 0)
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, nil, 800, 8000, 0)
 	metricIndex := memory.New()
 	metricIndex.Init()
 	defer metricIndex.Stop()
@@ -247,7 +247,7 @@ func BenchmarkProcessMetricDataSameMetric(b *testing.B) {
 	mdata.SetSingleSchema(conf.NewRetentionMT(10, 10000, 600, 10, 0))
 	mdata.SetSingleAgg(conf.Avg, conf.Min, conf.Max)
 
-	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, 0, 0, 800, 8000, 0)
+	aggmetrics := mdata.NewAggMetrics(store, &cache.MockCache{}, false, nil, 800, 8000, 0)
 	metricIndex := memory.New()
 	metricIndex.Init()
 	defer metricIndex.Stop()

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -31,39 +31,41 @@ type AggMetric struct {
 	store       Store
 	cachePusher cache.CachePusher
 	sync.RWMutex
-	key             schema.AMKey
-	rob             *ReorderBuffer
-	currentChunkPos int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
-	numChunks       uint32 // max size of the circular buffer
-	chunkSpan       uint32 // span of individual chunks in seconds
-	chunks          []*chunk.Chunk
-	aggregators     []*Aggregator
-	dropFirstChunk  bool
-	ttl             uint32
-	lastSaveStart   uint32 // last chunk T0 that was added to the write Queue.
-	lastSaveFinish  uint32 // last chunk T0 successfully written to Cassandra.
-	lastWrite       uint32 // wall clock time of when last point was successfully added (possibly to the ROB)
-	firstTs         uint32 // timestamp of first point seen
+	key                    schema.AMKey
+	rob                    *ReorderBuffer
+	currentChunkPos        int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
+	numChunks              uint32 // max size of the circular buffer
+	chunkSpan              uint32 // span of individual chunks in seconds
+	chunks                 []*chunk.Chunk
+	aggregators            []*Aggregator
+	dropFirstChunk         bool
+	ingestAfterNextChunkT0 uint32
+	ttl                    uint32
+	lastSaveStart          uint32 // last chunk T0 that was added to the write Queue.
+	lastSaveFinish         uint32 // last chunk T0 successfully written to Cassandra.
+	lastWrite              uint32 // wall clock time of when last point was successfully added (possibly to the ROB)
+	firstTs                uint32 // timestamp of first point seen
 }
 
 // NewAggMetric creates a metric with given key, it retains the given number of chunks each chunkSpan seconds long
 // it optionally also creates aggregations with the given settings
 // the 0th retention is the native archive of this metric. if there's several others, we create aggregators, using agg.
 // it's the callers responsibility to make sure agg is not nil in that case!
-func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, retentions conf.Retentions, reorderWindow, interval uint32, agg *conf.Aggregation, dropFirstChunk bool) *AggMetric {
+func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, retentions conf.Retentions, reorderWindow, interval uint32, agg *conf.Aggregation, dropFirstChunk bool, ingestAfter int64) *AggMetric {
 
 	// note: during parsing of retentions, we assure there's at least 1.
 	ret := retentions[0]
 
 	m := AggMetric{
-		cachePusher:    cachePusher,
-		store:          store,
-		key:            key,
-		chunkSpan:      ret.ChunkSpan,
-		numChunks:      ret.NumChunks,
-		chunks:         make([]*chunk.Chunk, 0, ret.NumChunks),
-		dropFirstChunk: dropFirstChunk,
-		ttl:            uint32(ret.MaxRetention()),
+		cachePusher:            cachePusher,
+		store:                  store,
+		key:                    key,
+		chunkSpan:              ret.ChunkSpan,
+		numChunks:              ret.NumChunks,
+		chunks:                 make([]*chunk.Chunk, 0, ret.NumChunks),
+		dropFirstChunk:         dropFirstChunk,
+		ingestAfterNextChunkT0: uint32(ingestAfter-(ingestAfter%int64(ret.ChunkSpan))) + ret.ChunkSpan,
+		ttl:                    uint32(ret.MaxRetention()),
 		// we set LastWrite here to make sure a new Chunk doesn't get immediately
 		// garbage collected right after creating it, before we can push to it.
 		lastWrite: uint32(time.Now().Unix()),
@@ -73,7 +75,7 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 	}
 
 	for _, ret := range retentions[1:] {
-		m.aggregators = append(m.aggregators, NewAggregator(store, cachePusher, key, ret, *agg, dropFirstChunk))
+		m.aggregators = append(m.aggregators, NewAggregator(store, cachePusher, key, ret, *agg, dropFirstChunk, ingestAfter))
 	}
 
 	return &m
@@ -424,6 +426,12 @@ func (a *AggMetric) persist(pos int) {
 
 // don't ever call with a ts of 0, cause we use 0 to mean not initialized!
 func (a *AggMetric) Add(ts uint32, val float64) {
+	if ts < a.ingestAfterNextChunkT0 {
+		// TODO: add metric to keep track of the # of points discarded
+		log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-after. First chunk considered starts at %d", ts, val, a.ingestAfterNextChunkT0)
+		return
+	}
+
 	a.Lock()
 	defer a.Unlock()
 

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -31,47 +31,47 @@ type AggMetric struct {
 	store       Store
 	cachePusher cache.CachePusher
 	sync.RWMutex
-	key                    schema.AMKey
-	rob                    *ReorderBuffer
-	currentChunkPos        int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
-	numChunks              uint32 // max size of the circular buffer
-	chunkSpan              uint32 // span of individual chunks in seconds
-	chunks                 []*chunk.Chunk
-	aggregators            []*Aggregator
-	dropFirstChunk         bool
-	ingestAfterNextChunkT0 uint32
-	ttl                    uint32
-	lastSaveStart          uint32 // last chunk T0 that was added to the write Queue.
-	lastSaveFinish         uint32 // last chunk T0 successfully written to Cassandra.
-	lastWrite              uint32 // wall clock time of when last point was successfully added (possibly to the ROB)
-	firstTs                uint32 // timestamp of first point seen
+	key                   schema.AMKey
+	rob                   *ReorderBuffer
+	currentChunkPos       int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
+	numChunks             uint32 // max size of the circular buffer
+	chunkSpan             uint32 // span of individual chunks in seconds
+	chunks                []*chunk.Chunk
+	aggregators           []*Aggregator
+	dropFirstChunk        bool
+	ingestFromNextChunkT0 uint32
+	ttl                   uint32
+	lastSaveStart         uint32 // last chunk T0 that was added to the write Queue.
+	lastSaveFinish        uint32 // last chunk T0 successfully written to Cassandra.
+	lastWrite             uint32 // wall clock time of when last point was successfully added (possibly to the ROB)
+	firstTs               uint32 // timestamp of first point seen
 }
 
 // NewAggMetric creates a metric with given key, it retains the given number of chunks each chunkSpan seconds long
 // it optionally also creates aggregations with the given settings
 // the 0th retention is the native archive of this metric. if there's several others, we create aggregators, using agg.
 // it's the callers responsibility to make sure agg is not nil in that case!
-func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, retentions conf.Retentions, reorderWindow, interval uint32, agg *conf.Aggregation, dropFirstChunk bool, ingestAfter int64) *AggMetric {
+func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, retentions conf.Retentions, reorderWindow, interval uint32, agg *conf.Aggregation, dropFirstChunk bool, ingestFrom int64) *AggMetric {
 
 	// note: during parsing of retentions, we assure there's at least 1.
 	ret := retentions[0]
 
-	ingestAfterNextChunkT0 := uint32(0)
-	if ingestAfter > 0 {
-		// compute start of next chunk after ingestAfter
-		ingestAfterNextChunkT0 = uint32(ingestAfter-(ingestAfter%int64(ret.ChunkSpan))) + ret.ChunkSpan
+	ingestFromNextChunkT0 := uint32(0)
+	if ingestFrom > 0 {
+		// compute start of next chunk after ingestFrom
+		ingestFromNextChunkT0 = uint32(ingestFrom-(ingestFrom%int64(ret.ChunkSpan))) + ret.ChunkSpan
 	}
 
 	m := AggMetric{
-		cachePusher:            cachePusher,
-		store:                  store,
-		key:                    key,
-		chunkSpan:              ret.ChunkSpan,
-		numChunks:              ret.NumChunks,
-		chunks:                 make([]*chunk.Chunk, 0, ret.NumChunks),
-		dropFirstChunk:         dropFirstChunk,
-		ingestAfterNextChunkT0: ingestAfterNextChunkT0,
-		ttl:                    uint32(ret.MaxRetention()),
+		cachePusher:           cachePusher,
+		store:                 store,
+		key:                   key,
+		chunkSpan:             ret.ChunkSpan,
+		numChunks:             ret.NumChunks,
+		chunks:                make([]*chunk.Chunk, 0, ret.NumChunks),
+		dropFirstChunk:        dropFirstChunk,
+		ingestFromNextChunkT0: ingestFromNextChunkT0,
+		ttl:                   uint32(ret.MaxRetention()),
 		// we set LastWrite here to make sure a new Chunk doesn't get immediately
 		// garbage collected right after creating it, before we can push to it.
 		lastWrite: uint32(time.Now().Unix()),
@@ -81,7 +81,7 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 	}
 
 	for _, ret := range retentions[1:] {
-		m.aggregators = append(m.aggregators, NewAggregator(store, cachePusher, key, ret, *agg, dropFirstChunk, ingestAfter))
+		m.aggregators = append(m.aggregators, NewAggregator(store, cachePusher, key, ret, *agg, dropFirstChunk, ingestFrom))
 	}
 
 	return &m
@@ -432,10 +432,10 @@ func (a *AggMetric) persist(pos int) {
 
 // don't ever call with a ts of 0, cause we use 0 to mean not initialized!
 func (a *AggMetric) Add(ts uint32, val float64) {
-	if ts < a.ingestAfterNextChunkT0 {
+	if ts < a.ingestFromNextChunkT0 {
 		// TODO: add metric to keep track of the # of points discarded
 		if log.IsLevelEnabled(log.DebugLevel) {
-			log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-after. First chunk considered starts at %d", ts, val, a.ingestAfterNextChunkT0)
+			log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-from. First chunk considered starts at %d", ts, val, a.ingestFromNextChunkT0)
 		}
 		return
 	}

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -434,7 +434,9 @@ func (a *AggMetric) persist(pos int) {
 func (a *AggMetric) Add(ts uint32, val float64) {
 	if ts < a.ingestAfterNextChunkT0 {
 		// TODO: add metric to keep track of the # of points discarded
-		log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-after. First chunk considered starts at %d", ts, val, a.ingestAfterNextChunkT0)
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-after. First chunk considered starts at %d", ts, val, a.ingestAfterNextChunkT0)
+		}
 		return
 	}
 

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -58,8 +58,8 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 
 	ingestFromT0 := uint32(0)
 	if ingestFrom > 0 {
-		// compute start of next chunk after ingestFrom
-		ingestFromT0 = uint32(ingestFrom-(ingestFrom%int64(ret.ChunkSpan))) + ret.ChunkSpan
+		// compute next chunk boundary starting from 'ingestFrom'
+		ingestFromT0 = AggBoundary(uint32(ingestFrom), ret.ChunkSpan)
 	}
 
 	m := AggMetric{

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -434,6 +434,10 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 		if log.IsLevelEnabled(log.DebugLevel) {
 			log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-from. First chunk considered starts at %d", ts, val, a.ingestFromT0)
 		}
+		// even if a point is too old for our raw data, it may not be too old for aggregated data
+		// for example let's say a chunk starts at t0=3600 but we have 300-secondly aggregates
+		// that mean the aggregators need data from 3301 and onwards, because we aggregate 3301-3600 into a point with ts=3600
+		a.addAggregators(ts, val)
 		return
 	}
 

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -58,7 +58,7 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 
 	ingestFromT0 := uint32(0)
 	if ingestFrom > 0 {
-		// compute next chunk boundary starting from 'ingestFrom'
+		// we only want to ingest data that will go into chunks with a t0 >= 'ingestFrom'.
 		ingestFromT0 = AggBoundary(uint32(ingestFrom), ret.ChunkSpan)
 	}
 

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -56,6 +56,12 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 	// note: during parsing of retentions, we assure there's at least 1.
 	ret := retentions[0]
 
+	ingestAfterNextChunkT0 := uint32(0)
+	if ingestAfter > 0 {
+		// compute start of next chunk after ingestAfter
+		ingestAfterNextChunkT0 = uint32(ingestAfter-(ingestAfter%int64(ret.ChunkSpan))) + ret.ChunkSpan
+	}
+
 	m := AggMetric{
 		cachePusher:            cachePusher,
 		store:                  store,
@@ -64,7 +70,7 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 		numChunks:              ret.NumChunks,
 		chunks:                 make([]*chunk.Chunk, 0, ret.NumChunks),
 		dropFirstChunk:         dropFirstChunk,
-		ingestAfterNextChunkT0: uint32(ingestAfter-(ingestAfter%int64(ret.ChunkSpan))) + ret.ChunkSpan,
+		ingestAfterNextChunkT0: ingestAfterNextChunkT0,
 		ttl:                    uint32(ret.MaxRetention()),
 		// we set LastWrite here to make sure a new Chunk doesn't get immediately
 		// garbage collected right after creating it, before we can push to it.

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -292,6 +292,8 @@ func TestAggMetricDropFirstChunk(t *testing.T) {
 	m.Add(30, 30)
 	m.Add(31, 31)
 	m.Add(32, 32)
+	// the chunk that point belongs to is not returned by the search because the chunk has
+	// not been closed yet which will happen if a point belonging to the following chunk is added
 	m.Add(40, 40)
 	itgens, err := mockstore.Search(test.NewContext(), test.GetAMKey(42), 0, 0, 1000)
 	if err != nil {
@@ -320,6 +322,8 @@ func TestAggMetricIngestFrom(t *testing.T) {
 	m.Add(30, 30)
 	m.Add(31, 31)
 	m.Add(32, 32)
+	// the chunk that point belongs to is not returned by the search because the chunk has
+	// not been closed yet which will happen if a point belonging to the following chunk is added
 	m.Add(40, 40)
 	itgens, err := mockstore.Search(test.NewContext(), test.GetAMKey(42), 0, 0, 1000)
 	if err != nil {

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -302,7 +302,7 @@ func TestAggMetricDropFirstChunk(t *testing.T) {
 	}
 }
 
-func TestAggMetricIngestAfter(t *testing.T) {
+func TestAggMetricIngestFrom(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 	cluster.Manager.SetPrimary(true)
 	mockstore.Reset()

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -339,7 +339,7 @@ func TestAggMetricIngestFrom(t *testing.T) {
 }
 
 func itersToPoints(iters []tsz.Iter) []schema.Point {
-	points := make([]schema.Point, 0)
+	var points []schema.Point
 	for _, it := range iters {
 		for it.Next() {
 			ts, val := it.Values()

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -18,10 +18,7 @@ type AggMetrics struct {
 	store          Store
 	cachePusher    cache.CachePusher
 	dropFirstChunk bool
-	ingestAfter    struct {
-		orgID     uint32
-		timestamp int64
-	}
+	ingestAfter    map[uint32]int64
 	chunkMaxStale  uint32
 	metricMaxStale uint32
 	gcInterval     time.Duration
@@ -30,18 +27,12 @@ type AggMetrics struct {
 	Metrics map[uint32]map[schema.Key]*AggMetric
 }
 
-func NewAggMetrics(store Store, cachePusher cache.CachePusher, dropFirstChunk bool, ingestAfterOrgID uint32, ingestAfterTimestamp int64, chunkMaxStale, metricMaxStale uint32, gcInterval time.Duration) *AggMetrics {
+func NewAggMetrics(store Store, cachePusher cache.CachePusher, dropFirstChunk bool, ingestAfter map[uint32]int64, chunkMaxStale, metricMaxStale uint32, gcInterval time.Duration) *AggMetrics {
 	ms := AggMetrics{
 		store:          store,
 		cachePusher:    cachePusher,
 		dropFirstChunk: dropFirstChunk,
-		ingestAfter: struct {
-			orgID     uint32
-			timestamp int64
-		}{
-			orgID:     ingestAfterOrgID,
-			timestamp: ingestAfterTimestamp,
-		},
+		ingestAfter:    ingestAfter,
 		Metrics:        make(map[uint32]map[schema.Key]*AggMetric),
 		chunkMaxStale:  chunkMaxStale,
 		metricMaxStale: metricMaxStale,
@@ -173,10 +164,7 @@ func (ms *AggMetrics) GetOrCreate(key schema.MKey, schemaId, aggId uint16, inter
 		ms.Unlock()
 		return m
 	}
-	ingestAfter := int64(0)
-	if key.Org == ms.ingestAfter.orgID {
-		ingestAfter = ms.ingestAfter.timestamp
-	}
+	ingestAfter := ms.ingestAfter[key.Org]
 	m = NewAggMetric(ms.store, ms.cachePusher, k, confSchema.Retentions, confSchema.ReorderWindow, interval, &agg, ms.dropFirstChunk, ingestAfter)
 	ms.Metrics[key.Org][key.Key] = m
 	active := len(ms.Metrics[key.Org])

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -18,7 +18,7 @@ type AggMetrics struct {
 	store          Store
 	cachePusher    cache.CachePusher
 	dropFirstChunk bool
-	ingestAfter    map[uint32]int64
+	ingestFrom     map[uint32]int64
 	chunkMaxStale  uint32
 	metricMaxStale uint32
 	gcInterval     time.Duration
@@ -27,12 +27,12 @@ type AggMetrics struct {
 	Metrics map[uint32]map[schema.Key]*AggMetric
 }
 
-func NewAggMetrics(store Store, cachePusher cache.CachePusher, dropFirstChunk bool, ingestAfter map[uint32]int64, chunkMaxStale, metricMaxStale uint32, gcInterval time.Duration) *AggMetrics {
+func NewAggMetrics(store Store, cachePusher cache.CachePusher, dropFirstChunk bool, ingestFrom map[uint32]int64, chunkMaxStale, metricMaxStale uint32, gcInterval time.Duration) *AggMetrics {
 	ms := AggMetrics{
 		store:          store,
 		cachePusher:    cachePusher,
 		dropFirstChunk: dropFirstChunk,
-		ingestAfter:    ingestAfter,
+		ingestFrom:     ingestFrom,
 		Metrics:        make(map[uint32]map[schema.Key]*AggMetric),
 		chunkMaxStale:  chunkMaxStale,
 		metricMaxStale: metricMaxStale,
@@ -164,8 +164,8 @@ func (ms *AggMetrics) GetOrCreate(key schema.MKey, schemaId, aggId uint16, inter
 		ms.Unlock()
 		return m
 	}
-	ingestAfter := ms.ingestAfter[key.Org]
-	m = NewAggMetric(ms.store, ms.cachePusher, k, confSchema.Retentions, confSchema.ReorderWindow, interval, &agg, ms.dropFirstChunk, ingestAfter)
+	ingestFrom := ms.ingestFrom[key.Org]
+	m = NewAggMetric(ms.store, ms.cachePusher, k, confSchema.Retentions, confSchema.ReorderWindow, interval, &agg, ms.dropFirstChunk, ingestFrom)
 	ms.Metrics[key.Org][key.Key] = m
 	active := len(ms.Metrics[key.Org])
 	ms.Unlock()

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -29,7 +29,7 @@ type Aggregator struct {
 	lstMetric       *AggMetric
 }
 
-func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey, ret conf.Retention, agg conf.Aggregation, dropFirstChunk bool) *Aggregator {
+func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey, ret conf.Retention, agg conf.Aggregation, dropFirstChunk bool, ingestAfter int64) *Aggregator {
 	if len(agg.AggregationMethod) == 0 {
 		panic("NewAggregator called without aggregations. this should never happen")
 	}
@@ -43,31 +43,31 @@ func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey,
 		case conf.Avg:
 			if aggregator.sumMetric == nil {
 				key.Archive = schema.NewArchive(schema.Sum, span)
-				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk)
+				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
 			}
 			if aggregator.cntMetric == nil {
 				key.Archive = schema.NewArchive(schema.Cnt, span)
-				aggregator.cntMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk)
+				aggregator.cntMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
 			}
 		case conf.Sum:
 			if aggregator.sumMetric == nil {
 				key.Archive = schema.NewArchive(schema.Sum, span)
-				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk)
+				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
 			}
 		case conf.Lst:
 			if aggregator.lstMetric == nil {
 				key.Archive = schema.NewArchive(schema.Lst, span)
-				aggregator.lstMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk)
+				aggregator.lstMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
 			}
 		case conf.Max:
 			if aggregator.maxMetric == nil {
 				key.Archive = schema.NewArchive(schema.Max, span)
-				aggregator.maxMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk)
+				aggregator.maxMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
 			}
 		case conf.Min:
 			if aggregator.minMetric == nil {
 				key.Archive = schema.NewArchive(schema.Min, span)
-				aggregator.minMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk)
+				aggregator.minMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
 			}
 		}
 	}

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -29,7 +29,7 @@ type Aggregator struct {
 	lstMetric       *AggMetric
 }
 
-func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey, ret conf.Retention, agg conf.Aggregation, dropFirstChunk bool, ingestAfter int64) *Aggregator {
+func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey, ret conf.Retention, agg conf.Aggregation, dropFirstChunk bool, ingestFrom int64) *Aggregator {
 	if len(agg.AggregationMethod) == 0 {
 		panic("NewAggregator called without aggregations. this should never happen")
 	}
@@ -43,31 +43,31 @@ func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey,
 		case conf.Avg:
 			if aggregator.sumMetric == nil {
 				key.Archive = schema.NewArchive(schema.Sum, span)
-				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
+				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestFrom)
 			}
 			if aggregator.cntMetric == nil {
 				key.Archive = schema.NewArchive(schema.Cnt, span)
-				aggregator.cntMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
+				aggregator.cntMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestFrom)
 			}
 		case conf.Sum:
 			if aggregator.sumMetric == nil {
 				key.Archive = schema.NewArchive(schema.Sum, span)
-				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
+				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestFrom)
 			}
 		case conf.Lst:
 			if aggregator.lstMetric == nil {
 				key.Archive = schema.NewArchive(schema.Lst, span)
-				aggregator.lstMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
+				aggregator.lstMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestFrom)
 			}
 		case conf.Max:
 			if aggregator.maxMetric == nil {
 				key.Archive = schema.NewArchive(schema.Max, span)
-				aggregator.maxMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
+				aggregator.maxMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestFrom)
 			}
 		case conf.Min:
 			if aggregator.minMetric == nil {
 				key.Archive = schema.NewArchive(schema.Min, span)
-				aggregator.minMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestAfter)
+				aggregator.minMetric = NewAggMetric(store, cachePusher, key, conf.Retentions{ret}, 0, span, nil, dropFirstChunk, ingestFrom)
 			}
 		}
 	}

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -95,6 +95,8 @@ func (agg *Aggregator) flush() {
 	agg.agg.Reset()
 }
 
+// Add adds the point to the in-progress aggregation, and flushes it if we reached the boundary
+// points going back in time are accepted, unless they go into a previous bucket, in which case they are ignored
 func (agg *Aggregator) Add(ts uint32, val float64) {
 	boundary := AggBoundary(ts, agg.span)
 
@@ -111,8 +113,6 @@ func (agg *Aggregator) Add(ts uint32, val float64) {
 		}
 		agg.currentBoundary = boundary
 		agg.agg.Add(val)
-	} else {
-		panic("aggregator: boundary < agg.currentBoundary. ts > lastSeen should already have been asserted")
 	}
 }
 

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -76,13 +76,13 @@ func TestAggregator(t *testing.T) {
 		AggregationMethod: []conf.Method{conf.Avg, conf.Min, conf.Max, conf.Sum, conf.Lst},
 	}
 
-	agg := NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(0), ret, aggs, false)
+	agg := NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(0), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	expected := []schema.Point{}
 	compare("simple-min-unfinished", agg.minMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false)
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
@@ -91,7 +91,33 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block", agg.minMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(2), ret, aggs, false)
+	// chunkspan is 120, ingestAfter = 140 means points before chunk starting at 240 are discarded
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 140)
+	agg.Add(100, 123.4)
+	agg.Add(110, 5)
+	agg.Add(130, 130)
+	expected = []schema.Point{}
+	compare("simple-min-ingest-after-all-before-next-chunk", agg.minMetric, expected)
+
+	// chunkspan is 120, ingestAfter = 115 means points before chunk starting at 120 are discarded
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 115)
+	agg.Add(100, 123.4)
+	agg.Add(110, 5)
+	agg.Add(130, 130)
+	expected = []schema.Point{
+		{Val: 5, Ts: 120},
+	}
+	compare("simple-min-ingest-after-one-in-next-chunk", agg.minMetric, expected)
+
+	// chunkspan is 120, ingestAfter = 120 means points before chunk starting at 240 are discarded
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 120)
+	agg.Add(100, 123.4)
+	agg.Add(110, 5)
+	agg.Add(130, 130)
+	expected = []schema.Point{}
+	compare("simple-min-ingest-after-on-chunk-boundary", agg.minMetric, expected)
+
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(2), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(120, 4)
@@ -100,7 +126,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(3), ret, aggs, false)
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(3), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(150, 1.123)
@@ -111,7 +137,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-two-blocks-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(4), ret, aggs, false)
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(4), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(190, 2451.123)

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -91,15 +91,15 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block", agg.minMetric, expected)
 
-	// chunkspan is 120, ingestAfter = 140 means points before chunk starting at 240 are discarded
+	// chunkspan is 120, ingestFrom = 140 means points before chunk starting at 240 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 140)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
 	expected = []schema.Point{}
-	compare("simple-min-ingest-after-all-before-next-chunk", agg.minMetric, expected)
+	compare("simple-min-ingest-from-all-before-next-chunk", agg.minMetric, expected)
 
-	// chunkspan is 120, ingestAfter = 115 means points before chunk starting at 120 are discarded
+	// chunkspan is 120, ingestFrom = 115 means points before chunk starting at 120 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 115)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
@@ -107,15 +107,15 @@ func TestAggregator(t *testing.T) {
 	expected = []schema.Point{
 		{Val: 5, Ts: 120},
 	}
-	compare("simple-min-ingest-after-one-in-next-chunk", agg.minMetric, expected)
+	compare("simple-min-ingest-from-one-in-next-chunk", agg.minMetric, expected)
 
-	// chunkspan is 120, ingestAfter = 120 means points before chunk starting at 240 are discarded
+	// chunkspan is 120, ingestFrom = 120 means points before chunk starting at 240 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 120)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
 	expected = []schema.Point{}
-	compare("simple-min-ingest-after-on-chunk-boundary", agg.minMetric, expected)
+	compare("simple-min-ingest-from-on-chunk-boundary", agg.minMetric, expected)
 
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(2), ret, aggs, false, 0)
 	agg.Add(100, 123.4)

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -109,12 +109,14 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-ingest-from-one-in-next-chunk", agg.minMetric, expected)
 
-	// chunkspan is 120, ingestFrom = 120 means points before chunk starting at 240 are discarded
+	// chunkspan is 120, ingestFrom = 120 means points before chunk starting at 120 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 120)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
-	expected = []schema.Point{}
+	expected = []schema.Point{
+		{Val: 5, Ts: 120},
+	}
 	compare("simple-min-ingest-from-on-chunk-boundary", agg.minMetric, expected)
 
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(2), ret, aggs, false, 0)

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -95,6 +95,8 @@ func TestAggregator(t *testing.T) {
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 140)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
+	// this point is not flushed to agg.minMetric because no point after it with a timestamp
+	// crossing the aggregation boundary is added (aggregation span here is 60)
 	agg.Add(130, 130)
 	expected = []schema.Point{}
 	compare("simple-min-ingest-from-all-before-next-chunk", agg.minMetric, expected)
@@ -103,6 +105,7 @@ func TestAggregator(t *testing.T) {
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 115)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
+	// this point is not flushed to agg.minMetric for the same reason as in the previous test
 	agg.Add(130, 130)
 	expected = []schema.Point{
 		{Val: 5, Ts: 120},
@@ -113,6 +116,7 @@ func TestAggregator(t *testing.T) {
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 120)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
+	// this point is not flushed to agg.minMetric for the same reason as in the previous test
 	agg.Add(130, 130)
 	expected = []schema.Point{
 		{Val: 5, Ts: 120},

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -91,6 +91,17 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block", agg.minMetric, expected)
 
+	// points with a timestamp belonging to the previous aggregation are ignored
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 0)
+	agg.Add(100, 123.4)
+	agg.Add(110, 5)
+	agg.Add(130, 130)
+	agg.Add(90, 24)
+	expected = []schema.Point{
+		{Val: 5, Ts: 120},
+	}
+	compare("simple-min-ignore-back-in-time", agg.minMetric, expected)
+
 	// chunkspan is 120, ingestFrom = 140 means points before chunk starting at 240 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret, aggs, false, 140)
 	agg.Add(100, 123.4)

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -12,6 +12,8 @@ instance = default
 
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -9,6 +9,8 @@ instance = default
 
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -9,6 +9,8 @@ instance = default
 
 # forego persisting of first received (and typically incomplete) chunk
 drop-first-chunk = false
+# only ingest data for chunks that have a t0 equal or higher to the given timestamp. Specified per org. syntax: orgID:timestamp[,...]
+ingest-from =
 # max age for a chunk before to be considered stale and to be persisted to Cassandra
 chunk-max-stale = 1h
 # max age for a metric before to be considered stale and to be purged from in-memory ring buffer.

--- a/util/flag_parsers.go
+++ b/util/flag_parsers.go
@@ -7,32 +7,32 @@ import (
 	"strings"
 )
 
-func ParseIngestAfterFlag(ingestAfterStr string) (uint32, int64, error) {
+func ParseIngestFromFlag(ingestFromStr string) (uint32, int64, error) {
 	orgID := 0
 	timestamp := 0
-	if len(ingestAfterStr) > 0 {
-		ingestAfterParts := strings.Split(ingestAfterStr, ":")
-		if len(ingestAfterParts) != 2 {
-			return 0, 0, fmt.Errorf("Could not parse ingest-after. %s", ingestAfterStr)
+	if len(ingestFromStr) > 0 {
+		ingestFromParts := strings.Split(ingestFromStr, ":")
+		if len(ingestFromParts) != 2 {
+			return 0, 0, fmt.Errorf("Could not parse ingest-from. %s", ingestFromStr)
 		}
 		var err error
-		orgID, err = strconv.Atoi(ingestAfterParts[0])
+		orgID, err = strconv.Atoi(ingestFromParts[0])
 		if err != nil {
-			return 0, 0, fmt.Errorf("Could not parse org id from ingest-after. %s", ingestAfterStr)
+			return 0, 0, fmt.Errorf("Could not parse org id from ingest-from. %s", ingestFromStr)
 		}
 		if orgID < 0 || orgID > math.MaxUint32 {
 			return 0, 0, fmt.Errorf("Org id out of range. %d", orgID)
 		}
-		timestamp, err = strconv.Atoi(ingestAfterParts[1])
+		timestamp, err = strconv.Atoi(ingestFromParts[1])
 		if err != nil {
-			return 0, 0, fmt.Errorf("Could not parse timestamp from ingest-after. %s", ingestAfterStr)
+			return 0, 0, fmt.Errorf("Could not parse timestamp from ingest-from. %s", ingestFromStr)
 		}
 	}
 	return uint32(orgID), int64(timestamp), nil
 }
 
-func MustParseIngestAfterFlag(ingestAfterStr string) (uint32, int64) {
-	orgID, timestamp, err := ParseIngestAfterFlag(ingestAfterStr)
+func MustParseIngestFromFlag(ingestFromStr string) (uint32, int64) {
+	orgID, timestamp, err := ParseIngestFromFlag(ingestFromStr)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/util/flag_parsers.go
+++ b/util/flag_parsers.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+func MustParseIngestAfterFlag(ingestAfterStr string) (uint32, int64) {
+	orgID := 0
+	timestamp := 0
+	if len(ingestAfterStr) > 0 {
+		ingestAfterParts := strings.Split(ingestAfterStr, ":")
+		if len(ingestAfterParts) != 2 {
+			panic(fmt.Sprintf("Could not parse ingest-after. %s", ingestAfterStr))
+		}
+		var err error
+		orgID, err = strconv.Atoi(ingestAfterParts[0])
+		if err != nil {
+			panic(fmt.Sprintf("Could not parse org id from ingest-after. %s", ingestAfterStr))
+		}
+		if orgID < 0 || orgID > math.MaxUint32 {
+			panic(fmt.Sprintf("Org id out of range. %d", orgID))
+		}
+		timestamp, err = strconv.Atoi(ingestAfterParts[1])
+		if err != nil {
+			panic(fmt.Sprintf("Could not parse timestamp from ingest-after. %s", ingestAfterStr))
+		}
+	}
+	return uint32(orgID), int64(timestamp)
+}

--- a/util/flag_parsers.go
+++ b/util/flag_parsers.go
@@ -7,26 +7,34 @@ import (
 	"strings"
 )
 
-func MustParseIngestAfterFlag(ingestAfterStr string) (uint32, int64) {
+func ParseIngestAfterFlag(ingestAfterStr string) (uint32, int64, error) {
 	orgID := 0
 	timestamp := 0
 	if len(ingestAfterStr) > 0 {
 		ingestAfterParts := strings.Split(ingestAfterStr, ":")
 		if len(ingestAfterParts) != 2 {
-			panic(fmt.Sprintf("Could not parse ingest-after. %s", ingestAfterStr))
+			return 0, 0, fmt.Errorf("Could not parse ingest-after. %s", ingestAfterStr)
 		}
 		var err error
 		orgID, err = strconv.Atoi(ingestAfterParts[0])
 		if err != nil {
-			panic(fmt.Sprintf("Could not parse org id from ingest-after. %s", ingestAfterStr))
+			return 0, 0, fmt.Errorf("Could not parse org id from ingest-after. %s", ingestAfterStr)
 		}
 		if orgID < 0 || orgID > math.MaxUint32 {
-			panic(fmt.Sprintf("Org id out of range. %d", orgID))
+			return 0, 0, fmt.Errorf("Org id out of range. %d", orgID)
 		}
 		timestamp, err = strconv.Atoi(ingestAfterParts[1])
 		if err != nil {
-			panic(fmt.Sprintf("Could not parse timestamp from ingest-after. %s", ingestAfterStr))
+			return 0, 0, fmt.Errorf("Could not parse timestamp from ingest-after. %s", ingestAfterStr)
 		}
 	}
-	return uint32(orgID), int64(timestamp)
+	return uint32(orgID), int64(timestamp), nil
+}
+
+func MustParseIngestAfterFlag(ingestAfterStr string) (uint32, int64) {
+	orgID, timestamp, err := ParseIngestAfterFlag(ingestAfterStr)
+	if err != nil {
+		panic(err.Error())
+	}
+	return orgID, timestamp
 }

--- a/util/flag_parsers_test.go
+++ b/util/flag_parsers_test.go
@@ -2,39 +2,39 @@ package util
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseIngestFromFlag(t *testing.T) {
 	tests := []struct {
-		name              string
-		ingestFromStr     string
-		expectedOrgID     uint32
-		expectedTimestamp int64
-		shouldErr         bool
+		name          string
+		ingestFromStr string
+		want          map[uint32]int64
+		wantErr       bool
 	}{
-		{"empty", "", 0, 0, false},
-		{"only zeroes", "0:0", 0, 0, false},
-		{"typical", "10:4738913", 10, 4738913, false},
-		{"missing timestamp", "0", 0, 0, true},
-		{"text no number 1", "text", 0, 0, true},
-		{"text no number 2", "1:text", 0, 0, true},
-		{"orgid overflow", "10000000000:0", 0, 0, true},
+		{"empty", "", nil, false},
+		{"only zeroes", "0:0", nil, true},
+		{"zero timestamp", "10:0", nil, true},
+		{"typical", "10:4738913", map[uint32]int64{10: 4738913}, false},
+		{"missing timestamp", "0", nil, true},
+		{"text no number 1", "text", nil, true},
+		{"text no number 2", "1:text", nil, true},
+		{"orgid overflow", "10000000000:0", nil, true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			orgID, timestamp, err := ParseIngestFromFlag(test.ingestFromStr)
-			if err == nil && test.shouldErr {
-				t.Errorf("ParseIngestFromFlag() should have errored but did not")
+			got, err := ParseIngestFromFlags(test.ingestFromStr)
+			if err == nil && test.wantErr {
+				t.Errorf("ParseIngestFromFlags() should have errored but did not")
 			}
-			if err != nil && !test.shouldErr {
-				t.Errorf("ParseIngestFromFlag() errored but should not have = %v", err)
+			if err != nil && !test.wantErr {
+				t.Errorf("ParseIngestFromFlags() errored but should not have = %v", err)
 			}
-			if orgID != test.expectedOrgID {
-				t.Errorf("ParseIngestFromFlag() expected org id %d, got %d", test.expectedOrgID, orgID)
-			}
-			if timestamp != test.expectedTimestamp {
-				t.Errorf("ParseIngestFromFlag() expected timestamp %d, got %d", test.expectedOrgID, timestamp)
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("ParseIngestFromFlags() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/util/flag_parsers_test.go
+++ b/util/flag_parsers_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 )
 
-func TestMustParseIngestAfterFlag(t *testing.T) {
+func TestParseIngestAfterFlag(t *testing.T) {
 	tests := []struct {
 		name              string
 		ingestAfterStr    string
 		expectedOrgID     uint32
 		expectedTimestamp int64
-		shouldPanic       bool
+		shouldErr         bool
 	}{
 		{"empty", "", 0, 0, false},
 		{"only zeroes", "0:0", 0, 0, false},
@@ -23,21 +23,18 @@ func TestMustParseIngestAfterFlag(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if r == nil && test.shouldPanic {
-					t.Errorf("MustParseIngestAfterFlag() should have paniced but did not")
-				}
-				if r != nil && !test.shouldPanic {
-					t.Errorf("MustParseIngestAfterFlag() panic-ed but should not have = %v", r)
-				}
-			}()
-			orgID, timestamp := MustParseIngestAfterFlag(test.ingestAfterStr)
+			orgID, timestamp, err := ParseIngestAfterFlag(test.ingestAfterStr)
+			if err == nil && test.shouldErr {
+				t.Errorf("ParseIngestAfterFlag() should have errored but did not")
+			}
+			if err != nil && !test.shouldErr {
+				t.Errorf("ParseIngestAfterFlag() errored but should not have = %v", err)
+			}
 			if orgID != test.expectedOrgID {
-				t.Errorf("MustParseIngestAfterFlag() expected org id %d, got %d", test.expectedOrgID, orgID)
+				t.Errorf("ParseIngestAfterFlag() expected org id %d, got %d", test.expectedOrgID, orgID)
 			}
 			if timestamp != test.expectedTimestamp {
-				t.Errorf("MustParseIngestAfterFlag() expected timestamp %d, got %d", test.expectedOrgID, timestamp)
+				t.Errorf("ParseIngestAfterFlag() expected timestamp %d, got %d", test.expectedOrgID, timestamp)
 			}
 		})
 	}

--- a/util/flag_parsers_test.go
+++ b/util/flag_parsers_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-func TestParseIngestAfterFlag(t *testing.T) {
+func TestParseIngestFromFlag(t *testing.T) {
 	tests := []struct {
 		name              string
-		ingestAfterStr    string
+		ingestFromStr     string
 		expectedOrgID     uint32
 		expectedTimestamp int64
 		shouldErr         bool
@@ -23,18 +23,18 @@ func TestParseIngestAfterFlag(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			orgID, timestamp, err := ParseIngestAfterFlag(test.ingestAfterStr)
+			orgID, timestamp, err := ParseIngestFromFlag(test.ingestFromStr)
 			if err == nil && test.shouldErr {
-				t.Errorf("ParseIngestAfterFlag() should have errored but did not")
+				t.Errorf("ParseIngestFromFlag() should have errored but did not")
 			}
 			if err != nil && !test.shouldErr {
-				t.Errorf("ParseIngestAfterFlag() errored but should not have = %v", err)
+				t.Errorf("ParseIngestFromFlag() errored but should not have = %v", err)
 			}
 			if orgID != test.expectedOrgID {
-				t.Errorf("ParseIngestAfterFlag() expected org id %d, got %d", test.expectedOrgID, orgID)
+				t.Errorf("ParseIngestFromFlag() expected org id %d, got %d", test.expectedOrgID, orgID)
 			}
 			if timestamp != test.expectedTimestamp {
-				t.Errorf("ParseIngestAfterFlag() expected timestamp %d, got %d", test.expectedOrgID, timestamp)
+				t.Errorf("ParseIngestFromFlag() expected timestamp %d, got %d", test.expectedOrgID, timestamp)
 			}
 		})
 	}

--- a/util/flag_parsers_test.go
+++ b/util/flag_parsers_test.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestMustParseIngestAfterFlag(t *testing.T) {
+	tests := []struct {
+		name              string
+		ingestAfterStr    string
+		expectedOrgID     uint32
+		expectedTimestamp int64
+		shouldPanic       bool
+	}{
+		{"empty", "", 0, 0, false},
+		{"only zeroes", "0:0", 0, 0, false},
+		{"typical", "10:4738913", 10, 4738913, false},
+		{"missing timestamp", "0", 0, 0, true},
+		{"text no number 1", "text", 0, 0, true},
+		{"text no number 2", "1:text", 0, 0, true},
+		{"orgid overflow", "10000000000:0", 0, 0, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil && test.shouldPanic {
+					t.Errorf("MustParseIngestAfterFlag() should have paniced but did not")
+				}
+				if r != nil && !test.shouldPanic {
+					t.Errorf("MustParseIngestAfterFlag() panic-ed but should not have = %v", r)
+				}
+			}()
+			orgID, timestamp := MustParseIngestAfterFlag(test.ingestAfterStr)
+			if orgID != test.expectedOrgID {
+				t.Errorf("MustParseIngestAfterFlag() expected org id %d, got %d", test.expectedOrgID, orgID)
+			}
+			if timestamp != test.expectedTimestamp {
+				t.Errorf("MustParseIngestAfterFlag() expected timestamp %d, got %d", test.expectedOrgID, timestamp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
New flag 'ingest-from' that instructs metrictank to discard any point of a specific org id that does not belong to chunks starting after a given timestamp.
e.g. 20:67031 with a chunk span of 10 will discard all points with org id 20 and timestamps lesser than 67040