### PR TITLE
WIP: process requests on a per shard basis, not per peer.

### DIFF
--- a/api/models/request.go
+++ b/api/models/request.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/raintank/schema"
 
-	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/util"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -27,7 +26,7 @@ type Req struct {
 	// we need to make this differentiation to tie back to the original request (and we can't just fill in the concrete consolidation in the request,
 	// because one request may result in multiple series with different consolidators)
 	ConsReq  consolidation.Consolidator `json:"consolidator_req"`
-	Node     cluster.Node               `json:"-"`
+	Shard    int32                      `json:"shard"`
 	SchemaId uint16                     `json:"schemaId"`
 	AggId    uint16                     `json:"aggId"`
 
@@ -39,7 +38,7 @@ type Req struct {
 	AggNum       uint32 `json:"aggNum"`       // how many points to consolidate together at runtime, after fetching from the archive
 }
 
-func NewReq(key schema.MKey, target, patt string, from, to, maxPoints, rawInterval uint32, cons, consReq consolidation.Consolidator, node cluster.Node, schemaId, aggId uint16) Req {
+func NewReq(key schema.MKey, target, patt string, from, to, maxPoints, rawInterval uint32, cons, consReq consolidation.Consolidator, shard int32, schemaId, aggId uint16) Req {
 	return Req{
 		key,
 		target,
@@ -50,7 +49,7 @@ func NewReq(key schema.MKey, target, patt string, from, to, maxPoints, rawInterv
 		rawInterval,
 		cons,
 		consReq,
-		node,
+		shard,
 		schemaId,
 		aggId,
 		-1, // this is supposed to be updated still!
@@ -132,7 +131,7 @@ func (a Req) Equals(b Req) bool {
 	if a.ConsReq != b.ConsReq {
 		return false
 	}
-	if a.Node.GetName() != b.Node.GetName() {
+	if a.Shard != b.Shard {
 		return false
 	}
 	if a.SchemaId != b.SchemaId {

--- a/api/prometheus_querier.go
+++ b/api/prometheus_querier.go
@@ -88,7 +88,7 @@ func (q *querier) Select(matchers ...*labels.Matcher) (storage.SeriesSet, error)
 				fn := mdata.Aggregations.Get(archive.AggId).AggregationMethod[0]
 				cons := consolidation.Consolidator(fn)
 
-				newReq := models.NewReq(archive.Id, archive.NameWithTags(), target, q.from, q.to, math.MaxUint32, uint32(archive.Interval), cons, consReq, s.Node, archive.SchemaId, archive.AggId)
+				newReq := models.NewReq(archive.Id, archive.NameWithTags(), target, q.from, q.to, math.MaxUint32, uint32(archive.Interval), cons, consReq, s.Shard, archive.SchemaId, archive.AggId)
 				reqs = append(reqs, newReq)
 			}
 		}

--- a/cluster/if.go
+++ b/cluster/if.go
@@ -8,6 +8,7 @@ type Node interface {
 	IsLocal() bool
 	IsReady() bool
 	GetPartitions() []int32
+	GetShard() (int32, error)
 	GetPriority() int
 	HasData() bool
 	Post(context.Context, string, string, Traceable) ([]byte, error)

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 )
@@ -25,6 +26,15 @@ func (n *MockNode) IsReady() bool {
 
 func (n *MockNode) GetPartitions() []int32 {
 	return n.partitions
+}
+
+// GetShard returns the Shard group of this node. This assumes that each node in the cluster
+// has the same number of partitions.
+func (n *MockNode) GetShard() (int32, error) {
+	if len(n.partitions) == 0 {
+		return 0, fmt.Errorf("node has no partitions")
+	}
+	return n.partitions[0] / int32(len(n.partitions)), nil
 }
 
 func (n *MockNode) HasData() bool {

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -180,6 +180,13 @@ func (n HTTPNode) GetPartitions() []int32 {
 	return n.Partitions
 }
 
+func (n HTTPNode) GetShard() (int32, error) {
+	if len(n.Partitions) == 0 {
+		return 0, fmt.Errorf("node has no partitions")
+	}
+	return n.Partitions[0] / int32(len(n.Partitions)), nil
+}
+
 func (n HTTPNode) HasData() bool {
 	return len(n.Partitions) > 0
 }


### PR DESCRIPTION
This change refactors the processing flow for render queries.
Matching series are fetched from all shards, but instead of tracking
the node that the series were found on, we now track the shard.
When processing requests, we group by the shard, then send all of
those requests to a peer from the shard. if the request to the peer
fails, additional peers for the shard will be tried.