### PR TITLE
increase connection pool usage.

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -123,6 +123,8 @@ func ConfigProcess() {
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: time.Second,
+		MaxIdleConns:        1000,
+		MaxIdleConnsPerHost: 100,
 	}
 	client = http.Client{
 		Transport: transport,


### PR DESCRIPTION
Default maxIdleConns is 100, but default maxIdleConnsPerHost is only
2.  MT nodes are very chatty and these low limits will result in lots
of requests having to establish new TCP connections.