### PR TITLE
eat dots

### DIFF
--- a/schema/metric.go
+++ b/schema/metric.go
@@ -47,6 +47,7 @@ func (m *MetricData) Validate() error {
 	if m.Interval == 0 {
 		return ErrInvalidIntervalzero
 	}
+	m.Name = EatDots(m.Name)
 	if m.Name == "" {
 		return ErrInvalidEmptyName
 	}
@@ -192,6 +193,7 @@ func (m *MetricDefinition) Validate() error {
 	if m.Interval == 0 {
 		return ErrInvalidIntervalzero
 	}
+	m.Name = EatDots(m.Name)
 	if m.Name == "" {
 		return ErrInvalidEmptyName
 	}


### PR DESCRIPTION
This PR starts using `EatDots` from `schema`. This is part of our overall dot munging effort.

See also: #1008, graphite-ng/carbon-relay-ng#296, raintank/schema#34