### PR TITLE
when adding new point to aggregate, always see if we can flush

### DIFF
--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -407,6 +407,7 @@ func TestGetAggregated(t *testing.T) {
 		{Val: 21 + 22, Ts: 25},
 		{Val: 30, Ts: 30},
 		{Val: 31 + 32, Ts: 35},
+		{Val: 40, Ts: 40},
 	}
 	assertPointsEqual(t, got, expected)
 }
@@ -454,6 +455,7 @@ func TestGetAggregatedIngestFrom(t *testing.T) {
 	expected := []schema.Point{
 		{Val: 26 + 30, Ts: 30},
 		{Val: 31 + 32, Ts: 35},
+		{Val: 40, Ts: 40},
 	}
 	assertPointsEqual(t, got, expected)
 }

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -101,9 +101,11 @@ func (agg *Aggregator) Add(ts uint32, val float64) {
 	boundary := AggBoundary(ts, agg.span)
 
 	if boundary < agg.currentBoundary {
+		// ignore the point it was for a previous bucket. we can't process it
 		return
 	} else if boundary > agg.currentBoundary {
-		// store current totals as a new point in their series
+		// point is for a more recent bucket
+		// store current aggregates as a new point in their series and start the new bucket
 		// if the cnt is still 0, the numbers are invalid, not to be flushed and we can simply reuse the aggregation
 		if agg.agg.Cnt != 0 {
 			agg.flush()
@@ -111,6 +113,11 @@ func (agg *Aggregator) Add(ts uint32, val float64) {
 		agg.currentBoundary = boundary
 	}
 	agg.agg.Add(val)
+
+	// if the ts of the point is a boundary, it means no more point can possibly come in for the same aggregation.
+	// e.g. if aggspan is 10s and we're adding a point with timestamp 12:34:10, then any subsequent point will go
+	// in the bucket for 12:34:20 or later.
+	// so it is time to flush the result
 	if ts == boundary {
 		agg.flush()
 	}

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -100,11 +100,8 @@ func (agg *Aggregator) flush() {
 func (agg *Aggregator) Add(ts uint32, val float64) {
 	boundary := AggBoundary(ts, agg.span)
 
-	if boundary == agg.currentBoundary {
-		agg.agg.Add(val)
-		if ts == boundary {
-			agg.flush()
-		}
+	if boundary < agg.currentBoundary {
+		return
 	} else if boundary > agg.currentBoundary {
 		// store current totals as a new point in their series
 		// if the cnt is still 0, the numbers are invalid, not to be flushed and we can simply reuse the aggregation
@@ -112,7 +109,10 @@ func (agg *Aggregator) Add(ts uint32, val float64) {
 			agg.flush()
 		}
 		agg.currentBoundary = boundary
-		agg.agg.Add(val)
+	}
+	agg.agg.Add(val)
+	if ts == boundary {
+		agg.flush()
 	}
 }
 


### PR DESCRIPTION
e.g. when flushing every 10s and we reach a timestamp like 12:34:10
we can always flush, because any next point will always go into
the next bucket.  We already did this but only in the case of already
having data in the bucket. In the case of an unfortunate mismatch
between aggergation and series (e.g. aggregate across 10s but the
data itself comes every 10s or even less frequent), we can also
just flush in this case, rather than waiting.