### PR TITLE
we want a warning if the call to ThisNode() is slow

### DIFF
--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -151,6 +151,24 @@ func (c *MemberlistManager) setList(list *memberlist.Memberlist) {
 }
 
 func (c *MemberlistManager) ThisNode() Node {
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		start := time.Now()
+		ticker := time.NewTicker(time.Second * 3)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case now := <-ticker.C:
+				log.Warnf("MemberlistManager: ThisNode() has been blocked for %s", now.Sub(start))
+			}
+		}
+	}()
+
 	return c.thisNode()
 }
 


### PR DESCRIPTION
we use the `/node` route for the kubernetes liveness check, so we want to know if handling that call takes longer than we expect