### PR TITLE
Use new partition methods

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -102,12 +102,12 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
-  digest = "1:ac52ddd069a36a6545ba4869aa169de501b2d9711437688a632cf9f8d8f5053c"
+  digest = "1:0c31fa2fb2c809d61d640e28cc400087fe205df6ec9623dd1eb91a7de8d4f5d6"
   name = "github.com/cespare/xxhash"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "5c37fe3735342a2e0d01c87a907579987c8936cc"
-  version = "v1.0.0"
+  revision = "3b82fb7d186719faeedd0c2864f868c74fbf79a1"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
@@ -116,6 +116,14 @@
   pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3db74f0cf75d9759d2bdfb6cb55f7d7d372c01f847c5e1ab2fe03773dc2bf024"
+  name = "github.com/dgryski/go-jump"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "e1f439676b570800a863c37b78d1f868f51a85fc"
 
 [[projects]]
   branch = "master"
@@ -713,14 +721,14 @@
   revision = "05a94bb32ad1f23f4b01edb2edd06862d4a484d2"
 
 [[projects]]
-  digest = "1:79cd8a8ab808d2806d7201bb39f5d0c7de4aadf067c1ca9793ea40f9654412b5"
+  digest = "1:dec53b91f232decdae33a4500125ac5bc21964e3d10390c8ef52ef8bdc5abced"
   name = "github.com/raintank/schema"
   packages = [
     ".",
     "msg",
   ]
   pruneopts = "NUT"
-  revision = "172e29ac645828b87130d8ae8b41e0a3727ad40d"
+  revision = "81ecd4b90851930216f37f1ce898cc4f7469d441"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -111,7 +111,7 @@ unused-packages = true
 
 [[constraint]]
   name = "github.com/raintank/schema"
-  revision = "172e29ac645828b87130d8ae8b41e0a3727ad40d"
+  revision = "81ecd4b90851930216f37f1ce898cc4f7469d441"
 
 [[constraint]]
   name = "github.com/rs/cors"

--- a/cluster/partitioner/partitioner.go
+++ b/cluster/partitioner/partitioner.go
@@ -11,44 +11,24 @@ type Partitioner interface {
 }
 
 type Kafka struct {
-	PartitionBy string
+	Method schema.PartitionByMethod
 }
 
 func NewKafka(partitionBy string) (*Kafka, error) {
+	var method schema.PartitionByMethod
 	switch partitionBy {
 	case "byOrg":
+		method = schema.PartitionByOrg
 	case "bySeries":
+		method = schema.PartitionBySeries
 	case "bySeriesWithTags":
+		method = schema.PartitionBySeriesWithTags
 	default:
 		return nil, fmt.Errorf("partitionBy must be one of 'byOrg|bySeries|bySeriesWithTags'. got %s", partitionBy)
 	}
-	return &Kafka{
-		PartitionBy: partitionBy,
-	}, nil
+	return &Kafka{Method: method}, nil
 }
 
 func (k *Kafka) Partition(m schema.PartitionedMetric, numPartitions int32) (int32, error) {
-	partition, err := k.GetPartition(m, numPartitions)
-	if err != nil {
-		return 0, err
-	}
-	return partition, nil
-}
-
-func (k *Kafka) GetPartition(m schema.PartitionedMetric, numPartitions int32) (int32, error) {
-	switch k.PartitionBy {
-	case "byOrg":
-		// partition by organisation: metrics for the same org should go to the same
-		// partition/MetricTank (optimize for locality~performance)
-		return m.PartitionID(schema.PartitionByOrg, numPartitions)
-	case "bySeries":
-		// partition by series: metrics are distributed across all metrictank instances
-		// to allow horizontal scalability
-		return m.PartitionID(schema.PartitionBySeries, numPartitions)
-	case "bySeriesWithTags":
-		// partition by series with tags: metrics are distributed across all metrictank instances
-		// to allow horizontal scalability
-		return m.PartitionID(schema.PartitionBySeriesWithTags, numPartitions)
-	}
-	return -1, fmt.Errorf("unknown partitionBy setting.")
+	return m.PartitionID(k.Method, numPartitions)
 }

