### PR TITLE
prevent dereference of nil when querying meta tag records on query node

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1342,6 +1342,10 @@ func (s *Server) showPlan(ctx *middleware.Context, request models.GraphiteRender
 }
 
 func (s *Server) getMetaTagRecords(ctx *middleware.Context) {
+	if s.MetricIndex == nil {
+		response.Write(ctx, response.NewJson(200, []tagquery.MetaTagRecord{}, ""))
+		return
+	}
 	metaTagRecords := s.MetricIndex.MetaTagRecordList(ctx.OrgId)
 	response.Write(ctx, response.NewJson(200, metaTagRecords, ""))
 }


### PR DESCRIPTION
When the list of meta tag records gets requested on a query node, we need to make sure that we don't try to de-reference the MetricIndex because it is `nil`.