### PR TITLE
add tool to issue a predictable tag query render workload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
-.PHONY: test bin docker debug
+.PHONY: test bin docker debug stacktest
 default:
 	$(MAKE) all
 test:
 	CGO_ENABLED=1 go test -race -short ./...
 test-all:
 	CGO_ENABLED=1 go test -race ./...
+
+stacktest:
+	# count=1 forces uncached runs
+	# not using stacktest/... here because Go would run them all in parallel,
+	# or at least the TestMain's, and the stacks would conflict with each other
+	go test -count=1 -v ./stacktest/tests/chaos_cluster
+	go test -count=1 -v ./stacktest/tests/end2end_carbon
+	go test -count=1 -v ./stacktest/tests/end2end_carbon_bigtable
+
 check:
 	$(MAKE) test
 bin:

--- a/stacktest/graphite/comparator.go
+++ b/stacktest/graphite/comparator.go
@@ -1,19 +1,31 @@
 package graphite
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
-type Comparator func(p float64) bool
+type Comparator struct {
+	Name string
+	Fn   func(p float64) bool
+}
 
 // Eq returns a comparator that checks whether a float equals the given float
 func Eq(good float64) Comparator {
-	return func(p float64) bool {
-		return (math.IsNaN(good) && math.IsNaN(p)) || p == good
+	return Comparator{
+		Name: fmt.Sprintf("Eq(%f)", good),
+		Fn: func(p float64) bool {
+			return (math.IsNaN(good) && math.IsNaN(p)) || p == good
+		},
 	}
 }
 
 // Eq returns a comparator that checks whether a float is bigger or equal than the given float (or both are NaN)
 func Ge(good float64) Comparator {
-	return func(p float64) bool {
-		return (math.IsNaN(good) && math.IsNaN(p)) || p >= good
+	return Comparator{
+		Name: fmt.Sprintf("Ge(%f)", good),
+		Fn: func(p float64) bool {
+			return (math.IsNaN(good) && math.IsNaN(p)) || p >= good
+		},
 	}
 }

--- a/stacktest/graphite/comparator.go
+++ b/stacktest/graphite/comparator.go
@@ -4,12 +4,14 @@ import "math"
 
 type Comparator func(p float64) bool
 
+// Eq returns a comparator that checks whether a float equals the given float
 func Eq(good float64) Comparator {
 	return func(p float64) bool {
 		return (math.IsNaN(good) && math.IsNaN(p)) || p == good
 	}
 }
 
+// Eq returns a comparator that checks whether a float is bigger or equal than the given float (or both are NaN)
 func Ge(good float64) Comparator {
 	return func(p float64) bool {
 		return (math.IsNaN(good) && math.IsNaN(p)) || p >= good

--- a/stacktest/graphite/graphite.go
+++ b/stacktest/graphite/graphite.go
@@ -48,15 +48,15 @@ func ExecuteRenderQuery(req *http.Request) Response {
 	var r Response
 	resp, err := renderClient.Do(req)
 	if err != nil {
-		r.httpErr = err
+		r.HTTPErr = err
 		return r
 	}
-	r.code = resp.StatusCode
+	r.Code = resp.StatusCode
 	traceHeader := resp.Header["Trace-Id"]
 	if len(traceHeader) > 0 {
-		r.traceID = traceHeader[0]
+		r.TraceID = traceHeader[0]
 	}
-	r.decodeErr = json.NewDecoder(resp.Body).Decode(&r.r)
+	r.DecodeErr = json.NewDecoder(resp.Body).Decode(&r.Decoded)
 	resp.Body.Close()
 	return r
 }
@@ -114,14 +114,14 @@ func checkWorker(req *http.Request, wg *sync.WaitGroup, cr *checkResultsTemp, va
 		}
 	}
 	// if not valid, try to categorize in the common buckets, or fall back to 'other'
-	if r.httpErr == nil && r.decodeErr == nil && len(r.r) == 0 {
+	if r.HTTPErr == nil && r.DecodeErr == nil && len(r.Decoded) == 0 {
 		cr.Lock()
 		cr.empty += 1
 		cr.Unlock()
 		return
 	}
-	if r.httpErr != nil {
-		if err2, ok := r.httpErr.(*url.Error); ok {
+	if r.HTTPErr != nil {
+		if err2, ok := r.HTTPErr.(*url.Error); ok {
 			if err3, ok := err2.Err.(net.Error); ok {
 				if err3.Timeout() {
 					cr.Lock()

--- a/stacktest/graphite/graphite.go
+++ b/stacktest/graphite/graphite.go
@@ -20,15 +20,32 @@ func init() {
 	}
 }
 
-func renderQuery(base, target, from string) Response {
-	var r Response
+func RequestForLocalTestingGraphite(target, from string) *http.Request {
+	return RequestForLocalTesting("http://localhost", target, from)
+}
+
+func RequestForLocalTestingGraphite8080(target, from string) *http.Request {
+	return RequestForLocalTesting("http://localhost:8080", target, from)
+}
+
+func RequestForLocalTestingMT(target, from string) *http.Request {
+	req := RequestForLocalTesting("http://localhost:6060", target, from)
+	req.Header.Add("X-Org-Id", "1")
+	return req
+}
+
+func RequestForLocalTesting(base, target, from string) *http.Request {
 	url := fmt.Sprintf("%s/render?target=%s&format=json&from=%s", base, target, from)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		panic(err)
 	}
-	req.Header.Add("X-Org-Id", "1") // only really needed for MT, not for graphite. oh well...
-	//fmt.Println("requesting", url)
+
+	return req
+}
+
+func ExecuteRenderQuery(req *http.Request) Response {
+	var r Response
 	resp, err := renderClient.Do(req)
 	if err != nil {
 		r.httpErr = err
@@ -44,24 +61,13 @@ func renderQuery(base, target, from string) Response {
 	return r
 }
 
-func RetryGraphite(query, from string, times int, validate Validator) (bool, Response) {
-	return retry(query, from, times, validate, "http://localhost")
-}
-
-func RetryGraphite8080(query, from string, times int, validate Validator) (bool, Response) {
-	return retry(query, from, times, validate, "http://localhost:8080")
-}
-
-func RetryMT(query, from string, times int, validate Validator) (bool, Response) {
-	return retry(query, from, times, validate, "http://localhost:6060")
-}
-func retry(query, from string, times int, validate Validator, base string) (bool, Response) {
+func Retry(req *http.Request, times int, validate Validator) (bool, Response) {
 	var resp Response
 	for i := 0; i < times; i++ {
 		if i > 0 {
 			time.Sleep(time.Second)
 		}
-		resp = renderQuery(base, query, from)
+		resp = ExecuteRenderQuery(req)
 		if validate(resp) {
 			return true, resp
 		}
@@ -96,8 +102,8 @@ func newCheckResultsTemp(validators []Validator) *checkResultsTemp {
 	}
 }
 
-func checkWorker(base, query, from string, wg *sync.WaitGroup, cr *checkResultsTemp, validators []Validator) {
-	r := renderQuery(base, query, from)
+func checkWorker(req *http.Request, wg *sync.WaitGroup, cr *checkResultsTemp, validators []Validator) {
+	r := ExecuteRenderQuery(req)
 	defer wg.Done()
 	for i, v := range validators {
 		if v(r) {
@@ -148,7 +154,8 @@ func CheckMT(endpoints []int, query, from string, dur time.Duration, reqs int, v
 	for range tick.C {
 		wg.Add(1)
 		base := fmt.Sprintf("http://localhost:%d", endpoints[issued%len(endpoints)])
-		go checkWorker(base, query, from, wg, ret, validators)
+		req := RequestForLocalTesting(base, query, from)
+		go checkWorker(req, wg, ret, validators)
 		issued += 1
 		if issued == reqs {
 			break

--- a/stacktest/graphite/graphite.go
+++ b/stacktest/graphite/graphite.go
@@ -61,7 +61,7 @@ func ExecuteRenderQuery(req *http.Request) Response {
 	return r
 }
 
-func Retry(req *http.Request, times int, validate Validator) (bool, Response) {
+func Retry(req *http.Request, times int, validate Validator) (Response, bool) {
 	var resp Response
 	for i := 0; i < times; i++ {
 		if i > 0 {
@@ -69,10 +69,10 @@ func Retry(req *http.Request, times int, validate Validator) (bool, Response) {
 		}
 		resp = ExecuteRenderQuery(req)
 		if validate(resp) {
-			return true, resp
+			return resp, true
 		}
 	}
-	return false, resp
+	return resp, false
 }
 
 // temporary check results

--- a/stacktest/graphite/validate.go
+++ b/stacktest/graphite/validate.go
@@ -3,6 +3,7 @@ package graphite
 import (
 	"fmt"
 	"math"
+	"strings"
 )
 
 // Response is a convenience type:
@@ -28,23 +29,29 @@ func (r Response) StringWithoutData() string {
 	return fmt.Sprintf("<Response>{HTTPErr: %v, DecodeErr: %v, Code: %d, TraceID: %s, Decoded: %s}", r.HTTPErr, r.DecodeErr, r.Code, r.TraceID, data)
 }
 
-type Validator func(resp Response) bool
+type Validator struct {
+	Name string
+	Fn   func(resp Response) bool
+}
 
 // ValidateTargets returns a function that validates that the response contains exactly all named targets
 func ValidateTargets(targets []string) Validator {
-	return func(resp Response) bool {
-		if resp.HTTPErr != nil || resp.DecodeErr != nil || resp.Code != 200 {
-			return false
-		}
-		if len(resp.Decoded) != len(targets) {
-			return false
-		}
-		for i, r := range resp.Decoded {
-			if r.Target != targets[i] {
+	return Validator{
+		Name: fmt.Sprintf("ValidateTargets(%s)", strings.Join(targets, ",")),
+		Fn: func(resp Response) bool {
+			if resp.HTTPErr != nil || resp.DecodeErr != nil || resp.Code != 200 {
 				return false
 			}
-		}
-		return true
+			if len(resp.Decoded) != len(targets) {
+				return false
+			}
+			for i, r := range resp.Decoded {
+				if r.Target != targets[i] {
+					return false
+				}
+			}
+			return true
+		},
 	}
 }
 
@@ -60,37 +67,43 @@ func ValidateTargets(targets []string) Validator {
 // NOTE: 8 points are ignored (see comments further down) so you should only call this
 // for sufficiently long series, e.g. 15 points or so.
 func ValidateCorrect(num float64) Validator {
-	return func(resp Response) bool {
-		if resp.HTTPErr != nil || resp.DecodeErr != nil || resp.Code != 200 {
-			return false
-		}
-		if len(resp.Decoded) != 1 {
-			return false
-		}
-		points := resp.Decoded[0].Datapoints
-		// first 4 points can sometimes be null (or some of them, so that sums don't add up)
-		// We should at some point be more strict and clean that up,
-		// but that's not in scope for these tests which focus on cluster related problems
-		// last 2 points may be NaN or incomplete sums because some terms are NaN
-		// this is standard graphite behavior unlike the faulty cluster behavior.
-		// the faulty cluster behavior we're looking for is where terms are missing across the time range
-		// (because entire shards and their series are not taken into account)
-		for _, p := range points[5 : len(points)-3] {
-			if math.IsNaN(p.Val) {
+	return Validator{
+		Name: fmt.Sprintf("ValidateCorrect(%f)", num),
+		Fn: func(resp Response) bool {
+			if resp.HTTPErr != nil || resp.DecodeErr != nil || resp.Code != 200 {
 				return false
 			}
-			if p.Val > 12 || p.Val < num {
+			if len(resp.Decoded) != 1 {
 				return false
 			}
-		}
-		return true
+			points := resp.Decoded[0].Datapoints
+			// first 4 points can sometimes be null (or some of them, so that sums don't add up)
+			// We should at some point be more strict and clean that up,
+			// but that's not in scope for these tests which focus on cluster related problems
+			// last 2 points may be NaN or incomplete sums because some terms are NaN
+			// this is standard graphite behavior unlike the faulty cluster behavior.
+			// the faulty cluster behavior we're looking for is where terms are missing across the time range
+			// (because entire shards and their series are not taken into account)
+			for _, p := range points[5 : len(points)-3] {
+				if math.IsNaN(p.Val) {
+					return false
+				}
+				if p.Val > 12 || p.Val < num {
+					return false
+				}
+			}
+			return true
+		},
 	}
 }
 
 // ValidaterCode returns a validator that validates whether the response has the given code
 func ValidateCode(code int) Validator {
-	return func(resp Response) bool {
-		return resp.Code == code
+	return Validator{
+		Name: fmt.Sprintf("ValidateCode(%d)", code),
+		Fn: func(resp Response) bool {
+			return resp.Code == code
+		},
 	}
 }
 
@@ -114,40 +127,104 @@ func ValidatorAvgWindowed(numPoints int, cmp Comparator) Validator {
 					}
 					sum += p.Val
 				}
-				if cmp(sum / float64(len(points))) {
+				if cmp.Fn(sum / float64(len(points))) {
 					return true
 				}
 			}
 		}
 		return false
 	}
-	return func(resp Response) bool {
-		for _, series := range resp.Decoded {
-			if len(series.Datapoints) != numPoints {
-				return false
+	return Validator{
+		Name: fmt.Sprintf("ValidatorAvgWindowed(numPoints=%d, cmp=%s)", numPoints, cmp.Name),
+		Fn: func(resp Response) bool {
+			for _, series := range resp.Decoded {
+				if len(series.Datapoints) != numPoints {
+					return false
+				}
+				if !try(series.Datapoints) {
+					return false
+				}
 			}
-			if !try(series.Datapoints) {
-				return false
-			}
-		}
-		return true
+			return true
+		},
 	}
 }
 
 // ValidatorLenNulls returns a validator that validates that any of the series contained
 // within the response, has a length of l and no more than prefix nulls up front.
 func ValidatorLenNulls(prefix, l int) Validator {
-	return func(resp Response) bool {
-		for _, series := range resp.Decoded {
-			if len(series.Datapoints) != l {
-				return false
+	return Validator{
+		Name: fmt.Sprintf("ValidatorLenNulls(prefix=%d, l=%d)", prefix, l),
+		Fn: func(resp Response) bool {
+			for _, series := range resp.Decoded {
+				if len(series.Datapoints) != l {
+					return false
+				}
+				for i, dp := range series.Datapoints {
+					if math.IsNaN(dp.Val) && i+1 > prefix {
+						return false
+					}
+				}
 			}
-			for i, dp := range series.Datapoints {
-				if math.IsNaN(dp.Val) && i+1 > prefix {
+			return true
+		},
+	}
+}
+
+// ValidatorAnd returns a validator that returns whether all given validators return true
+// it runs them in the order given and returns as soon as one fails.
+func ValidatorAnd(vals ...Validator) Validator {
+	var name string
+	for i, val := range vals {
+		if i > 0 {
+			name += " && "
+			name += val.Name
+		}
+	}
+	return Validator{
+		Name: name,
+		Fn: func(resp Response) bool {
+			for _, val := range vals {
+				if !val.Fn(resp) {
 					return false
 				}
 			}
+			return true
+		},
+	}
+}
+
+// ValidatorAndExhaustive returns a validator that returns whether all given validators return true
+// it runs them in the order given, always runs all of them, and prints a log at each run showing the intermediate status
+func ValidatorAndExhaustive(vals ...Validator) Validator {
+	var name string
+	for i, val := range vals {
+		if i > 0 {
+			name += " && "
+			name += val.Name
 		}
-		return true
+	}
+	return Validator{
+		Name: name,
+		Fn: func(resp Response) bool {
+			msg := "ValidatorAndExhaustive: "
+			ret := true
+			for i, val := range vals {
+				ok := val.Fn(resp)
+				if !ok {
+					ret = false
+				}
+				if i > 0 {
+					msg += ", "
+				}
+				if ok {
+					msg += vals[i].Name + ":  OK"
+				} else {
+					msg += vals[i].Name + ":FAIL"
+				}
+			}
+			fmt.Println(msg)
+			return ret
+		},
 	}
 }

--- a/stacktest/graphite/validate.go
+++ b/stacktest/graphite/validate.go
@@ -34,6 +34,12 @@ type Validator struct {
 	Fn   func(resp Response) bool
 }
 
+// Equal returns whether v1 equals v2
+// workaround for go-cmp which treats Validators unequal even if they have the same function pointer. not sure why
+func (v1 Validator) Equal(v2 Validator) bool {
+	return v1.Name == v2.Name
+}
+
 // ValidateTargets returns a function that validates that the response contains exactly all named targets
 func ValidateTargets(targets []string) Validator {
 	return Validator{

--- a/stacktest/graphite/validate.go
+++ b/stacktest/graphite/validate.go
@@ -1,6 +1,9 @@
 package graphite
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 // Response is a convenience type:
 // it provides original http and json decode errors, if applicable
@@ -11,6 +14,18 @@ type Response struct {
 	Code      int
 	TraceID   string
 	Decoded   Data
+}
+
+func (r Response) StringWithoutData() string {
+	data := "{"
+	for i, serie := range r.Decoded {
+		if i > 0 {
+			data += ","
+		}
+		data += fmt.Sprintf("%q", serie.Target)
+	}
+	data += "}"
+	return fmt.Sprintf("<Response>{HTTPErr: %v, DecodeErr: %v, Code: %d, TraceID: %s, Decoded: %s}", r.HTTPErr, r.DecodeErr, r.Code, r.TraceID, data)
 }
 
 type Validator func(resp Response) bool

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -105,17 +105,19 @@ func TestClusterStartup(t *testing.T) {
 func TestClusterBaseIngestWorkload(t *testing.T) {
 	grafana.PostAnnotation("TestClusterBaseIngestWorkload:begin")
 
+	// generate exactly numPartitions metrics, numbered 0..numPartitions where each metric goes to the partition of the same number
+	// each partition is consumed by 2 instances, and each instance consumes 4 partitions thus 4 metrics/s
 	fm = fakemetrics.NewKafka(numPartitions)
 
-	req := graphite.RequestForLocalTestingGraphite("perSecond(metrictank.stats.docker-cluster.*.input.kafka-mdm.metrics_received.counter32)", "-8s")
+	req := graphite.RequestForLocalTestingGraphite("perSecond(metrictank.stats.docker-cluster.*.input.kafka-mdm.metricdata.received.counter32)", "-8s")
 	resp, ok := graphite.Retry(req, 18, func(resp graphite.Response) bool {
 		exp := []string{
-			"perSecond(metrictank.stats.docker-cluster.metrictank0.input.kafka-mdm.metrics_received.counter32)",
-			"perSecond(metrictank.stats.docker-cluster.metrictank1.input.kafka-mdm.metrics_received.counter32)",
-			"perSecond(metrictank.stats.docker-cluster.metrictank2.input.kafka-mdm.metrics_received.counter32)",
-			"perSecond(metrictank.stats.docker-cluster.metrictank3.input.kafka-mdm.metrics_received.counter32)",
-			"perSecond(metrictank.stats.docker-cluster.metrictank4.input.kafka-mdm.metrics_received.counter32)",
-			"perSecond(metrictank.stats.docker-cluster.metrictank5.input.kafka-mdm.metrics_received.counter32)",
+			"perSecond(metrictank.stats.docker-cluster.metrictank0.input.kafka-mdm.metricdata.received.counter32)",
+			"perSecond(metrictank.stats.docker-cluster.metrictank1.input.kafka-mdm.metricdata.received.counter32)",
+			"perSecond(metrictank.stats.docker-cluster.metrictank2.input.kafka-mdm.metricdata.received.counter32)",
+			"perSecond(metrictank.stats.docker-cluster.metrictank3.input.kafka-mdm.metricdata.received.counter32)",
+			"perSecond(metrictank.stats.docker-cluster.metrictank4.input.kafka-mdm.metricdata.received.counter32)",
+			"perSecond(metrictank.stats.docker-cluster.metrictank5.input.kafka-mdm.metricdata.received.counter32)",
 		}
 		// avg rate must be 4 (metrics ingested per second by each instance)
 		return graphite.ValidateTargets(exp)(resp) && graphite.ValidatorAvgWindowed(8, graphite.Eq(4))(resp)

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -49,6 +49,10 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 
 	fmt.Println("launching docker-chaos stack...")
 	cmd = exec.CommandContext(ctx, "docker-compose", "up", "--force-recreate", "-V")

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -182,7 +182,7 @@ func TestIsolateOneInstance(t *testing.T) {
 	if mt4Results.Valid[0]+mt4Results.Valid[1] != numReqMt4 {
 		t.Fatalf("expected mt4 to return either correct or erroring responses (total %d). got %s", numReqMt4, spew.Sdump(mt4Results))
 	}
-	if mt4Results.Valid[1] < numReqMt4*30/100 {
+	if mt4Results.Valid[0] < numReqMt4*30/100 {
 		// the instance is completely down for 30s of the 60s experiment run, but we allow some slack
 		t.Fatalf("expected at least 30%% of all mt4 results to succeed. did %d queries. got %s", numReqMt4, spew.Sdump(mt4Results))
 	}

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -52,6 +52,7 @@ func TestMain(m *testing.M) {
 
 	fmt.Println("launching docker-chaos stack...")
 	cmd = exec.CommandContext(ctx, "docker-compose", "up", "--force-recreate", "-V")
+	cmd.Dir = test.Path("docker/docker-chaos")
 	cmd.Env = append(cmd.Env, "MT_CLUSTER_MIN_AVAILABLE_SHARDS=12")
 
 	tracker, err = track.NewTracker(cmd, false, false, "launch-stdout", "launch-stderr")
@@ -85,7 +86,7 @@ func TestClusterStartup(t *testing.T) {
 		{Str: "metrictank3_1.*metricIndex initialized.*starting data consumption$"},
 		{Str: "metrictank4_1.*metricIndex initialized.*starting data consumption$"},
 		{Str: "metrictank5_1.*metricIndex initialized.*starting data consumption$"},
-		{Str: "grafana.*Initializing HTTP Server.*:3000"},
+		{Str: "grafana.*HTTP Server Listen.*3000"},
 	}
 	select {
 	case <-tracker.Match(matchers):

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/metrictank/stacktest/grafana"
 	"github.com/grafana/metrictank/stacktest/graphite"
 	"github.com/grafana/metrictank/stacktest/track"
+	"github.com/grafana/metrictank/test"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 
 	fmt.Println("stopping docker-chaos stack should it be running...")
 	cmd := exec.CommandContext(ctx, "docker-compose", "down")
-	cmd.Dir = docker.Path("docker/docker-chaos")
+	cmd.Dir = test.Path("docker/docker-chaos")
 	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err.Error())

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -101,7 +101,8 @@ func TestClusterBaseIngestWorkload(t *testing.T) {
 
 	fm = fakemetrics.NewKafka(numPartitions)
 
-	suc6, resp := graphite.RetryGraphite("perSecond(metrictank.stats.docker-cluster.*.input.kafka-mdm.metrics_received.counter32)", "-8s", 18, func(resp graphite.Response) bool {
+	req := graphite.RequestForLocalTestingGraphite("perSecond(metrictank.stats.docker-cluster.*.input.kafka-mdm.metrics_received.counter32)", "-8s")
+	suc6, resp := graphite.Retry(req, 18, func(resp graphite.Response) bool {
 		exp := []string{
 			"perSecond(metrictank.stats.docker-cluster.metrictank0.input.kafka-mdm.metrics_received.counter32)",
 			"perSecond(metrictank.stats.docker-cluster.metrictank1.input.kafka-mdm.metrics_received.counter32)",
@@ -118,7 +119,8 @@ func TestClusterBaseIngestWorkload(t *testing.T) {
 		t.Fatalf("cluster did not reach a state where each MT instance receives 4 points per second. last response was: %s", spew.Sdump(resp))
 	}
 
-	suc6, resp = graphite.RetryMT("sum(some.id.of.a.metric.*)", "-16s", 20, graphite.ValidateCorrect(12))
+	req = graphite.RequestForLocalTestingMT("sum(some.id.of.a.metric.*)", "-16s")
+	suc6, resp = graphite.Retry(req, 20, graphite.ValidateCorrect(12))
 	if !suc6 {
 		grafana.PostAnnotation("TestClusterBaseIngestWorkload:FAIL")
 		t.Fatalf("could not query correct result set. sum of 12 series, each valued 1, should result in 12.  last response was: %s", spew.Sdump(resp))

--- a/stacktest/tests/end2end_carbon/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon/end2end_carbon_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/metrictank/logger"
-	"github.com/grafana/metrictank/stacktest/docker"
 	"github.com/grafana/metrictank/stacktest/fakemetrics"
 	"github.com/grafana/metrictank/stacktest/grafana"
 	"github.com/grafana/metrictank/stacktest/graphite"
 	"github.com/grafana/metrictank/stacktest/track"
+	"github.com/grafana/metrictank/test"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	// introduced here https://github.com/docker/compose/releases/tag/1.19.0
 	// but circleCI machine image still stuck with 1.14.0
 	cmd := exec.Command("docker-compose", "up", "--force-recreate")
-	cmd.Dir = docker.Path("docker/docker-dev")
+	cmd.Dir = test.Path("docker/docker-dev")
 
 	tracker, err = track.NewTracker(cmd, false, false, "launch-stdout", "launch-stderr")
 	if err != nil {

--- a/stacktest/tests/end2end_carbon/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon/end2end_carbon_test.go
@@ -104,7 +104,8 @@ func TestBaseIngestWorkload(t *testing.T) {
 
 	fm = fakemetrics.NewCarbon(metricsPerSecond)
 
-	suc6, resp := graphite.RetryGraphite8080("perSecond(metrictank.stats.docker-env.*.input.carbon.metricdata.received.counter32)", "-8s", 18, func(resp graphite.Response) bool {
+	req := graphite.RequestForLocalTestingGraphite8080("perSecond(metrictank.stats.docker-env.*.input.carbon.metricdata.received.counter32)", "-8s")
+	suc6, resp := graphite.Retry(req, 18, func(resp graphite.Response) bool {
 		exp := []string{
 			"perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)",
 		}

--- a/stacktest/tests/end2end_carbon/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon/end2end_carbon_test.go
@@ -105,7 +105,7 @@ func TestBaseIngestWorkload(t *testing.T) {
 	fm = fakemetrics.NewCarbon(metricsPerSecond)
 
 	req := graphite.RequestForLocalTestingGraphite8080("perSecond(metrictank.stats.docker-env.*.input.carbon.metricdata.received.counter32)", "-8s")
-	suc6, resp := graphite.Retry(req, 18, func(resp graphite.Response) bool {
+	resp, ok := graphite.Retry(req, 18, func(resp graphite.Response) bool {
 		exp := []string{
 			"perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)",
 		}
@@ -115,7 +115,7 @@ func TestBaseIngestWorkload(t *testing.T) {
 		log.Printf("condition target names %t - condition len & nulls %t - condition avg value %t", a, b, c)
 		return a && b && c
 	})
-	if !suc6 {
+	if !ok {
 		grafana.PostAnnotation("TestBaseIngestWorkload:FAIL")
 		t.Fatalf("cluster did not reach a state where the MT instance processes at least %d points per second. last response was: %s", metricsPerSecond, spew.Sdump(resp))
 	}

--- a/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
@@ -2,7 +2,6 @@ package end2end_carbon_bigtable
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -35,10 +34,22 @@ func init() {
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if testing.Short() {
-		fmt.Println("skipping end2end carbon test (bigtable) in short mode")
+		log.Println("skipping end2end carbon test (bigtable) in short mode")
 		return
 	}
-	log.Println("launching docker-dev-bigtable stack...")
+
+	log.Println("stopping docker-dev stack should it be running...")
+	cmd := exec.Command("docker-compose", "down")
+	cmd.Dir = test.Path("docker/docker-dev-bigtable")
+	err := cmd.Start()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
 	version := exec.Command("docker-compose", "version")
 	output, err := version.CombinedOutput()
 	if err != nil {
@@ -46,17 +57,17 @@ func TestMain(m *testing.M) {
 	}
 	log.Println(string(output))
 
+	log.Println("launching docker-dev-bigtable stack...")
 	// TODO: should probably use -V flag here.
 	// introduced here https://github.com/docker/compose/releases/tag/1.19.0
 	// but circleCI machine image still stuck with 1.14.0
-	cmd := exec.Command("docker-compose", "up", "--force-recreate")
+	cmd = exec.Command("docker-compose", "up", "--force-recreate")
 	cmd.Dir = test.Path("docker/docker-dev-bigtable")
 
 	tracker, err = track.NewTracker(cmd, false, false, "launch-stdout", "launch-stderr")
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-
 	err = cmd.Start()
 	if err != nil {
 		log.Fatal(err.Error())
@@ -88,6 +99,7 @@ func TestStartup(t *testing.T) {
 	matchers := []track.Matcher{
 		{Str: "metrictank.*metricIndex initialized.*starting data consumption$"},
 		{Str: "metrictank.*carbon-in: listening on.*2003"},
+		{Str: "grafana.*HTTP Server Listen.*3000"},
 	}
 	select {
 	case <-tracker.Match(matchers):

--- a/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
@@ -104,7 +104,8 @@ func TestBaseIngestWorkload(t *testing.T) {
 
 	fm = fakemetrics.NewCarbon(metricsPerSecond)
 
-	suc6, resp := graphite.RetryGraphite8080("perSecond(metrictank.stats.docker-env.*.input.carbon.metricdata.received.counter32)", "-8s", 18, func(resp graphite.Response) bool {
+	req := graphite.RequestForLocalTestingGraphite8080("perSecond(metrictank.stats.docker-env.*.input.carbon.metricdata.received.counter32)", "-8s")
+	suc6, resp := graphite.Retry(req, 18, func(resp graphite.Response) bool {
 		exp := []string{
 			"perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)",
 		}

--- a/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/metrictank/logger"
-	"github.com/grafana/metrictank/stacktest/docker"
 	"github.com/grafana/metrictank/stacktest/fakemetrics"
 	"github.com/grafana/metrictank/stacktest/grafana"
 	"github.com/grafana/metrictank/stacktest/graphite"
 	"github.com/grafana/metrictank/stacktest/track"
+	"github.com/grafana/metrictank/test"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	// introduced here https://github.com/docker/compose/releases/tag/1.19.0
 	// but circleCI machine image still stuck with 1.14.0
 	cmd := exec.Command("docker-compose", "up", "--force-recreate")
-	cmd.Dir = docker.Path("docker/docker-dev-bigtable")
+	cmd.Dir = test.Path("docker/docker-dev-bigtable")
 
 	tracker, err = track.NewTracker(cmd, false, false, "launch-stdout", "launch-stderr")
 	if err != nil {

--- a/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
@@ -105,7 +105,7 @@ func TestBaseIngestWorkload(t *testing.T) {
 	fm = fakemetrics.NewCarbon(metricsPerSecond)
 
 	req := graphite.RequestForLocalTestingGraphite8080("perSecond(metrictank.stats.docker-env.*.input.carbon.metricdata.received.counter32)", "-8s")
-	suc6, resp := graphite.Retry(req, 18, func(resp graphite.Response) bool {
+	resp, ok := graphite.Retry(req, 18, func(resp graphite.Response) bool {
 		exp := []string{
 			"perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)",
 		}
@@ -115,7 +115,7 @@ func TestBaseIngestWorkload(t *testing.T) {
 		log.Printf("condition target names %t - condition len & nulls %t - condition avg value %t", a, b, c)
 		return a && b && c
 	})
-	if !suc6 {
+	if !ok {
 		grafana.PostAnnotation("TestBaseIngestWorkload:FAIL")
 		t.Fatalf("cluster did not reach a state where the MT instance processes at least %d points per second. last response was: %s", metricsPerSecond, spew.Sdump(resp))
 	}

--- a/stacktest/tests/predictable-tag-query-render-workload/README.md
+++ b/stacktest/tests/predictable-tag-query-render-workload/README.md
@@ -1,0 +1,8 @@
+This tool exerts a consistent workload of tagqueries on a graphite endpoint.
+
+It expects queries for fakemetrics id's like `123456.*` to result in 123456, 1234560 through 1234569
+which you can achieve with an ingest workload such as:
+
+```
+fakemetrics feed --period 60s --mpo 1800000 --add-tags --num-unique-tags 3
+```

--- a/stacktest/tests/predictable-tag-query-render-workload/main.go
+++ b/stacktest/tests/predictable-tag-query-render-workload/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/grafana/metrictank/logger"
+	"github.com/grafana/metrictank/stacktest/graphite"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	key    = os.Getenv("API_KEY")
+	base   = os.Getenv("API_ENDPOINT")
+	bearer = fmt.Sprintf("Bearer " + key)
+)
+
+func init() {
+	formatter := &logger.TextFormatter{}
+	formatter.TimestampFormat = "2006-01-02 15:04:05.000"
+	log.SetFormatter(formatter)
+	log.SetLevel(log.InfoLevel)
+}
+
+func main() {
+	go constantBackgroundLoad()
+	intermittentConcurrentLoad()
+}
+
+// if we have errors, reduce rate. otherwise do 1 request at a time without rest. this is a good workload for now
+func constantBackgroundLoad() {
+	url := fmt.Sprintf("%s/render?target=seriesByTag('region=west100')&format=json&from=-48h", base)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Authorization", bearer)
+
+	for {
+		resp := graphite.ExecuteRenderQuery(req)
+		if !graphite.ValidateTargets([]string{fakemetricName(100)})(resp) {
+			log.Error("bad response: ", resp.StringWithoutData())
+			time.Sleep(time.Second)
+			continue
+		}
+	}
+}
+
+// issue a low rate of queries that access the same data concurrently
+func intermittentConcurrentLoad() {
+	q1 := "seriesByTag('thirdkey=~onemorevalue123456.*')"
+	q2 := "seriesByTag('thirdkey=~onemorevalue1234567')"
+	q3 := "seriesByTag('thirdkey=~onemorevalue1234567', 'region=west1234567')"
+	q4 := "seriesByTag('thirdkey=~onemorevalue1234567', 'region!=foo')"
+	q5 := "seriesByTag('thirdkey=onemorevalue1234567', 'region=~.*1234')"
+
+	req1, _ := http.NewRequest("GET", fmt.Sprintf("%s/render?target=%s&format=json&from=-5min", base, url.QueryEscape(q1)), nil)
+	req1.Header.Add("Authorization", bearer)
+
+	req2, _ := http.NewRequest("GET", fmt.Sprintf("%s/render?target=%s&format=json&from=-5min", base, url.QueryEscape(q2)), nil)
+	req2.Header.Add("Authorization", bearer)
+
+	req3, _ := http.NewRequest("GET", fmt.Sprintf("%s/render?target=%s&format=json&from=-5min", base, url.QueryEscape(q3)), nil)
+	req3.Header.Add("Authorization", bearer)
+
+	req4, _ := http.NewRequest("GET", fmt.Sprintf("%s/render?target=%s&format=json&from=-5min", base, url.QueryEscape(q4)), nil)
+	req4.Header.Add("Authorization", bearer)
+
+	req5, _ := http.NewRequest("GET", fmt.Sprintf("%s/render?target=%s&format=json&from=-5min", base, url.QueryEscape(q5)), nil)
+	req5.Header.Add("Authorization", bearer)
+
+	ids := []int{1234560, 1234561, 1234562, 1234563, 1234564, 1234565, 1234566, 1234567, 1234568, 1234569, 123456}
+	expectedNames := make([]string, len(ids))
+	for i, id := range ids {
+		expectedNames[i] = fakemetricName(id)
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	tick := time.Tick(time.Second)
+
+	for range tick {
+		randDur1 := time.Duration(math.Abs(rand.NormFloat64())*1000) * 1000000
+		randDur2 := time.Duration(math.Abs(rand.NormFloat64())*1000) * 1000000
+		randDur3 := time.Duration(math.Abs(rand.NormFloat64())*1000) * 1000000
+		randDur4 := time.Duration(math.Abs(rand.NormFloat64())*1000) * 1000000
+		randDur5 := time.Duration(math.Abs(rand.NormFloat64())*1000) * 1000000
+
+		time.AfterFunc(randDur1, func() {
+			resp := graphite.ExecuteRenderQuery(req1)
+			if !graphite.ValidateTargets(expectedNames)(resp) {
+				log.Error("intermittentConcurrentLoad case 1 bad response", resp.StringWithoutData())
+			}
+		})
+		time.AfterFunc(randDur2, func() {
+			resp := graphite.ExecuteRenderQuery(req2)
+			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+				log.Error("intermittentConcurrentLoad case 2 bad response", resp.StringWithoutData())
+			}
+		})
+		time.AfterFunc(randDur3, func() {
+			resp := graphite.ExecuteRenderQuery(req3)
+			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+				log.Error("intermittentConcurrentLoad case 3 bad response", resp.StringWithoutData())
+			}
+		})
+		time.AfterFunc(randDur4, func() {
+			resp := graphite.ExecuteRenderQuery(req4)
+			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+				log.Error("intermittentConcurrentLoad case 4 bad response", resp.StringWithoutData())
+			}
+		})
+		time.AfterFunc(randDur5, func() {
+			resp := graphite.ExecuteRenderQuery(req5)
+			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+				log.Error("intermittentConcurrentLoad case 5 bad response", resp.StringWithoutData())
+			}
+		})
+	}
+}
+
+func fakemetricName(num int) string {
+	return fmt.Sprintf("some.id.of.a.metric.%d;afewmoretags=forgoodmeasure;anothertag=somelongervalue;goodforpeoplewhojustusetags=forbasicallyeverything;lotsandlotsoftags=morefunforeveryone;manymoreother=lotsoftagstointern;onetwothreefourfivesix=seveneightnineten;os=ubuntu;region=west%d;secondkey=anothervalue%d;thirdkey=onemorevalue%d", num, num, num, num)
+}

--- a/stacktest/tests/predictable-tag-query-render-workload/main.go
+++ b/stacktest/tests/predictable-tag-query-render-workload/main.go
@@ -40,7 +40,7 @@ func constantBackgroundLoad() {
 
 	for {
 		resp := graphite.ExecuteRenderQuery(req)
-		if !graphite.ValidateTargets([]string{fakemetricName(100)})(resp) {
+		if !graphite.ValidateTargets([]string{fakemetricName(100)}).Fn(resp) {
 			log.Error("bad response: ", resp.StringWithoutData())
 			time.Sleep(time.Second)
 			continue
@@ -89,31 +89,31 @@ func intermittentConcurrentLoad() {
 
 		time.AfterFunc(randDur1, func() {
 			resp := graphite.ExecuteRenderQuery(req1)
-			if !graphite.ValidateTargets(expectedNames)(resp) {
+			if !graphite.ValidateTargets(expectedNames).Fn(resp) {
 				log.Error("intermittentConcurrentLoad case 1 bad response", resp.StringWithoutData())
 			}
 		})
 		time.AfterFunc(randDur2, func() {
 			resp := graphite.ExecuteRenderQuery(req2)
-			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+			if !graphite.ValidateTargets(expectedNames[7:8]).Fn(resp) {
 				log.Error("intermittentConcurrentLoad case 2 bad response", resp.StringWithoutData())
 			}
 		})
 		time.AfterFunc(randDur3, func() {
 			resp := graphite.ExecuteRenderQuery(req3)
-			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+			if !graphite.ValidateTargets(expectedNames[7:8]).Fn(resp) {
 				log.Error("intermittentConcurrentLoad case 3 bad response", resp.StringWithoutData())
 			}
 		})
 		time.AfterFunc(randDur4, func() {
 			resp := graphite.ExecuteRenderQuery(req4)
-			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+			if !graphite.ValidateTargets(expectedNames[7:8]).Fn(resp) {
 				log.Error("intermittentConcurrentLoad case 4 bad response", resp.StringWithoutData())
 			}
 		})
 		time.AfterFunc(randDur5, func() {
 			resp := graphite.ExecuteRenderQuery(req5)
-			if !graphite.ValidateTargets(expectedNames[7:8])(resp) {
+			if !graphite.ValidateTargets(expectedNames[7:8]).Fn(resp) {
 				log.Error("intermittentConcurrentLoad case 5 bad response", resp.StringWithoutData())
 			}
 		})

--- a/test/path.go
+++ b/test/path.go
@@ -1,4 +1,4 @@
-package docker
+package test
 
 import (
 	"os"


### PR DESCRIPTION
This PR:
* adds a tool to exert a basic, consistent render query workload, which was the main goal of this PR. the tool predictable-tag-query-render-workload has no output (it only prints errors)
* refactors and cleans up the existing stacktest code, which seemed to be overdue and has the largest footprint on the diffs.  the stacktest runs should look like so (note that some of the checks repeatedly check for various conditions and return as soon as all of them are true):
```
make stacktest
# count=1 forces uncached runs
# not using stacktest/... here because Go would run them all in parrallel,
# or at least the TestMain's, and the stacks would conflict with each other
go test -count=1 -v ./stacktest/tests/chaos_cluster
2019-08-14 00:10:25.956 [INFO] stopping docker-chaos stack should it be running...
2019-08-14 00:10:27.360 [INFO] docker-compose version 1.24.1, build unknown
docker-py version: 4.0.2
CPython version: 3.7.4
OpenSSL version: OpenSSL 1.1.1c  28 May 2019

2019-08-14 00:10:27.360 [INFO] launching docker-chaos stack...
=== RUN   TestClusterStartup
2019-08-14 00:10:54.591 [INFO] stack now running.
2019-08-14 00:10:54.591 [INFO] Go to http://localhost:3000 (and login as admin:admin) to see what's going on
--- PASS: TestClusterStartup (27.23s)
=== RUN   TestClusterBaseIngestWorkload
--- PASS: TestClusterBaseIngestWorkload (12.35s)
=== RUN   TestQueryWorkload
--- PASS: TestQueryWorkload (60.00s)
=== RUN   TestIsolateOneInstance
--- PASS: TestIsolateOneInstance (60.01s)
PASS
2019-08-14 00:13:06.951 [INFO] stopping docker-compose stack...
2019-08-14 00:13:17.607 [INFO] docker-compose stack is shut down
ok  	github.com/grafana/metrictank/stacktest/tests/chaos_cluster	171.656s
go test -count=1 -v ./stacktest/tests/end2end_carbon
2019-08-14 00:13:18.416 [INFO] stopping docker-dev stack should it be running...
2019-08-14 00:13:20.407 [INFO] docker-compose version 1.24.1, build unknown
docker-py version: 4.0.2
CPython version: 3.7.4
OpenSSL version: OpenSSL 1.1.1c  28 May 2019

2019-08-14 00:13:20.407 [INFO] launching docker-dev stack...
=== RUN   TestStartup
2019-08-14 00:13:40.944 [INFO] stack now running.
2019-08-14 00:13:40.944 [INFO] Go to http://localhost:3000 (and login as admin:admin) to see what's going on
--- PASS: TestStartup (20.54s)
=== RUN   TestBaseIngestWorkload
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):  OK, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):  OK
--- PASS: TestBaseIngestWorkload (7.43s)
PASS
2019-08-14 00:13:48.376 [INFO] stopping docker-compose stack...
2019-08-14 00:13:52.133 [INFO] docker-compose stack is shut down
ok  	github.com/grafana/metrictank/stacktest/tests/end2end_carbon	33.719s
go test -count=1 -v ./stacktest/tests/end2end_carbon_bigtable
2019-08-14 00:13:53.046 [INFO] stopping docker-dev stack should it be running...
2019-08-14 00:13:54.303 [INFO] docker-compose version 1.24.1, build unknown
docker-py version: 4.0.2
CPython version: 3.7.4
OpenSSL version: OpenSSL 1.1.1c  28 May 2019

2019-08-14 00:13:54.303 [INFO] launching docker-dev-bigtable stack...
=== RUN   TestStartup
2019-08-14 00:13:59.843 [INFO] stack now running.
2019-08-14 00:13:59.843 [INFO] Go to http://localhost:3000 (and login as admin:admin) to see what's going on
--- PASS: TestStartup (5.54s)
=== RUN   TestBaseIngestWorkload
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):FAIL, ValidatorLenNulls(prefix=1, l=8):  OK, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):  OK
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):FAIL, ValidatorLenNulls(prefix=1, l=8):  OK, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):  OK
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):FAIL, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):FAIL
ValidatorAndExhaustive: ValidateTargets(perSecond(metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32)):  OK, ValidatorLenNulls(prefix=1, l=8):  OK, ValidatorAvgWindowed(numPoints=8, cmp=Ge(1000.000000)):  OK
--- PASS: TestBaseIngestWorkload (7.31s)
PASS
2019-08-14 00:14:07.151 [INFO] stopping docker-compose stack...
2019-08-14 00:14:18.102 [INFO] docker-compose stack is shut down
ok  	github.com/grafana/metrictank/stacktest/tests/end2end_carbon_bigtable	25.059s
```

 
