### PR TITLE
clean up tracing

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/metrictank/util"
 	opentracing "github.com/opentracing/opentracing-go"
 	tags "github.com/opentracing/opentracing-go/ext"
+	traceLog "github.com/opentracing/opentracing-go/log"
 	"github.com/raintank/schema"
 	log "github.com/sirupsen/logrus"
 )
@@ -263,7 +264,7 @@ func (s *Server) getTargetsLocal(ctx context.Context, ss *models.StorageStats, r
 	log.Debugf("DP getTargetsLocal: handling %d reqs locally", len(reqs))
 	rCtx, span := tracing.NewSpan(ctx, s.Tracer, "getTargetsLocal")
 	defer span.Finish()
-	span.SetTag("num_reqs", len(reqs))
+	span.LogFields(traceLog.Int("num_reqs", len(reqs)))
 	responses := make(chan getTargetsResp, len(reqs))
 
 	var wg sync.WaitGroup

--- a/api/models/ccache.go
+++ b/api/models/ccache.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"fmt"
+
 	opentracing "github.com/opentracing/opentracing-go"
+	traceLog "github.com/opentracing/opentracing-go/log"
 )
 
 type CCacheDelete struct {
@@ -14,9 +17,11 @@ type CCacheDelete struct {
 }
 
 func (cd CCacheDelete) Trace(span opentracing.Span) {
-	span.SetTag("patterns", cd.Patterns)
-	span.SetTag("org", cd.OrgId)
-	span.SetTag("propagate", cd.Propagate)
+	span.LogFields(
+		traceLog.String("patterns", fmt.Sprintf("%q", cd.Patterns)),
+		traceLog.Int32("org", int32(cd.OrgId)),
+		traceLog.Bool("propagate", cd.Propagate),
+	)
 }
 
 func (cd CCacheDelete) TraceDebug(span opentracing.Span) {

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 	"strconv"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/grafana/metrictank/idx"
 	pickle "github.com/kisielk/og-rek"
 	opentracing "github.com/opentracing/opentracing-go"
+	traceLog "github.com/opentracing/opentracing-go/log"
 	"gopkg.in/macaron.v1"
 )
 
@@ -133,8 +135,10 @@ type GraphiteTagDelSeries struct {
 }
 
 func (g GraphiteTagDelSeries) Trace(span opentracing.Span) {
-	span.SetTag("paths", g.Paths)
-	span.SetTag("propagate", g.Propagate)
+	span.LogFields(
+		traceLog.String("paths", fmt.Sprintf("%q", g.Paths)),
+		traceLog.Bool("propagate", g.Propagate),
+	)
 }
 
 func (g GraphiteTagDelSeries) TraceDebug(span opentracing.Span) {

--- a/api/models/meta_records.go
+++ b/api/models/meta_records.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"fmt"
+
 	opentracing "github.com/opentracing/opentracing-go"
+	traceLog "github.com/opentracing/opentracing-go/log"
 )
 
 type MetaTagRecordUpsert struct {
@@ -11,9 +14,11 @@ type MetaTagRecordUpsert struct {
 }
 
 func (m MetaTagRecordUpsert) Trace(span opentracing.Span) {
-	span.SetTag("metaTags", m.MetaTags)
-	span.SetTag("queries", m.Queries)
-	span.SetTag("propagate", m.Propagate)
+	span.LogFields(
+		traceLog.String("metaTags", fmt.Sprintf("%q", m.MetaTags)),
+		traceLog.String("queries", fmt.Sprintf("%q", m.Queries)),
+		traceLog.Bool("propagate", m.Propagate),
+	)
 }
 
 func (m MetaTagRecordUpsert) TraceDebug(span opentracing.Span) {
@@ -39,9 +44,11 @@ type IndexMetaTagRecordUpsert struct {
 }
 
 func (m IndexMetaTagRecordUpsert) Trace(span opentracing.Span) {
-	span.SetTag("org", m.OrgId)
-	span.SetTag("metaTags", m.MetaTags)
-	span.SetTag("queries", m.Queries)
+	span.SetTag("orgId", m.OrgId)
+	span.LogFields(
+		traceLog.String("metaTags", fmt.Sprintf("%q", m.MetaTags)),
+		traceLog.String("queries", fmt.Sprintf("%q", m.Queries)),
+	)
 }
 
 func (m IndexMetaTagRecordUpsert) TraceDebug(span opentracing.Span) {

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -1,8 +1,11 @@
 package models
 
 import (
+	"fmt"
+
 	"github.com/grafana/metrictank/cluster"
 	opentracing "github.com/opentracing/opentracing-go"
+	traceLog "github.com/opentracing/opentracing-go/log"
 	"github.com/raintank/schema"
 )
 
@@ -30,7 +33,7 @@ type IndexList struct {
 }
 
 func (i IndexList) Trace(span opentracing.Span) {
-	span.SetTag("org", i.OrgId)
+	span.SetTag("orgId", i.OrgId)
 }
 
 func (i IndexList) TraceDebug(span opentracing.Span) {
@@ -43,9 +46,11 @@ type IndexFindByTag struct {
 }
 
 func (t IndexFindByTag) Trace(span opentracing.Span) {
-	span.SetTag("org", t.OrgId)
-	span.SetTag("expressions", t.Expr)
-	span.SetTag("from", t.From)
+	span.SetTag("orgId", t.OrgId)
+	span.LogFields(
+		traceLog.Int64("from", t.From),
+		traceLog.String("expressions", fmt.Sprintf("%q", t.Expr)),
+	)
 }
 
 func (i IndexFindByTag) TraceDebug(span opentracing.Span) {
@@ -59,10 +64,12 @@ type IndexTagDetails struct {
 }
 
 func (t IndexTagDetails) Trace(span opentracing.Span) {
-	span.SetTag("org", t.OrgId)
-	span.SetTag("filter", t.Filter)
-	span.SetTag("tag", t.Tag)
-	span.SetTag("from", t.From)
+	span.SetTag("orgId", t.OrgId)
+	span.LogFields(
+		traceLog.Int64("from", t.From),
+		traceLog.String("filter", t.Filter),
+		traceLog.String("tag", t.Tag),
+	)
 }
 
 func (i IndexTagDetails) TraceDebug(span opentracing.Span) {
@@ -75,9 +82,11 @@ type IndexTags struct {
 }
 
 func (t IndexTags) Trace(span opentracing.Span) {
-	span.SetTag("org", t.OrgId)
-	span.SetTag("filter", t.Filter)
-	span.SetTag("from", t.From)
+	span.SetTag("orgId", t.OrgId)
+	span.LogFields(
+		traceLog.Int64("from", t.From),
+		traceLog.String("filter", t.Filter),
+	)
 }
 
 func (i IndexTags) TraceDebug(span opentracing.Span) {
@@ -92,11 +101,13 @@ type IndexAutoCompleteTags struct {
 }
 
 func (t IndexAutoCompleteTags) Trace(span opentracing.Span) {
-	span.SetTag("org", t.OrgId)
-	span.SetTag("Prefix", t.Prefix)
-	span.SetTag("expressions", t.Expr)
-	span.SetTag("from", t.From)
-	span.SetTag("limit", t.Limit)
+	span.SetTag("orgId", t.OrgId)
+	span.LogFields(
+		traceLog.Int64("from", t.From),
+		traceLog.String("prefix", t.Prefix),
+		traceLog.String("expressions", fmt.Sprintf("%q", t.Expr)),
+		traceLog.Int("limit", int(t.Limit)),
+	)
 }
 
 func (i IndexAutoCompleteTags) TraceDebug(span opentracing.Span) {
@@ -112,12 +123,14 @@ type IndexAutoCompleteTagValues struct {
 }
 
 func (t IndexAutoCompleteTagValues) Trace(span opentracing.Span) {
-	span.SetTag("org", t.OrgId)
-	span.SetTag("Prefix", t.Prefix)
-	span.SetTag("tag", t.Tag)
-	span.SetTag("expressions", t.Expr)
-	span.SetTag("from", t.From)
-	span.SetTag("limit", t.Limit)
+	span.SetTag("orgId", t.OrgId)
+	span.LogFields(
+		traceLog.Int64("from", t.From),
+		traceLog.String("prefix", t.Prefix),
+		traceLog.String("tag", t.Tag),
+		traceLog.String("expressions", fmt.Sprintf("%q", t.Expr)),
+		traceLog.Int("limit", int(t.Limit)),
+	)
 }
 
 func (i IndexAutoCompleteTagValues) TraceDebug(span opentracing.Span) {
@@ -129,8 +142,8 @@ type IndexTagDelSeries struct {
 }
 
 func (t IndexTagDelSeries) Trace(span opentracing.Span) {
-	span.SetTag("org", t.OrgId)
-	span.SetTag("paths", t.Paths)
+	span.SetTag("orgId", t.OrgId)
+	span.LogFields(traceLog.String("paths", fmt.Sprintf("%q", t.Paths)))
 }
 
 func (i IndexTagDelSeries) TraceDebug(span opentracing.Span) {
@@ -147,9 +160,11 @@ type IndexFind struct {
 }
 
 func (i IndexFind) Trace(span opentracing.Span) {
-	span.SetTag("q", i.Patterns)
-	span.SetTag("org", i.OrgId)
-	span.SetTag("from", i.From)
+	span.SetTag("orgId", i.OrgId)
+	span.LogFields(
+		traceLog.Int64("from", i.From),
+		traceLog.String("q", fmt.Sprintf("%q", i.Patterns)),
+	)
 }
 
 func (i IndexFind) TraceDebug(span opentracing.Span) {
@@ -160,7 +175,7 @@ type GetData struct {
 }
 
 func (g GetData) Trace(span opentracing.Span) {
-	span.SetTag("num_reqs", len(g.Requests))
+	span.LogFields(traceLog.Int("num_reqs", len(g.Requests)))
 }
 
 func (g GetData) TraceDebug(span opentracing.Span) {
@@ -181,8 +196,8 @@ type IndexDelete struct {
 }
 
 func (i IndexDelete) Trace(span opentracing.Span) {
-	span.SetTag("q", i.Query)
-	span.SetTag("org", i.OrgId)
+	span.SetTag("orgId", i.OrgId)
+	span.LogFields(traceLog.String("q", i.Query))
 }
 
 func (i IndexDelete) TraceDebug(span opentracing.Span) {

--- a/api/models/storagestats.go
+++ b/api/models/storagestats.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/metrictank/mdata/cache"
 	opentracing "github.com/opentracing/opentracing-go"
+	traceLog "github.com/opentracing/opentracing-go/log"
 )
 
 //go:generate msgp
@@ -73,10 +74,12 @@ func (ss *StorageStats) MarshalJSONFastRaw(b []byte) ([]byte, error) {
 }
 
 func (ss *StorageStats) Trace(span opentracing.Span) {
-	span.SetTag("cache-miss", atomic.LoadUint32(&ss.CacheMiss))
-	span.SetTag("cache-hit-partial", atomic.LoadUint32(&ss.CacheHitPartial))
-	span.SetTag("cache-hit", atomic.LoadUint32(&ss.CacheHit))
-	span.SetTag("chunks-from-tank", atomic.LoadUint32(&ss.ChunksFromTank))
-	span.SetTag("chunks-from-cache", atomic.LoadUint32(&ss.ChunksFromCache))
-	span.SetTag("chunks-from-store", atomic.LoadUint32(&ss.ChunksFromStore))
+	span.LogFields(
+		traceLog.Int32("cache-miss", int32(atomic.LoadUint32(&ss.CacheMiss))),
+		traceLog.Int32("cache-hit-partial", int32(atomic.LoadUint32(&ss.CacheHitPartial))),
+		traceLog.Int32("cache-hit", int32(atomic.LoadUint32(&ss.CacheHit))),
+		traceLog.Int32("chunks-from-tank", int32(atomic.LoadUint32(&ss.ChunksFromTank))),
+		traceLog.Int32("chunks-from-cache", int32(atomic.LoadUint32(&ss.ChunksFromCache))),
+		traceLog.Int32("chunks-from-store", int32(atomic.LoadUint32(&ss.ChunksFromStore))),
+	)
 }


### PR DESCRIPTION
- change many of the span tags to span logs. Having so many tags
  puts a lot of strain on jaeger.  The span tags weren't something
  that we would every query by, so are better of being logs.
- pass the trace context through when proxying requests to graphite (needs https://github.com/raintank/graphite-mt/pull/13 for the trace contexts to make it back to MT again)
- set the nodatapoints tag on the root span, not the executePlan span.