### PR TITLE
Optimize log statement in ingest path

### DIFF
--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -319,7 +319,9 @@ func (a *AggMetric) Get(from, to uint32) (Result, error) {
 // caller must hold lock
 func (a *AggMetric) addAggregators(ts uint32, val float64) {
 	for _, agg := range a.aggregators {
-		log.Debugf("AM: %s pushing %d,%f to aggregator %d", a.key, ts, val, agg.span)
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("AM: %s pushing %d,%f to aggregator %d", a.key, ts, val, agg.span)
+		}
 		agg.Add(ts, val)
 	}
 }


### PR DESCRIPTION
This log statement is on a very hot path for nodes which ingest a lot. I've seen production examples where `AggMetric.addAggregators()` was responsible for `7.75%` of `alloc_objects`. That's the benchmark before and after:

```
--- before ---
replay@mst-nb:~/go/src/github.com/grafana/metrictank$ /usr/local/bin/go test -benchmem -run=^$ github.com/grafana/metrictank/input -bench '^(BenchmarkProcessMetricPoint)$' -benchtime=10s
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/input
BenchmarkProcessMetricPoint-8           10000000              1268 ns/op             187 B/op          8 allocs/op
PASS
ok      github.com/grafana/metrictank/input     14.049s
--- after ---
replay@mst-nb:~/go/src/github.com/grafana/metrictank$ /usr/local/bin/go test -benchmem -run=^$ github.com/grafana/metrictank/input -bench '^(BenchmarkProcessMetricPoint)$' -benchtime=10s
goos: linux
goarch: amd64
pkg: github.com/grafana/metrictank/input
BenchmarkProcessMetricPoint-8           20000000              1152 ns/op             139 B/op          4 allocs/op
PASS
ok      github.com/grafana/metrictank/input     24.262s
```