### PR TITLE
do not ignore archive in msgp

### DIFF
--- a/idx/idx.go
+++ b/idx/idx.go
@@ -13,7 +13,6 @@ import (
 var OrgIdPublic = uint32(0)
 
 //go:generate msgp
-//msgp:ignore Archive
 
 type Node struct {
 	Path        string

--- a/idx/idx_gen.go
+++ b/idx/idx_gen.go
@@ -7,6 +7,213 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *Archive) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "MetricDefinition":
+			err = z.MetricDefinition.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "MetricDefinition")
+				return
+			}
+		case "SchemaId":
+			z.SchemaId, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "SchemaId")
+				return
+			}
+		case "AggId":
+			z.AggId, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "AggId")
+				return
+			}
+		case "IrId":
+			z.IrId, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "IrId")
+				return
+			}
+		case "LastSave":
+			z.LastSave, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "LastSave")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *Archive) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 5
+	// write "MetricDefinition"
+	err = en.Append(0x85, 0xb0, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e)
+	if err != nil {
+		return
+	}
+	err = z.MetricDefinition.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "MetricDefinition")
+		return
+	}
+	// write "SchemaId"
+	err = en.Append(0xa8, 0x53, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x49, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.SchemaId)
+	if err != nil {
+		err = msgp.WrapError(err, "SchemaId")
+		return
+	}
+	// write "AggId"
+	err = en.Append(0xa5, 0x41, 0x67, 0x67, 0x49, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.AggId)
+	if err != nil {
+		err = msgp.WrapError(err, "AggId")
+		return
+	}
+	// write "IrId"
+	err = en.Append(0xa4, 0x49, 0x72, 0x49, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.IrId)
+	if err != nil {
+		err = msgp.WrapError(err, "IrId")
+		return
+	}
+	// write "LastSave"
+	err = en.Append(0xa8, 0x4c, 0x61, 0x73, 0x74, 0x53, 0x61, 0x76, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.LastSave)
+	if err != nil {
+		err = msgp.WrapError(err, "LastSave")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Archive) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 5
+	// string "MetricDefinition"
+	o = append(o, 0x85, 0xb0, 0x4d, 0x65, 0x74, 0x72, 0x69, 0x63, 0x44, 0x65, 0x66, 0x69, 0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e)
+	o, err = z.MetricDefinition.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "MetricDefinition")
+		return
+	}
+	// string "SchemaId"
+	o = append(o, 0xa8, 0x53, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x49, 0x64)
+	o = msgp.AppendUint16(o, z.SchemaId)
+	// string "AggId"
+	o = append(o, 0xa5, 0x41, 0x67, 0x67, 0x49, 0x64)
+	o = msgp.AppendUint16(o, z.AggId)
+	// string "IrId"
+	o = append(o, 0xa4, 0x49, 0x72, 0x49, 0x64)
+	o = msgp.AppendUint16(o, z.IrId)
+	// string "LastSave"
+	o = append(o, 0xa8, 0x4c, 0x61, 0x73, 0x74, 0x53, 0x61, 0x76, 0x65)
+	o = msgp.AppendUint32(o, z.LastSave)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Archive) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "MetricDefinition":
+			bts, err = z.MetricDefinition.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MetricDefinition")
+				return
+			}
+		case "SchemaId":
+			z.SchemaId, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SchemaId")
+				return
+			}
+		case "AggId":
+			z.AggId, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AggId")
+				return
+			}
+		case "IrId":
+			z.IrId, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "IrId")
+				return
+			}
+		case "LastSave":
+			z.LastSave, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LastSave")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *Archive) Msgsize() (s int) {
+	s = 1 + 17 + z.MetricDefinition.Msgsize() + 9 + msgp.Uint16Size + 6 + msgp.Uint16Size + 5 + msgp.Uint16Size + 9 + msgp.Uint32Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *Node) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/idx/idx_gen_test.go
+++ b/idx/idx_gen_test.go
@@ -9,6 +9,119 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+func TestMarshalUnmarshalArchive(t *testing.T) {
+	v := Archive{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgArchive(b *testing.B) {
+	v := Archive{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgArchive(b *testing.B) {
+	v := Archive{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalArchive(b *testing.B) {
+	v := Archive{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeArchive(t *testing.T) {
+	v := Archive{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := Archive{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeArchive(b *testing.B) {
+	v := Archive{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeArchive(b *testing.B) {
+	v := Archive{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalNode(t *testing.T) {
 	v := Node{}
 	bts, err := v.MarshalMsg(nil)


### PR DESCRIPTION
This change caused an issue when rolling out MT, because it makes the peer nodes unable to talk to each other. 

I did a test rollout in my QA instance with this version, the issue that I've seen before does not seem to happen anymore.