--- a/cmd/mt-index-migrate/main.go
+++ b/cmd/mt-index-migrate/main.go
@@ -24,7 +24,7 @@ var (
 	dstKeyspace     = flag.String("dst-keyspace", "raintank", "Cassandra keyspace in use on destination.")
 	srcTable        = flag.String("src-table", "metric_idx", "Cassandra table name in use on source.")
 	dstTable        = flag.String("dst-table", "metric_idx", "Cassandra table name in use on destination.")
-	partitionScheme = flag.String("partition-scheme", "byOrg", "method used for partitioning metrics. (byOrg|bySeries)")
+	partitionScheme = flag.String("partition-scheme", "byOrg", "method used for partitioning metrics. (byOrg|bySeries|bySeriesWithTags)")
 	numPartitions   = flag.Int("num-partitions", 1, "number of partitions in cluster")
 	schemaFile      = flag.String("schema-file", "/etc/metrictank/schema-idx-cassandra.toml", "File containing the needed schemas in case database needs initializing")
 
@@ -52,6 +52,10 @@ func main() {
 	}
 	log.SetLevel(lvl)
 	log.Infof("logging level set to '%s'", *logLevel)
+
+	if *numPartitions < 1 {
+		log.Fatalf("number of partitions must be set to at least 1")
+	}
 
 	defsChan := make(chan *schema.MetricDefinition, 100)
 

--- a/cmd/mt-whisper-importer-writer/main.go
+++ b/cmd/mt-whisper-importer-writer/main.go
@@ -33,7 +33,7 @@ var (
 	exitOnError     = flag.Bool("exit-on-error", false, "Exit with a message when there's an error")
 	httpEndpoint    = flag.String("http-endpoint", "0.0.0.0:8080", "The http endpoint to listen on")
 	ttlsStr         = flag.String("ttls", "35d", "list of ttl strings used by MT separated by ','")
-	partitionScheme = flag.String("partition-scheme", "bySeries", "method used for partitioning metrics. This should match the settings of tsdb-gw. (byOrg|bySeries)")
+	partitionScheme = flag.String("partition-scheme", "bySeries", "method used for partitioning metrics. This should match the settings of tsdb-gw. (byOrg|bySeries|bySeriesWithTags)")
 	uriPath         = flag.String("uri-path", "/metrics/import", "the URI on which we expect chunks to get posted")
 	numPartitions   = flag.Int("num-partitions", 1, "Number of Partitions")
 	logLevel        = flag.String("log-level", "info", "log level. panic|fatal|error|warning|info|debug")
@@ -89,6 +89,10 @@ func main() {
 	}
 	log.SetLevel(lvl)
 	log.Infof("logging level set to '%s'", *logLevel)
+
+	if *numPartitions < 1 {
+		log.Fatalf("number of partitions must be set to at least 1")
+	}
 
 	// the specified port is not relevant as we don't use clustering with this tool
 	cluster.Init("mt-whisper-importer-writer", version, time.Now(), "http", int(80))

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -195,7 +195,7 @@ Flags:
   -num-partitions int
     	number of partitions in cluster (default 1)
   -partition-scheme string
-    	method used for partitioning metrics. (byOrg|bySeries) (default "byOrg")
+    	method used for partitioning metrics. (byOrg|bySeries|bySeriesWithTags) (default "byOrg")
   -schema-file string
     	File containing the needed schemas in case database needs initializing (default "/etc/metrictank/schema-idx-cassandra.toml")
   -src-cass-addr string
@@ -734,7 +734,7 @@ Usage of ./mt-whisper-importer-writer:
   -num-partitions int
     	Number of Partitions (default 1)
   -partition-scheme string
-    	method used for partitioning metrics. This should match the settings of tsdb-gw. (byOrg|bySeries) (default "bySeries")
+    	method used for partitioning metrics. This should match the settings of tsdb-gw. (byOrg|bySeries|bySeriesWithTags) (default "bySeries")
   -ttls string
     	list of ttl strings used by MT separated by ',' (default "35d")
   -uri-path string

--- a/mdata/notifierKafka/notifierKafka.go
+++ b/mdata/notifierKafka/notifierKafka.go
@@ -296,9 +296,9 @@ func (c *NotifierKafka) flush() {
 		}
 		messagesSize.Value(buf.Len())
 		kafkaMsg := &sarama.ProducerMessage{
+			Partition: partition,
 			Topic:     topic,
 			Value:     sarama.ByteEncoder(buf.Bytes()),
-			Partition: partition,
 		}
 		payload = append(payload, kafkaMsg)
 	}

--- a/stacktest/fakemetrics/fakemetrics.go
+++ b/stacktest/fakemetrics/fakemetrics.go
@@ -61,7 +61,7 @@ func NewFakeMetrics(metrics []*schema.MetricData, o out.Out, stats met.Backend) 
 
 func NewKafka(num int) *FakeMetrics {
 	stats, _ := helper.New(false, "", "standard", "", "")
-	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", stats, "lastNum")
+	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", stats, "lastNum", int32(num))
 	if err != nil {
 		log.Fatalf("failed to create kafka-mdm output. %s", err.Error())
 	}

--- a/stacktest/fakemetrics/fakemetrics.go
+++ b/stacktest/fakemetrics/fakemetrics.go
@@ -61,7 +61,7 @@ func NewFakeMetrics(metrics []*schema.MetricData, o out.Out, stats met.Backend) 
 
 func NewKafka(num int) *FakeMetrics {
 	stats, _ := helper.New(false, "", "standard", "", "")
-	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", stats, "lastNum", int32(num))
+	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", stats, "lastNum")
 	if err != nil {
 		log.Fatalf("failed to create kafka-mdm output. %s", err.Error())
 	}

--- a/vendor/github.com/cespare/xxhash/xxhash.go
+++ b/vendor/github.com/cespare/xxhash/xxhash.go
@@ -4,7 +4,8 @@ package xxhash
 
 import (
 	"encoding/binary"
-	"hash"
+	"errors"
+	"math/bits"
 )
 
 const (
@@ -29,72 +30,79 @@ var (
 	prime5v = prime5
 )
 
-type xxh struct {
+// Digest implements hash.Hash64.
+type Digest struct {
 	v1    uint64
 	v2    uint64
 	v3    uint64
 	v4    uint64
-	total int
+	total uint64
 	mem   [32]byte
 	n     int // how much of mem is used
 }
 
-// New creates a new hash.Hash64 that implements the 64-bit xxHash algorithm.
-func New() hash.Hash64 {
-	var x xxh
-	x.Reset()
-	return &x
+// New creates a new Digest that computes the 64-bit xxHash algorithm.
+func New() *Digest {
+	var d Digest
+	d.Reset()
+	return &d
 }
 
-func (x *xxh) Reset() {
-	x.n = 0
-	x.total = 0
-	x.v1 = prime1v + prime2
-	x.v2 = prime2
-	x.v3 = 0
-	x.v4 = -prime1v
+// Reset clears the Digest's state so that it can be reused.
+func (d *Digest) Reset() {
+	d.v1 = prime1v + prime2
+	d.v2 = prime2
+	d.v3 = 0
+	d.v4 = -prime1v
+	d.total = 0
+	d.n = 0
 }
 
-func (x *xxh) Size() int      { return 8 }
-func (x *xxh) BlockSize() int { return 32 }
+// Size always returns 8 bytes.
+func (d *Digest) Size() int { return 8 }
 
-// Write adds more data to x. It always returns len(b), nil.
-func (x *xxh) Write(b []byte) (n int, err error) {
+// BlockSize always returns 32 bytes.
+func (d *Digest) BlockSize() int { return 32 }
+
+// Write adds more data to d. It always returns len(b), nil.
+func (d *Digest) Write(b []byte) (n int, err error) {
 	n = len(b)
-	x.total += len(b)
+	d.total += uint64(n)
 
-	if x.n+len(b) < 32 {
+	if d.n+n < 32 {
 		// This new data doesn't even fill the current block.
-		copy(x.mem[x.n:], b)
-		x.n += len(b)
+		copy(d.mem[d.n:], b)
+		d.n += n
 		return
 	}
 
-	if x.n > 0 {
+	if d.n > 0 {
 		// Finish off the partial block.
-		copy(x.mem[x.n:], b)
-		x.v1 = round(x.v1, u64(x.mem[0:8]))
-		x.v2 = round(x.v2, u64(x.mem[8:16]))
-		x.v3 = round(x.v3, u64(x.mem[16:24]))
-		x.v4 = round(x.v4, u64(x.mem[24:32]))
-		b = b[32-x.n:]
-		x.n = 0
+		copy(d.mem[d.n:], b)
+		d.v1 = round(d.v1, u64(d.mem[0:8]))
+		d.v2 = round(d.v2, u64(d.mem[8:16]))
+		d.v3 = round(d.v3, u64(d.mem[16:24]))
+		d.v4 = round(d.v4, u64(d.mem[24:32]))
+		b = b[32-d.n:]
+		d.n = 0
 	}
 
 	if len(b) >= 32 {
 		// One or more full blocks left.
-		b = writeBlocks(x, b)
+		nw := writeBlocks(d, b)
+		b = b[nw:]
 	}
 
 	// Store any remaining partial block.
-	copy(x.mem[:], b)
-	x.n = len(b)
+	copy(d.mem[:], b)
+	d.n = len(b)
 
 	return
 }
 
-func (x *xxh) Sum(b []byte) []byte {
-	s := x.Sum64()
+// Sum appends the current hash to b and returns the resulting slice.
+func (d *Digest) Sum(b []byte) []byte {
+	s := d.Sum64()
 	return append(
 		b,
 		byte(s>>56),
@@ -108,35 +116,36 @@ func (x *xxh) Sum(b []byte) []byte {
 	)
 }
 
-func (x *xxh) Sum64() uint64 {
+// Sum64 returns the current hash.
+func (d *Digest) Sum64() uint64 {
 	var h uint64
 
-	if x.total >= 32 {
-		v1, v2, v3, v4 := x.v1, x.v2, x.v3, x.v4
+	if d.total >= 32 {
+		v1, v2, v3, v4 := d.v1, d.v2, d.v3, d.v4
 		h = rol1(v1) + rol7(v2) + rol12(v3) + rol18(v4)
 		h = mergeRound(h, v1)
 		h = mergeRound(h, v2)
 		h = mergeRound(h, v3)
 		h = mergeRound(h, v4)
 	} else {
-		h = x.v3 + prime5
+		h = d.v3 + prime5
 	}
 
-	h += uint64(x.total)
+	h += d.total
 
-	i, end := 0, x.n
+	i, end := 0, d.n
 	for ; i+8 <= end; i += 8 {
-		k1 := round(0, u64(x.mem[i:i+8]))
+		k1 := round(0, u64(d.mem[i:i+8]))
 		h ^= k1
 		h = rol27(h)*prime1 + prime4
 	}
 	if i+4 <= end {
-		h ^= uint64(u32(x.mem[i:i+4])) * prime1
+		h ^= uint64(u32(d.mem[i:i+4])) * prime1
 		h = rol23(h)*prime2 + prime3
 		i += 4
 	}
 	for i < end {
-		h ^= uint64(x.mem[i]) * prime5
+		h ^= uint64(d.mem[i]) * prime5
 		h = rol11(h) * prime1
 		i++
 	}
@@ -148,6 +157,56 @@ func (x *xxh) Sum64() uint64 {
 	h ^= h >> 32
 
 	return h
+}
+
+const (
+	magic         = "xxh\x06"
+	marshaledSize = len(magic) + 8*5 + 32
+)
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (d *Digest) MarshalBinary() ([]byte, error) {
+	b := make([]byte, 0, marshaledSize)
+	b = append(b, magic...)
+	b = appendUint64(b, d.v1)
+	b = appendUint64(b, d.v2)
+	b = appendUint64(b, d.v3)
+	b = appendUint64(b, d.v4)
+	b = appendUint64(b, d.total)
+	b = append(b, d.mem[:d.n]...)
+	b = b[:len(b)+len(d.mem)-d.n]
+	return b, nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+func (d *Digest) UnmarshalBinary(b []byte) error {
+	if len(b) < len(magic) || string(b[:len(magic)]) != magic {
+		return errors.New("xxhash: invalid hash state identifier")
+	}
+	if len(b) != marshaledSize {
+		return errors.New("xxhash: invalid hash state size")
+	}
+	b = b[len(magic):]
+	b, d.v1 = consumeUint64(b)
+	b, d.v2 = consumeUint64(b)
+	b, d.v3 = consumeUint64(b)
+	b, d.v4 = consumeUint64(b)
+	b, d.total = consumeUint64(b)
+	copy(d.mem[:], b)
+	b = b[len(d.mem):]
+	d.n = int(d.total % uint64(len(d.mem)))
+	return nil
+}
+
+func appendUint64(b []byte, x uint64) []byte {
+	var a [8]byte
+	binary.LittleEndian.PutUint64(a[:], x)
+	return append(b, a[:]...)
+}
+
+func consumeUint64(b []byte) ([]byte, uint64) {
+	x := u64(b)
+	return b[8:], x
 }
 
 func u64(b []byte) uint64 { return binary.LittleEndian.Uint64(b) }
@@ -167,21 +226,11 @@ func mergeRound(acc, val uint64) uint64 {
 	return acc
 }
 
-// It's important for performance to get the rotates to actually compile to
-// ROLQs. gc will do this for us but only if rotate amount is a constant.
-//
-// TODO(caleb): In Go 1.9 a single function
-//   rol(x uint64, k uint) uint64
-// should do instead. See https://golang.org/issue/18254.
-//
-// TODO(caleb): In Go 1.x (1.9?) consider using the new math/bits package to be more
-// explicit about things. See https://golang.org/issue/18616.
-
-func rol1(x uint64) uint64  { return (x << 1) | (x >> (64 - 1)) }
-func rol7(x uint64) uint64  { return (x << 7) | (x >> (64 - 7)) }
-func rol11(x uint64) uint64 { return (x << 11) | (x >> (64 - 11)) }
-func rol12(x uint64) uint64 { return (x << 12) | (x >> (64 - 12)) }
-func rol18(x uint64) uint64 { return (x << 18) | (x >> (64 - 18)) }
-func rol23(x uint64) uint64 { return (x << 23) | (x >> (64 - 23)) }
-func rol27(x uint64) uint64 { return (x << 27) | (x >> (64 - 27)) }
-func rol31(x uint64) uint64 { return (x << 31) | (x >> (64 - 31)) }
+func rol1(x uint64) uint64  { return bits.RotateLeft64(x, 1) }
+func rol7(x uint64) uint64  { return bits.RotateLeft64(x, 7) }
+func rol11(x uint64) uint64 { return bits.RotateLeft64(x, 11) }
+func rol12(x uint64) uint64 { return bits.RotateLeft64(x, 12) }
+func rol18(x uint64) uint64 { return bits.RotateLeft64(x, 18) }
+func rol23(x uint64) uint64 { return bits.RotateLeft64(x, 23) }
+func rol27(x uint64) uint64 { return bits.RotateLeft64(x, 27) }
+func rol31(x uint64) uint64 { return bits.RotateLeft64(x, 31) }

--- a/vendor/github.com/cespare/xxhash/xxhash_amd64.go
+++ b/vendor/github.com/cespare/xxhash/xxhash_amd64.go
@@ -1,6 +1,6 @@
 // +build !appengine
 // +build gc
-// +build !noasm
+// +build !purego
 
 package xxhash
 
@@ -9,4 +9,5 @@ package xxhash
 //go:noescape
 func Sum64(b []byte) uint64
 
-func writeBlocks(x *xxh, b []byte) []byte
+//go:noescape
+func writeBlocks(*Digest, []byte) int

--- a/vendor/github.com/cespare/xxhash/xxhash_amd64.s
+++ b/vendor/github.com/cespare/xxhash/xxhash_amd64.s
@@ -1,6 +1,6 @@
 // +build !appengine
 // +build gc
-// +build !noasm
+// +build !purego
 
 #include "textflag.h"
 
@@ -170,23 +170,22 @@ finalize:
 	RET
 
 // writeBlocks uses the same registers as above except that it uses AX to store
-// the x pointer.
+// the d pointer.
 
-// func writeBlocks(x *xxh, b []byte) []byte
-TEXT ·writeBlocks(SB), NOSPLIT, $0-56
+// func writeBlocks(d *Digest, b []byte) int
+TEXT ·writeBlocks(SB), NOSPLIT, $0-40
 	// Load fixed primes needed for round.
 	MOVQ ·prime1v(SB), R13
 	MOVQ ·prime2v(SB), R14
 
 	// Load slice.
 	MOVQ b_base+8(FP), CX
-	MOVQ CX, ret_base+32(FP) // initialize return base pointer; see NOTE below
 	MOVQ b_len+16(FP), DX
 	LEAQ (CX)(DX*1), BX
 	SUBQ $32, BX
 
-	// Load vN from x.
-	MOVQ x+0(FP), AX
+	// Load vN from d.
+	MOVQ d+0(FP), AX
 	MOVQ 0(AX), R8   // v1
 	MOVQ 8(AX), R9   // v2
 	MOVQ 16(AX), R10 // v3
@@ -203,31 +202,14 @@ blockLoop:
 	CMPQ CX, BX
 	JLE  blockLoop
 
-	// Copy vN back to x.
+	// Copy vN back to d.
 	MOVQ R8, 0(AX)
 	MOVQ R9, 8(AX)
 	MOVQ R10, 16(AX)
 	MOVQ R11, 24(AX)
 
-	// Construct return slice.
-	// NOTE: It's important that we don't construct a slice that has a base
-	// pointer off the end of the original slice, as in Go 1.7+ this will
-	// cause runtime crashes. (See discussion in, for example,
-	// https://github.com/golang/go/issues/16772.)
-	// Therefore, we calculate the length/cap first, and if they're zero, we
-	// keep the old base. This is what the compiler does as well if you
-	// write code like
-	//   b = b[len(b):]
-
-	// New length is 32 - (CX - BX) -> BX+32 - CX.
-	ADDQ $32, BX
-	SUBQ CX, BX
-	JZ   afterSetBase
-
-	MOVQ CX, ret_base+32(FP)
-
-afterSetBase:
-	MOVQ BX, ret_len+40(FP)
-	MOVQ BX, ret_cap+48(FP) // set cap == len
+	// The number of bytes written is CX minus the old base pointer.
+	SUBQ b_base+8(FP), CX
+	MOVQ CX, ret+32(FP)
 
 	RET

--- a/vendor/github.com/cespare/xxhash/xxhash_other.go
+++ b/vendor/github.com/cespare/xxhash/xxhash_other.go
@@ -1,13 +1,13 @@
-// +build !amd64 appengine !gc noasm
+// +build !amd64 appengine !gc purego
 
 package xxhash
 
 // Sum64 computes the 64-bit xxHash digest of b.
 func Sum64(b []byte) uint64 {
 	// A simpler version would be
-	//   x := New()
-	//   x.Write(b)
-	//   return x.Sum64()
+	//   d := New()
+	//   d.Write(b)
+	//   return d.Sum64()
 	// but this is faster, particularly for small inputs.
 
 	n := len(b)
@@ -61,8 +61,9 @@ func Sum64(b []byte) uint64 {
 	return h
 }
 
-func writeBlocks(x *xxh, b []byte) []byte {
-	v1, v2, v3, v4 := x.v1, x.v2, x.v3, x.v4
+func writeBlocks(d *Digest, b []byte) int {
+	v1, v2, v3, v4 := d.v1, d.v2, d.v3, d.v4
+	n := len(b)
 	for len(b) >= 32 {
 		v1 = round(v1, u64(b[0:8:len(b)]))
 		v2 = round(v2, u64(b[8:16:len(b)]))
@@ -70,6 +71,6 @@ func writeBlocks(x *xxh, b []byte) []byte {
 		v4 = round(v4, u64(b[24:32:len(b)]))
 		b = b[32:len(b):len(b)]
 	}
-	x.v1, x.v2, x.v3, x.v4 = v1, v2, v3, v4
-	return b
+	d.v1, d.v2, d.v3, d.v4 = v1, v2, v3, v4
+	return n - len(b)
 }

--- a/vendor/github.com/cespare/xxhash/xxhash_safe.go
+++ b/vendor/github.com/cespare/xxhash/xxhash_safe.go
@@ -8,3 +8,8 @@ package xxhash
 func Sum64String(s string) uint64 {
 	return Sum64([]byte(s))
 }
+
+// WriteString adds more data to d. It always returns len(s), nil.
+func (d *Digest) WriteString(s string) (n int, err error) {
+	return d.Write([]byte(s))
+}

--- a/vendor/github.com/cespare/xxhash/xxhash_unsafe.go
+++ b/vendor/github.com/cespare/xxhash/xxhash_unsafe.go
@@ -10,21 +10,37 @@ import (
 	"unsafe"
 )
 
+// Notes:
+//
+// See https://groups.google.com/d/msg/golang-nuts/dcjzJy-bSpw/tcZYBzQqAQAJ
+// for some discussion about these unsafe conversions.
+//
+// In the future it's possible that compiler optimizations will make these
+// unsafe operations unnecessary: https://golang.org/issue/2205.
+//
+// Both of these wrapper functions still incur function call overhead since they
+// will not be inlined. We could write Go/asm copies of Sum64 and Digest.Write
+// for strings to squeeze out a bit more speed. Mid-stack inlining should
+// eventually fix this.
+
 // Sum64String computes the 64-bit xxHash digest of s.
 // It may be faster than Sum64([]byte(s)) by avoiding a copy.
-//
-// TODO(caleb): Consider removing this if an optimization is ever added to make
-// it unnecessary: https://golang.org/issue/2205.
-//
-// TODO(caleb): We still have a function call; we could instead write Go/asm
-// copies of Sum64 for strings to squeeze out a bit more speed.
 func Sum64String(s string) uint64 {
-	// See https://groups.google.com/d/msg/golang-nuts/dcjzJy-bSpw/tcZYBzQqAQAJ
-	// for some discussion about this unsafe conversion.
 	var b []byte
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
 	bh.Len = len(s)
 	bh.Cap = len(s)
 	return Sum64(b)
+}
+
+// WriteString adds more data to d. It always returns len(s), nil.
+// It may be faster than Write([]byte(s)) by avoiding a copy.
+func (d *Digest) WriteString(s string) (n int, err error) {
+	var b []byte
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
+	bh.Len = len(s)
+	bh.Cap = len(s)
+	return d.Write(b)
 }

--- a/vendor/github.com/dgryski/go-jump/LICENSE
+++ b/vendor/github.com/dgryski/go-jump/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Damian Gryski <damian@gryski.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/dgryski/go-jump/jump.go
+++ b/vendor/github.com/dgryski/go-jump/jump.go
@@ -1,0 +1,23 @@
+// Package jump implements Google's Jump Consistent Hash
+/*
+
+From the paper "A Fast, Minimal Memory, Consistent Hash Algorithm" by John Lamping, Eric Veach (2014).
+
+http://arxiv.org/abs/1406.2294
+*/
+package jump
+
+// Hash consistently chooses a hash bucket number in the range [0, numBuckets) for the given key. numBuckets must be >= 1.
+func Hash(key uint64, numBuckets int) int32 {
+
+	var b int64 = -1
+	var j int64
+
+	for j < int64(numBuckets) {
+		b = j
+		key = key*2862933555777941757 + 1
+		j = int64(float64(b+1) * (float64(int64(1)<<31) / float64((key>>33)+1)))
+	}
+
+	return int32(b)
+}

--- a/vendor/github.com/raintank/schema/metric.go
+++ b/vendor/github.com/raintank/schema/metric.go
@@ -3,9 +3,9 @@ package schema
 import (
 	"bytes"
 	"crypto/md5"
-	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -16,18 +16,13 @@ var ErrInvalidOrgIdzero = errors.New("org-id cannot be 0")
 var ErrInvalidEmptyName = errors.New("name cannot be empty")
 var ErrInvalidMtype = errors.New("invalid mtype")
 var ErrInvalidTagFormat = errors.New("invalid tag format")
+var ErrUnknownPartitionMethod = errors.New("unknown partition method")
 
 type PartitionedMetric interface {
 	Validate() error
 	SetId()
-	// return a []byte key comprised of the metric's OrgId
-	// accepts an input []byte to allow callers to re-use
-	// buffers to reduce memory allocations
-	KeyByOrgId([]byte) []byte
-	// return a []byte key comprised of the metric's Name
-	// accepts an input []byte to allow callers to re-use
-	// buffers to reduce memory allocations
-	KeyBySeries([]byte) []byte
+	// PartitionID returns the partition id that should be used for this metric.
+	PartitionID(method PartitionByMethod, partitions int32) (int32, error)
 }
 
 //go:generate msgp
@@ -62,25 +57,6 @@ func (m *MetricData) Validate() error {
 		return ErrInvalidTagFormat
 	}
 	return nil
-}
-
-func (m *MetricData) KeyByOrgId(b []byte) []byte {
-	if cap(b)-len(b) < 4 {
-		// not enough unused space in the slice so we need to grow it.
-		newBuf := make([]byte, len(b), len(b)+4)
-		copy(newBuf, b)
-		b = newBuf
-	}
-	// PutUint32 writes directly to the slice rather then appending.
-	// so we need to set the length to 4 more bytes then it currently is.
-	b = b[:len(b)+4]
-	binary.LittleEndian.PutUint32(b[len(b)-4:], uint32(m.OrgId))
-	return b
-}
-
-func (m *MetricData) KeyBySeries(b []byte) []byte {
-	b = append(b, []byte(m.Name)...)
-	return b
 }
 
 // returns a id (hash key) in the format OrgId.md5Sum
@@ -125,7 +101,7 @@ type MetricDefinition struct {
 
 	// this is a special attribute that does not need to be set, it is only used
 	// to keep the state of NameWithTags()
-	nameWithTags string `json:"-"`
+	nameWithTags string
 }
 
 // NameWithTags deduplicates the name and tags strings by storing their content
@@ -138,27 +114,26 @@ func (m *MetricDefinition) NameWithTags() string {
 		return m.nameWithTags
 	}
 
-	sort.Strings(m.Tags)
+	nameWithTagsBuffer := &bytes.Buffer{}
+	_ = writeSortedTagString(nameWithTagsBuffer, m.Name, m.Tags)
+	m.nameWithTags = nameWithTagsBuffer.String()
 
-	nameWithTagsBuffer := bytes.NewBufferString(m.Name)
-	tagPositions := make([]int, 0, len(m.Tags)*2)
+	var i int
+	cursor := len(m.Name)
+	m.Name = m.nameWithTags[:cursor]
 	for _, t := range m.Tags {
-		if len(t) >= 5 && t[:5] == "name=" {
+		if len(t) > 5 && t[:5] == "name=" {
 			continue
 		}
-
-		nameWithTagsBuffer.WriteString(";")
-		tagPositions = append(tagPositions, nameWithTagsBuffer.Len())
-		nameWithTagsBuffer.WriteString(t)
-		tagPositions = append(tagPositions, nameWithTagsBuffer.Len())
+		m.Tags[i] = m.nameWithTags[cursor+1 : cursor+1+len(t)]
+		cursor += len(t) + 1
+		i++
 	}
 
-	m.nameWithTags = nameWithTagsBuffer.String()
-	m.Tags = make([]string, len(tagPositions)/2)
-	for i := 0; i < len(m.Tags); i++ {
-		m.Tags[i] = m.nameWithTags[tagPositions[i*2]:tagPositions[i*2+1]]
+	// if a "name" tag existed, then we have to shorten the slice
+	if i < len(m.Tags) {
+		m.Tags = m.Tags[:i]
 	}
-	m.Name = m.nameWithTags[:len(m.Name)]
 
 	return m.nameWithTags
 }
@@ -196,7 +171,7 @@ func (m *MetricDefinition) SetId() {
 	fmt.Fprintf(buffer, "%d", m.Interval)
 
 	for _, t := range m.Tags {
-		if len(t) >= 5 && t[:5] == "name=" {
+		if len(t) > 5 && t[:5] == "name=" {
 			continue
 		}
 
@@ -227,25 +202,6 @@ func (m *MetricDefinition) Validate() error {
 		return ErrInvalidTagFormat
 	}
 	return nil
-}
-
-func (m *MetricDefinition) KeyByOrgId(b []byte) []byte {
-	if cap(b)-len(b) < 4 {
-		// not enough unused space in the slice so we need to grow it.
-		newBuf := make([]byte, len(b), len(b)+4)
-		copy(newBuf, b)
-		b = newBuf
-	}
-	// PutUint32 writes directly to the slice rather then appending.
-	// so we need to set the length to 4 more bytes then it currently is.
-	b = b[:len(b)+4]
-	binary.LittleEndian.PutUint32(b[len(b)-4:], uint32(m.OrgId))
-	return b
-}
-
-func (m *MetricDefinition) KeyBySeries(b []byte) []byte {
-	b = append(b, []byte(m.Name)...)
-	return b
 }
 
 // MetricDefinitionFromMetricData yields a MetricDefinition that has no references
@@ -286,6 +242,65 @@ func SanitizeNameAsTagValue(name string) string {
 
 	// the whole name consists of no other chars than '~'
 	return ""
+}
+
+// EatDots removes multiple consecutive, leading, and trailing dots
+// from name. If the provided name is only dots, it will return an
+// empty string
+// The vast majority of names will not need to be modified,
+// so we optimize for that case. This function only requires
+// allocations if the name does need to be modified.
+func EatDots(name string) string {
+	if len(name) == 0 {
+		return ""
+	}
+
+	dotsToRemove := 0
+	if name[0] == '.' {
+		dotsToRemove++
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] == '.' {
+			if name[i-1] == '.' {
+				dotsToRemove++
+			}
+			if i == len(name)-1 {
+				dotsToRemove++
+			}
+		}
+	}
+
+	// the majority of cases will return here
+	if dotsToRemove == 0 {
+		return name
+	}
+
+	if dotsToRemove >= len(name) {
+		return ""
+	}
+
+	newName := make([]byte, len(name)-dotsToRemove)
+	j := 0
+	sawDot := false
+	for i := 0; i < len(name); i++ {
+		if name[i] == '.' {
+			if j > 0 {
+				sawDot = true
+			}
+			continue
+		}
+
+		if sawDot {
+			newName[j] = '.'
+			sawDot = false
+			j++
+		}
+
+		newName[j] = name[i]
+		j++
+	}
+
+	return string(newName)
 }
 
 // ValidateTags returns whether all tags are in a valid format.
@@ -344,4 +359,31 @@ func ValidateTagValue(value string) bool {
 	}
 
 	return !strings.ContainsRune(value, ';')
+}
+
+func writeSortedTagString(w io.Writer, name string, tags []string) error {
+	sort.Strings(tags)
+
+	_, err := io.WriteString(w, name)
+	if err != nil {
+		return err
+	}
+
+	for _, t := range tags {
+		if len(t) > 5 && t[:5] == "name=" {
+			continue
+		}
+
+		_, err = io.WriteString(w, ";")
+		if err != nil {
+			return err
+		}
+
+		_, err = io.WriteString(w, t)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/vendor/github.com/raintank/schema/partition.go
+++ b/vendor/github.com/raintank/schema/partition.go
@@ -1,0 +1,116 @@
+package schema
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+
+	"github.com/cespare/xxhash"
+	jump "github.com/dgryski/go-jump"
+)
+
+type PartitionByMethod uint8
+
+const (
+	// partition by organization id only
+	PartitionByOrg PartitionByMethod = iota
+
+	// partition by the metric name only
+	PartitionBySeries
+
+	// partition by metric name and tags, with the best distribution
+	// recommended for new deployments.
+	PartitionBySeriesWithTags
+
+	// partition by metric name and tags, with a sub-optimal distribution when using tags.
+	// compatible with PartitionBySeries if a metric has no tags,
+	// making it possible to adopt tags for existing PartitionBySeries deployments without a migration.
+	PartitionBySeriesWithTagsFnv
+)
+
+func (m *MetricData) PartitionID(method PartitionByMethod, partitions int32) (int32, error) {
+	var partition int32
+
+	switch method {
+	case PartitionByOrg:
+		h := fnv.New32a()
+		err := binary.Write(h, binary.LittleEndian, uint32(m.OrgId))
+		if err != nil {
+			return 0, err
+		}
+		partition = int32(h.Sum32()) % partitions
+		if partition < 0 {
+			partition = -partition
+		}
+	case PartitionBySeries:
+		h := fnv.New32a()
+		h.Write([]byte(m.Name))
+		partition = int32(h.Sum32()) % partitions
+		if partition < 0 {
+			partition = -partition
+		}
+	case PartitionBySeriesWithTags:
+		h := xxhash.New()
+		if err := writeSortedTagString(h, m.Name, m.Tags); err != nil {
+			return 0, err
+		}
+		partition = jump.Hash(h.Sum64(), int(partitions))
+	case PartitionBySeriesWithTagsFnv:
+		h := fnv.New32a()
+		if err := writeSortedTagString(h, m.Name, m.Tags); err != nil {
+			return 0, err
+		}
+		partition = int32(h.Sum32()) % partitions
+		if partition < 0 {
+			partition = -partition
+		}
+	default:
+		return 0, ErrUnknownPartitionMethod
+	}
+
+	return partition, nil
+}
+
+func (m *MetricDefinition) PartitionID(method PartitionByMethod, partitions int32) (int32, error) {
+	var partition int32
+
+	switch method {
+	case PartitionByOrg:
+		h := fnv.New32a()
+		err := binary.Write(h, binary.LittleEndian, uint32(m.OrgId))
+		if err != nil {
+			return 0, err
+		}
+		partition = int32(h.Sum32()) % partitions
+		if partition < 0 {
+			partition = -partition
+		}
+	case PartitionBySeries:
+		h := fnv.New32a()
+		h.Write([]byte(m.Name))
+		partition = int32(h.Sum32()) % partitions
+		if partition < 0 {
+			partition = -partition
+		}
+	case PartitionBySeriesWithTags:
+		h := xxhash.New()
+		h.WriteString(m.NameWithTags())
+		partition = jump.Hash(h.Sum64(), int(partitions))
+	case PartitionBySeriesWithTagsFnv:
+		h := fnv.New32a()
+		if len(m.nameWithTags) > 0 {
+			h.Write([]byte(m.nameWithTags))
+		} else {
+			if err := writeSortedTagString(h, m.Name, m.Tags); err != nil {
+				return 0, err
+			}
+		}
+		partition = int32(h.Sum32()) % partitions
+		if partition < 0 {
+			partition = -partition
+		}
+	default:
+		return 0, ErrUnknownPartitionMethod
+	}
+
+	return partition, nil
+}


### PR DESCRIPTION
This PR replaces and supersedes #1282.

Now that raintank/schema#26 is merged we can switch over to using `PartionID` in `Metrictank` and `tsdb-gw`.

Remove the `Partitioner` interface in this PR or a later PR.

This PR adds a `keyBySeriesWithTags` option to partitioning.

After this is merged I think the following steps should be followed:
1. Update `tsdb-gw` to use the new partitioning code.
2. Move `raintank/schema` into `Metrictank`.
3. Update `tsdb-gw` to use the vendored code in `Metrictank`.
4. Implement `EatDots` in the validation methods.

See also: #1123, raintank/schema#26, raintank/tsdb-gw#138