### PR TITLE
fix slow ingest problems

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -705,14 +705,14 @@
   revision = "05a94bb32ad1f23f4b01edb2edd06862d4a484d2"
 
 [[projects]]
-  digest = "1:9916fdbc09d95838d0004e1f1737d783307ca75a06b9d2b278f0452bdcb1b790"
+  digest = "1:79cd8a8ab808d2806d7201bb39f5d0c7de4aadf067c1ca9793ea40f9654412b5"
   name = "github.com/raintank/schema"
   packages = [
     ".",
     "msg",
   ]
   pruneopts = "NUT"
-  revision = "01adbd1099945856c1e6955a89c643bcdbe33266"
+  revision = "172e29ac645828b87130d8ae8b41e0a3727ad40d"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -111,7 +111,7 @@ unused-packages = true
 
 [[constraint]]
   name = "github.com/raintank/schema"
-  revision = "01adbd1099945856c1e6955a89c643bcdbe33266"
+  revision = "172e29ac645828b87130d8ae8b41e0a3727ad40d"
 
 [[constraint]]
   name = "github.com/rs/cors"

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1767,19 +1767,8 @@ func toRegexp(pattern string) string {
 // fields, so we need to use atomic operations to read those fields
 // when copying.
 func CloneArchive(a *idx.Archive) idx.Archive {
-	def := schema.MetricDefinition{
-		Id:         a.MetricDefinition.Id,
-		OrgId:      a.MetricDefinition.OrgId,
-		Name:       a.MetricDefinition.Name,
-		Interval:   a.MetricDefinition.Interval,
-		Unit:       a.MetricDefinition.Unit,
-		Mtype:      a.MetricDefinition.Mtype,
-		Tags:       a.MetricDefinition.Tags,
-		LastUpdate: atomic.LoadInt64(&a.MetricDefinition.LastUpdate),
-		Partition:  atomic.LoadInt32(&a.MetricDefinition.Partition),
-	}
-	// update nameWithTags
-	def.NameWithTags()
+	// clones the Archive's MetricDefinition, including nameWithTags.
+	def := a.MetricDefinition.Clone()
 	return idx.Archive{
 		SchemaId:         a.SchemaId,
 		AggId:            a.AggId,

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1767,13 +1767,11 @@ func toRegexp(pattern string) string {
 // fields, so we need to use atomic operations to read those fields
 // when copying.
 func CloneArchive(a *idx.Archive) idx.Archive {
-	// clones the Archive's MetricDefinition, including nameWithTags.
-	def := a.MetricDefinition.Clone()
 	return idx.Archive{
 		SchemaId:         a.SchemaId,
 		AggId:            a.AggId,
 		IrId:             a.IrId,
 		LastSave:         atomic.LoadUint32(&a.LastSave),
-		MetricDefinition: def,
+		MetricDefinition: a.MetricDefinition.Clone(),
 	}
 }

--- a/vendor/github.com/raintank/schema/metric.go
+++ b/vendor/github.com/raintank/schema/metric.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync/atomic"
 )
 
 var ErrInvalidIntervalzero = errors.New("interval cannot be 0")
@@ -160,6 +161,23 @@ func (m *MetricDefinition) NameWithTags() string {
 	m.Name = m.nameWithTags[:len(m.Name)]
 
 	return m.nameWithTags
+}
+
+// Clone() returns a copy of the MetricDefinition. It uses atomic operations
+// to read certain properties that get updated atomically
+func (m *MetricDefinition) Clone() MetricDefinition {
+	return MetricDefinition{
+		Id:           m.Id,
+		OrgId:        m.OrgId,
+		Name:         m.Name,
+		Interval:     m.Interval,
+		Unit:         m.Unit,
+		Mtype:        m.Mtype,
+		Tags:         m.Tags,
+		LastUpdate:   atomic.LoadInt64(&m.LastUpdate),
+		Partition:    atomic.LoadInt32(&m.Partition),
+		nameWithTags: m.nameWithTags,
+	}
 }
 
 func (m *MetricDefinition) NameSanitizedAsTagValue() string {


### PR DESCRIPTION
This PR adds code to the vendored version of raintank/schema which has
already been merged into raintank/schema from this PR:
https://github.com/raintank/schema/pull/33. We can't yet merge master
from raintank/schema due to other required changes. The main point of
the PR is to add and use the Clone() method in raintank/schema/metric.go
in order to assign the nameWithTags values to a cloned MetricDefinition.

We also change the CloneArchive() method in idx/memory.go to use the
new Clone() method. This should reduce allocations caused by CloneArchive()
calling MetricDefinition.NameWithTags() which was causing problems,
especially during startup.

See also: https://github.com/raintank/schema/pull/33