### PR TITLE
Batch update meta records

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1450,7 +1450,7 @@ func (s *Server) metaTagRecordSwap(ctx *middleware.Context, swapRequest models.M
 			return
 		}
 	} else if !swapRequest.Propagate {
-		response.Write(ctx, response.NewJson(200, nil, ""))
+		response.Write(ctx, response.NewJson(200, models.MetaTagRecordSwapResult{}, ""))
 		return
 	}
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1421,3 +1421,76 @@ func (s *Server) metaTagRecordUpsert(ctx *middleware.Context, upsertRequest mode
 		response.Write(ctx, response.NewJson(200, res, ""))
 	}
 }
+
+func (s *Server) metaTagRecordSwap(ctx *middleware.Context, swapRequest models.MetaTagRecordSwap) {
+	metaTagRecords := make([]tagquery.MetaTagRecord, len(swapRequest.Records))
+	for i, rawRecord := range swapRequest.Records {
+		var err error
+		metaTagRecords[i], err = tagquery.ParseMetaTagRecord(rawRecord.MetaTags, rawRecord.Expressions)
+		if err != nil {
+			response.Write(ctx, response.WrapError(fmt.Errorf("Error when parsing record %d: %s", i, err)))
+			return
+		}
+	}
+
+	var added, deleted uint32
+	if s.MetricIndex != nil {
+		var err error
+		added, deleted, err = s.MetricIndex.MetaTagRecordSwap(ctx.OrgId, metaTagRecords)
+		if err != nil {
+			response.Write(ctx, response.WrapError(err))
+			return
+		}
+
+		if !swapRequest.Propagate {
+			response.Write(ctx, response.NewJson(200, models.MetaTagRecordSwapResult{
+				Added:   added,
+				Deleted: deleted,
+			}, ""))
+			return
+		}
+	} else if !swapRequest.Propagate {
+		response.Write(ctx, response.NewJson(200, nil, ""))
+		return
+	}
+
+	res := models.MetaTagRecordSwapResultByNode{
+		Local: models.MetaTagRecordSwapResult{
+			Added:   added,
+			Deleted: deleted,
+		},
+	}
+
+	indexSwapRequest := models.IndexMetaTagRecordSwap{
+		OrgId:   ctx.OrgId,
+		Records: swapRequest.Records,
+	}
+
+	results, errors := s.peerQuery(ctx.Req.Context(), indexSwapRequest, "metaTagRecordSwap", "/index/metaTags/swap")
+
+	if len(errors) > 0 {
+		res.PeerErrors = make(map[string]string, len(errors))
+		for peer, err := range errors {
+			res.PeerErrors[peer] = err.Error()
+		}
+	}
+
+	if len(results) > 0 {
+		res.PeerResults = make(map[string]models.MetaTagRecordSwapResult, len(results))
+		for peer, resp := range results {
+			peerResp := models.MetaTagRecordSwapResult{}
+			_, err := peerResp.UnmarshalMsg(resp.buf)
+			if err != nil {
+				res.PeerErrors[peer] = fmt.Sprintf("Error when unmarshaling response: %s", err.Error())
+				continue
+			}
+			res.PeerResults[peer] = peerResp
+		}
+	}
+
+	if len(errors) > 0 {
+		response.Write(ctx, response.NewJson(500, res, ""))
+	} else {
+		response.Write(ctx, response.NewJson(200, res, ""))
+	}
+}

--- a/api/models/meta_records.go
+++ b/api/models/meta_records.go
@@ -7,6 +7,8 @@ import (
 	traceLog "github.com/opentracing/opentracing-go/log"
 )
 
+//go:generate msgp
+
 type MetaTagRecordUpsert struct {
 	MetaTags    []string `json:"metaTags" binding:"Required"`
 	Expressions []string `json:"expressions" binding:"Required"`
@@ -30,7 +32,6 @@ type MetaTagRecordUpsertResultByNode struct {
 	PeerErrors  map[string]string                    `json:"peerErrors"`
 }
 
-//go:generate msgp
 type MetaTagRecordUpsertResult struct {
 	MetaTags []string `json:"metaTags"`
 	Queries  []string `json:"queries"`
@@ -52,4 +53,51 @@ func (m IndexMetaTagRecordUpsert) Trace(span opentracing.Span) {
 }
 
 func (m IndexMetaTagRecordUpsert) TraceDebug(span opentracing.Span) {
+}
+
+type MetaTagRecordSwap struct {
+	Records   []MetaTagRecord `json:"records"`
+	Propagate bool            `json:"propagate"`
+}
+
+type MetaTagRecord struct {
+	MetaTags    []string `json:"metaTags" binding:"Required"`
+	Expressions []string `json:"expressions" binding:"Required"`
+}
+
+func (m MetaTagRecordSwap) Trace(span opentracing.Span) {
+	span.LogFields(
+		traceLog.String("recordCount", string(len(m.Records))),
+		traceLog.Bool("propagate", m.Propagate),
+	)
+}
+
+func (m MetaTagRecordSwap) TraceDebug(span opentracing.Span) {
+}
+
+type MetaTagRecordSwapResultByNode struct {
+	Local       MetaTagRecordSwapResult            `json:"local"`
+	PeerResults map[string]MetaTagRecordSwapResult `json:"peerResults"`
+	PeerErrors  map[string]string                  `json:"peerErrors"`
+}
+
+type MetaTagRecordSwapResult struct {
+	Deleted uint32 `json:"deleted"`
+	Added   uint32 `json:"added"`
+}
+
+type IndexMetaTagRecordSwap struct {
+	OrgId     uint32          `json:"orgId" binding:"Required"`
+	Records   []MetaTagRecord `json:"records"`
+	Propagate bool            `json:"propagate"`
+}
+
+func (m IndexMetaTagRecordSwap) Trace(span opentracing.Span) {
+	span.SetTag("orgId", m.OrgId)
+	span.LogFields(
+		traceLog.String("recordCount", string(len(m.Records))),
+	)
+}
+
+func (m IndexMetaTagRecordSwap) TraceDebug(span opentracing.Span) {
 }

--- a/api/models/meta_records.go
+++ b/api/models/meta_records.go
@@ -67,7 +67,7 @@ type MetaTagRecord struct {
 
 func (m MetaTagRecordSwap) Trace(span opentracing.Span) {
 	span.LogFields(
-		traceLog.String("recordCount", string(len(m.Records))),
+		traceLog.Uint32("recordCount", uint32(len(m.Records))),
 		traceLog.Bool("propagate", m.Propagate),
 	)
 }
@@ -87,15 +87,14 @@ type MetaTagRecordSwapResult struct {
 }
 
 type IndexMetaTagRecordSwap struct {
-	OrgId     uint32          `json:"orgId" binding:"Required"`
-	Records   []MetaTagRecord `json:"records"`
-	Propagate bool            `json:"propagate"`
+	OrgId   uint32          `json:"orgId" binding:"Required"`
+	Records []MetaTagRecord `json:"records"`
 }
 
 func (m IndexMetaTagRecordSwap) Trace(span opentracing.Span) {
 	span.SetTag("orgId", m.OrgId)
 	span.LogFields(
-		traceLog.String("recordCount", string(len(m.Records))),
+		traceLog.Uint32("recordCount", uint32(len(m.Records))),
 	)
 }
 

--- a/api/models/meta_records_gen.go
+++ b/api/models/meta_records_gen.go
@@ -7,6 +7,203 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *IndexMetaTagRecordSwap) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "OrgId":
+			z.OrgId, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "OrgId")
+				return
+			}
+		case "Records":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Records")
+				return
+			}
+			if cap(z.Records) >= int(zb0002) {
+				z.Records = (z.Records)[:zb0002]
+			} else {
+				z.Records = make([]MetaTagRecord, zb0002)
+			}
+			for za0001 := range z.Records {
+				err = z.Records[za0001].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Records", za0001)
+					return
+				}
+			}
+		case "Propagate":
+			z.Propagate, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "Propagate")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IndexMetaTagRecordSwap) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 3
+	// write "OrgId"
+	err = en.Append(0x83, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.OrgId)
+	if err != nil {
+		err = msgp.WrapError(err, "OrgId")
+		return
+	}
+	// write "Records"
+	err = en.Append(0xa7, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Records)))
+	if err != nil {
+		err = msgp.WrapError(err, "Records")
+		return
+	}
+	for za0001 := range z.Records {
+		err = z.Records[za0001].EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Records", za0001)
+			return
+		}
+	}
+	// write "Propagate"
+	err = en.Append(0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.Propagate)
+	if err != nil {
+		err = msgp.WrapError(err, "Propagate")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IndexMetaTagRecordSwap) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "OrgId"
+	o = append(o, 0x83, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
+	o = msgp.AppendUint32(o, z.OrgId)
+	// string "Records"
+	o = append(o, 0xa7, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Records)))
+	for za0001 := range z.Records {
+		o, err = z.Records[za0001].MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Records", za0001)
+			return
+		}
+	}
+	// string "Propagate"
+	o = append(o, 0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
+	o = msgp.AppendBool(o, z.Propagate)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexMetaTagRecordSwap) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "OrgId":
+			z.OrgId, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "OrgId")
+				return
+			}
+		case "Records":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Records")
+				return
+			}
+			if cap(z.Records) >= int(zb0002) {
+				z.Records = (z.Records)[:zb0002]
+			} else {
+				z.Records = make([]MetaTagRecord, zb0002)
+			}
+			for za0001 := range z.Records {
+				bts, err = z.Records[za0001].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Records", za0001)
+					return
+				}
+			}
+		case "Propagate":
+			z.Propagate, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Propagate")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *IndexMetaTagRecordSwap) Msgsize() (s int) {
+	s = 1 + 6 + msgp.Uint32Size + 8 + msgp.ArrayHeaderSize
+	for za0001 := range z.Records {
+		s += z.Records[za0001].Msgsize()
+	}
+	s += 10 + msgp.BoolSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *IndexMetaTagRecordUpsert) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -234,6 +431,962 @@ func (z *IndexMetaTagRecordUpsert) Msgsize() (s int) {
 	s += 8 + msgp.ArrayHeaderSize
 	for za0002 := range z.Queries {
 		s += msgp.StringPrefixSize + len(z.Queries[za0002])
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *MetaTagRecord) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "MetaTags":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "MetaTags")
+				return
+			}
+			if cap(z.MetaTags) >= int(zb0002) {
+				z.MetaTags = (z.MetaTags)[:zb0002]
+			} else {
+				z.MetaTags = make([]string, zb0002)
+			}
+			for za0001 := range z.MetaTags {
+				z.MetaTags[za0001], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "MetaTags", za0001)
+					return
+				}
+			}
+		case "Expressions":
+			var zb0003 uint32
+			zb0003, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Expressions")
+				return
+			}
+			if cap(z.Expressions) >= int(zb0003) {
+				z.Expressions = (z.Expressions)[:zb0003]
+			} else {
+				z.Expressions = make([]string, zb0003)
+			}
+			for za0002 := range z.Expressions {
+				z.Expressions[za0002], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Expressions", za0002)
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *MetaTagRecord) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "MetaTags"
+	err = en.Append(0x82, 0xa8, 0x4d, 0x65, 0x74, 0x61, 0x54, 0x61, 0x67, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.MetaTags)))
+	if err != nil {
+		err = msgp.WrapError(err, "MetaTags")
+		return
+	}
+	for za0001 := range z.MetaTags {
+		err = en.WriteString(z.MetaTags[za0001])
+		if err != nil {
+			err = msgp.WrapError(err, "MetaTags", za0001)
+			return
+		}
+	}
+	// write "Expressions"
+	err = en.Append(0xab, 0x45, 0x78, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Expressions)))
+	if err != nil {
+		err = msgp.WrapError(err, "Expressions")
+		return
+	}
+	for za0002 := range z.Expressions {
+		err = en.WriteString(z.Expressions[za0002])
+		if err != nil {
+			err = msgp.WrapError(err, "Expressions", za0002)
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *MetaTagRecord) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "MetaTags"
+	o = append(o, 0x82, 0xa8, 0x4d, 0x65, 0x74, 0x61, 0x54, 0x61, 0x67, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.MetaTags)))
+	for za0001 := range z.MetaTags {
+		o = msgp.AppendString(o, z.MetaTags[za0001])
+	}
+	// string "Expressions"
+	o = append(o, 0xab, 0x45, 0x78, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Expressions)))
+	for za0002 := range z.Expressions {
+		o = msgp.AppendString(o, z.Expressions[za0002])
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MetaTagRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "MetaTags":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MetaTags")
+				return
+			}
+			if cap(z.MetaTags) >= int(zb0002) {
+				z.MetaTags = (z.MetaTags)[:zb0002]
+			} else {
+				z.MetaTags = make([]string, zb0002)
+			}
+			for za0001 := range z.MetaTags {
+				z.MetaTags[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "MetaTags", za0001)
+					return
+				}
+			}
+		case "Expressions":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Expressions")
+				return
+			}
+			if cap(z.Expressions) >= int(zb0003) {
+				z.Expressions = (z.Expressions)[:zb0003]
+			} else {
+				z.Expressions = make([]string, zb0003)
+			}
+			for za0002 := range z.Expressions {
+				z.Expressions[za0002], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Expressions", za0002)
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *MetaTagRecord) Msgsize() (s int) {
+	s = 1 + 9 + msgp.ArrayHeaderSize
+	for za0001 := range z.MetaTags {
+		s += msgp.StringPrefixSize + len(z.MetaTags[za0001])
+	}
+	s += 12 + msgp.ArrayHeaderSize
+	for za0002 := range z.Expressions {
+		s += msgp.StringPrefixSize + len(z.Expressions[za0002])
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *MetaTagRecordSwap) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Records":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Records")
+				return
+			}
+			if cap(z.Records) >= int(zb0002) {
+				z.Records = (z.Records)[:zb0002]
+			} else {
+				z.Records = make([]MetaTagRecord, zb0002)
+			}
+			for za0001 := range z.Records {
+				err = z.Records[za0001].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Records", za0001)
+					return
+				}
+			}
+		case "Propagate":
+			z.Propagate, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "Propagate")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *MetaTagRecordSwap) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Records"
+	err = en.Append(0x82, 0xa7, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Records)))
+	if err != nil {
+		err = msgp.WrapError(err, "Records")
+		return
+	}
+	for za0001 := range z.Records {
+		err = z.Records[za0001].EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Records", za0001)
+			return
+		}
+	}
+	// write "Propagate"
+	err = en.Append(0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.Propagate)
+	if err != nil {
+		err = msgp.WrapError(err, "Propagate")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *MetaTagRecordSwap) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Records"
+	o = append(o, 0x82, 0xa7, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Records)))
+	for za0001 := range z.Records {
+		o, err = z.Records[za0001].MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Records", za0001)
+			return
+		}
+	}
+	// string "Propagate"
+	o = append(o, 0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
+	o = msgp.AppendBool(o, z.Propagate)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MetaTagRecordSwap) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Records":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Records")
+				return
+			}
+			if cap(z.Records) >= int(zb0002) {
+				z.Records = (z.Records)[:zb0002]
+			} else {
+				z.Records = make([]MetaTagRecord, zb0002)
+			}
+			for za0001 := range z.Records {
+				bts, err = z.Records[za0001].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Records", za0001)
+					return
+				}
+			}
+		case "Propagate":
+			z.Propagate, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Propagate")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *MetaTagRecordSwap) Msgsize() (s int) {
+	s = 1 + 8 + msgp.ArrayHeaderSize
+	for za0001 := range z.Records {
+		s += z.Records[za0001].Msgsize()
+	}
+	s += 10 + msgp.BoolSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *MetaTagRecordSwapResult) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Deleted":
+			z.Deleted, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "Deleted")
+				return
+			}
+		case "Added":
+			z.Added, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "Added")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z MetaTagRecordSwapResult) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Deleted"
+	err = en.Append(0x82, 0xa7, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.Deleted)
+	if err != nil {
+		err = msgp.WrapError(err, "Deleted")
+		return
+	}
+	// write "Added"
+	err = en.Append(0xa5, 0x41, 0x64, 0x64, 0x65, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.Added)
+	if err != nil {
+		err = msgp.WrapError(err, "Added")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z MetaTagRecordSwapResult) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Deleted"
+	o = append(o, 0x82, 0xa7, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64)
+	o = msgp.AppendUint32(o, z.Deleted)
+	// string "Added"
+	o = append(o, 0xa5, 0x41, 0x64, 0x64, 0x65, 0x64)
+	o = msgp.AppendUint32(o, z.Added)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MetaTagRecordSwapResult) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Deleted":
+			z.Deleted, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Deleted")
+				return
+			}
+		case "Added":
+			z.Added, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Added")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z MetaTagRecordSwapResult) Msgsize() (s int) {
+	s = 1 + 8 + msgp.Uint32Size + 6 + msgp.Uint32Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *MetaTagRecordSwapResultByNode) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Local":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Local")
+				return
+			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Local")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Deleted":
+					z.Local.Deleted, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Local", "Deleted")
+						return
+					}
+				case "Added":
+					z.Local.Added, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Local", "Added")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Local")
+						return
+					}
+				}
+			}
+		case "PeerResults":
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "PeerResults")
+				return
+			}
+			if z.PeerResults == nil {
+				z.PeerResults = make(map[string]MetaTagRecordSwapResult, zb0003)
+			} else if len(z.PeerResults) > 0 {
+				for key := range z.PeerResults {
+					delete(z.PeerResults, key)
+				}
+			}
+			for zb0003 > 0 {
+				zb0003--
+				var za0001 string
+				var za0002 MetaTagRecordSwapResult
+				za0001, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "PeerResults")
+					return
+				}
+				var zb0004 uint32
+				zb0004, err = dc.ReadMapHeader()
+				if err != nil {
+					err = msgp.WrapError(err, "PeerResults", za0001)
+					return
+				}
+				for zb0004 > 0 {
+					zb0004--
+					field, err = dc.ReadMapKeyPtr()
+					if err != nil {
+						err = msgp.WrapError(err, "PeerResults", za0001)
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "Deleted":
+						za0002.Deleted, err = dc.ReadUint32()
+						if err != nil {
+							err = msgp.WrapError(err, "PeerResults", za0001, "Deleted")
+							return
+						}
+					case "Added":
+						za0002.Added, err = dc.ReadUint32()
+						if err != nil {
+							err = msgp.WrapError(err, "PeerResults", za0001, "Added")
+							return
+						}
+					default:
+						err = dc.Skip()
+						if err != nil {
+							err = msgp.WrapError(err, "PeerResults", za0001)
+							return
+						}
+					}
+				}
+				z.PeerResults[za0001] = za0002
+			}
+		case "PeerErrors":
+			var zb0005 uint32
+			zb0005, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "PeerErrors")
+				return
+			}
+			if z.PeerErrors == nil {
+				z.PeerErrors = make(map[string]string, zb0005)
+			} else if len(z.PeerErrors) > 0 {
+				for key := range z.PeerErrors {
+					delete(z.PeerErrors, key)
+				}
+			}
+			for zb0005 > 0 {
+				zb0005--
+				var za0003 string
+				var za0004 string
+				za0003, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "PeerErrors")
+					return
+				}
+				za0004, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "PeerErrors", za0003)
+					return
+				}
+				z.PeerErrors[za0003] = za0004
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *MetaTagRecordSwapResultByNode) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 3
+	// write "Local"
+	// map header, size 2
+	// write "Deleted"
+	err = en.Append(0x83, 0xa5, 0x4c, 0x6f, 0x63, 0x61, 0x6c, 0x82, 0xa7, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.Local.Deleted)
+	if err != nil {
+		err = msgp.WrapError(err, "Local", "Deleted")
+		return
+	}
+	// write "Added"
+	err = en.Append(0xa5, 0x41, 0x64, 0x64, 0x65, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.Local.Added)
+	if err != nil {
+		err = msgp.WrapError(err, "Local", "Added")
+		return
+	}
+	// write "PeerResults"
+	err = en.Append(0xab, 0x50, 0x65, 0x65, 0x72, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteMapHeader(uint32(len(z.PeerResults)))
+	if err != nil {
+		err = msgp.WrapError(err, "PeerResults")
+		return
+	}
+	for za0001, za0002 := range z.PeerResults {
+		err = en.WriteString(za0001)
+		if err != nil {
+			err = msgp.WrapError(err, "PeerResults")
+			return
+		}
+		// map header, size 2
+		// write "Deleted"
+		err = en.Append(0x82, 0xa7, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64)
+		if err != nil {
+			return
+		}
+		err = en.WriteUint32(za0002.Deleted)
+		if err != nil {
+			err = msgp.WrapError(err, "PeerResults", za0001, "Deleted")
+			return
+		}
+		// write "Added"
+		err = en.Append(0xa5, 0x41, 0x64, 0x64, 0x65, 0x64)
+		if err != nil {
+			return
+		}
+		err = en.WriteUint32(za0002.Added)
+		if err != nil {
+			err = msgp.WrapError(err, "PeerResults", za0001, "Added")
+			return
+		}
+	}
+	// write "PeerErrors"
+	err = en.Append(0xaa, 0x50, 0x65, 0x65, 0x72, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteMapHeader(uint32(len(z.PeerErrors)))
+	if err != nil {
+		err = msgp.WrapError(err, "PeerErrors")
+		return
+	}
+	for za0003, za0004 := range z.PeerErrors {
+		err = en.WriteString(za0003)
+		if err != nil {
+			err = msgp.WrapError(err, "PeerErrors")
+			return
+		}
+		err = en.WriteString(za0004)
+		if err != nil {
+			err = msgp.WrapError(err, "PeerErrors", za0003)
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *MetaTagRecordSwapResultByNode) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "Local"
+	// map header, size 2
+	// string "Deleted"
+	o = append(o, 0x83, 0xa5, 0x4c, 0x6f, 0x63, 0x61, 0x6c, 0x82, 0xa7, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64)
+	o = msgp.AppendUint32(o, z.Local.Deleted)
+	// string "Added"
+	o = append(o, 0xa5, 0x41, 0x64, 0x64, 0x65, 0x64)
+	o = msgp.AppendUint32(o, z.Local.Added)
+	// string "PeerResults"
+	o = append(o, 0xab, 0x50, 0x65, 0x65, 0x72, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.PeerResults)))
+	for za0001, za0002 := range z.PeerResults {
+		o = msgp.AppendString(o, za0001)
+		// map header, size 2
+		// string "Deleted"
+		o = append(o, 0x82, 0xa7, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x64)
+		o = msgp.AppendUint32(o, za0002.Deleted)
+		// string "Added"
+		o = append(o, 0xa5, 0x41, 0x64, 0x64, 0x65, 0x64)
+		o = msgp.AppendUint32(o, za0002.Added)
+	}
+	// string "PeerErrors"
+	o = append(o, 0xaa, 0x50, 0x65, 0x65, 0x72, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.PeerErrors)))
+	for za0003, za0004 := range z.PeerErrors {
+		o = msgp.AppendString(o, za0003)
+		o = msgp.AppendString(o, za0004)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MetaTagRecordSwapResultByNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Local":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Local")
+				return
+			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Local")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Deleted":
+					z.Local.Deleted, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Local", "Deleted")
+						return
+					}
+				case "Added":
+					z.Local.Added, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Local", "Added")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Local")
+						return
+					}
+				}
+			}
+		case "PeerResults":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PeerResults")
+				return
+			}
+			if z.PeerResults == nil {
+				z.PeerResults = make(map[string]MetaTagRecordSwapResult, zb0003)
+			} else if len(z.PeerResults) > 0 {
+				for key := range z.PeerResults {
+					delete(z.PeerResults, key)
+				}
+			}
+			for zb0003 > 0 {
+				var za0001 string
+				var za0002 MetaTagRecordSwapResult
+				zb0003--
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PeerResults")
+					return
+				}
+				var zb0004 uint32
+				zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PeerResults", za0001)
+					return
+				}
+				for zb0004 > 0 {
+					zb0004--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PeerResults", za0001)
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "Deleted":
+						za0002.Deleted, bts, err = msgp.ReadUint32Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "PeerResults", za0001, "Deleted")
+							return
+						}
+					case "Added":
+						za0002.Added, bts, err = msgp.ReadUint32Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "PeerResults", za0001, "Added")
+							return
+						}
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "PeerResults", za0001)
+							return
+						}
+					}
+				}
+				z.PeerResults[za0001] = za0002
+			}
+		case "PeerErrors":
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PeerErrors")
+				return
+			}
+			if z.PeerErrors == nil {
+				z.PeerErrors = make(map[string]string, zb0005)
+			} else if len(z.PeerErrors) > 0 {
+				for key := range z.PeerErrors {
+					delete(z.PeerErrors, key)
+				}
+			}
+			for zb0005 > 0 {
+				var za0003 string
+				var za0004 string
+				zb0005--
+				za0003, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PeerErrors")
+					return
+				}
+				za0004, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PeerErrors", za0003)
+					return
+				}
+				z.PeerErrors[za0003] = za0004
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *MetaTagRecordSwapResultByNode) Msgsize() (s int) {
+	s = 1 + 6 + 1 + 8 + msgp.Uint32Size + 6 + msgp.Uint32Size + 12 + msgp.MapHeaderSize
+	if z.PeerResults != nil {
+		for za0001, za0002 := range z.PeerResults {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + 1 + 8 + msgp.Uint32Size + 6 + msgp.Uint32Size
+		}
+	}
+	s += 11 + msgp.MapHeaderSize
+	if z.PeerErrors != nil {
+		for za0003, za0004 := range z.PeerErrors {
+			_ = za0004
+			s += msgp.StringPrefixSize + len(za0003) + msgp.StringPrefixSize + len(za0004)
+		}
 	}
 	return
 }

--- a/api/models/meta_records_gen.go
+++ b/api/models/meta_records_gen.go
@@ -49,12 +49,6 @@ func (z *IndexMetaTagRecordSwap) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-		case "Propagate":
-			z.Propagate, err = dc.ReadBool()
-			if err != nil {
-				err = msgp.WrapError(err, "Propagate")
-				return
-			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -68,9 +62,9 @@ func (z *IndexMetaTagRecordSwap) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *IndexMetaTagRecordSwap) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 3
+	// map header, size 2
 	// write "OrgId"
-	err = en.Append(0x83, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
+	err = en.Append(0x82, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
 	if err != nil {
 		return
 	}
@@ -96,25 +90,15 @@ func (z *IndexMetaTagRecordSwap) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	}
-	// write "Propagate"
-	err = en.Append(0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
-	if err != nil {
-		return
-	}
-	err = en.WriteBool(z.Propagate)
-	if err != nil {
-		err = msgp.WrapError(err, "Propagate")
-		return
-	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *IndexMetaTagRecordSwap) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 3
+	// map header, size 2
 	// string "OrgId"
-	o = append(o, 0x83, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
+	o = append(o, 0x82, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
 	o = msgp.AppendUint32(o, z.OrgId)
 	// string "Records"
 	o = append(o, 0xa7, 0x52, 0x65, 0x63, 0x6f, 0x72, 0x64, 0x73)
@@ -126,9 +110,6 @@ func (z *IndexMetaTagRecordSwap) MarshalMsg(b []byte) (o []byte, err error) {
 			return
 		}
 	}
-	// string "Propagate"
-	o = append(o, 0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
-	o = msgp.AppendBool(o, z.Propagate)
 	return
 }
 
@@ -175,12 +156,6 @@ func (z *IndexMetaTagRecordSwap) UnmarshalMsg(bts []byte) (o []byte, err error) 
 					return
 				}
 			}
-		case "Propagate":
-			z.Propagate, bts, err = msgp.ReadBoolBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Propagate")
-				return
-			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -199,7 +174,6 @@ func (z *IndexMetaTagRecordSwap) Msgsize() (s int) {
 	for za0001 := range z.Records {
 		s += z.Records[za0001].Msgsize()
 	}
-	s += 10 + msgp.BoolSize
 	return
 }
 

--- a/api/models/meta_records_gen_test.go
+++ b/api/models/meta_records_gen_test.go
@@ -9,6 +9,119 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+func TestMarshalUnmarshalIndexMetaTagRecordSwap(t *testing.T) {
+	v := IndexMetaTagRecordSwap{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexMetaTagRecordSwap(b *testing.B) {
+	v := IndexMetaTagRecordSwap{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexMetaTagRecordSwap(b *testing.B) {
+	v := IndexMetaTagRecordSwap{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexMetaTagRecordSwap(b *testing.B) {
+	v := IndexMetaTagRecordSwap{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexMetaTagRecordSwap(t *testing.T) {
+	v := IndexMetaTagRecordSwap{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexMetaTagRecordSwap{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexMetaTagRecordSwap(b *testing.B) {
+	v := IndexMetaTagRecordSwap{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexMetaTagRecordSwap(b *testing.B) {
+	v := IndexMetaTagRecordSwap{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalIndexMetaTagRecordUpsert(t *testing.T) {
 	v := IndexMetaTagRecordUpsert{}
 	bts, err := v.MarshalMsg(nil)
@@ -107,6 +220,458 @@ func BenchmarkEncodeIndexMetaTagRecordUpsert(b *testing.B) {
 
 func BenchmarkDecodeIndexMetaTagRecordUpsert(b *testing.B) {
 	v := IndexMetaTagRecordUpsert{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalMetaTagRecord(t *testing.T) {
+	v := MetaTagRecord{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgMetaTagRecord(b *testing.B) {
+	v := MetaTagRecord{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgMetaTagRecord(b *testing.B) {
+	v := MetaTagRecord{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalMetaTagRecord(b *testing.B) {
+	v := MetaTagRecord{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeMetaTagRecord(t *testing.T) {
+	v := MetaTagRecord{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := MetaTagRecord{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeMetaTagRecord(b *testing.B) {
+	v := MetaTagRecord{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeMetaTagRecord(b *testing.B) {
+	v := MetaTagRecord{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalMetaTagRecordSwap(t *testing.T) {
+	v := MetaTagRecordSwap{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgMetaTagRecordSwap(b *testing.B) {
+	v := MetaTagRecordSwap{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgMetaTagRecordSwap(b *testing.B) {
+	v := MetaTagRecordSwap{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalMetaTagRecordSwap(b *testing.B) {
+	v := MetaTagRecordSwap{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeMetaTagRecordSwap(t *testing.T) {
+	v := MetaTagRecordSwap{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := MetaTagRecordSwap{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeMetaTagRecordSwap(b *testing.B) {
+	v := MetaTagRecordSwap{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeMetaTagRecordSwap(b *testing.B) {
+	v := MetaTagRecordSwap{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalMetaTagRecordSwapResult(t *testing.T) {
+	v := MetaTagRecordSwapResult{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgMetaTagRecordSwapResult(b *testing.B) {
+	v := MetaTagRecordSwapResult{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgMetaTagRecordSwapResult(b *testing.B) {
+	v := MetaTagRecordSwapResult{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalMetaTagRecordSwapResult(b *testing.B) {
+	v := MetaTagRecordSwapResult{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeMetaTagRecordSwapResult(t *testing.T) {
+	v := MetaTagRecordSwapResult{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := MetaTagRecordSwapResult{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeMetaTagRecordSwapResult(b *testing.B) {
+	v := MetaTagRecordSwapResult{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeMetaTagRecordSwapResult(b *testing.B) {
+	v := MetaTagRecordSwapResult{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalMetaTagRecordSwapResultByNode(t *testing.T) {
+	v := MetaTagRecordSwapResultByNode{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgMetaTagRecordSwapResultByNode(b *testing.B) {
+	v := MetaTagRecordSwapResultByNode{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgMetaTagRecordSwapResultByNode(b *testing.B) {
+	v := MetaTagRecordSwapResultByNode{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalMetaTagRecordSwapResultByNode(b *testing.B) {
+	v := MetaTagRecordSwapResultByNode{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeMetaTagRecordSwapResultByNode(t *testing.T) {
+	v := MetaTagRecordSwapResultByNode{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := MetaTagRecordSwapResultByNode{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeMetaTagRecordSwapResultByNode(b *testing.B) {
+	v := MetaTagRecordSwapResultByNode{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeMetaTagRecordSwapResultByNode(b *testing.B) {
+	v := MetaTagRecordSwapResultByNode{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/api/routes.go
+++ b/api/routes.go
@@ -49,6 +49,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/tags/autoComplete/values", ready, bind(models.IndexAutoCompleteTagValues{})).Get(s.indexAutoCompleteTagValues).Post(s.indexAutoCompleteTagValues)
 	r.Combo("/index/tags/delSeries", ready, bind(models.IndexTagDelSeries{})).Get(s.indexTagDelSeries).Post(s.indexTagDelSeries)
 	r.Combo("/index/metaTags/upsert", ready, bind(models.IndexMetaTagRecordUpsert{})).Get(s.indexMetaTagRecordUpsert).Post(s.indexMetaTagRecordUpsert)
+	r.Combo("/index/metaTags/swap", ready, bind(models.IndexMetaTagRecordSwap{})).Get(s.indexMetaTagRecordSwap).Post(s.indexMetaTagRecordSwap)
 
 	r.Combo("/ccache/delete", bind(models.CCacheDelete{})).Post(s.ccacheDelete).Get(s.ccacheDelete)
 
@@ -74,6 +75,7 @@ func (s *Server) RegisterRoutes() {
 
 	// Meta Tags
 	r.Post("/metaTags/upsert", withOrg, ready, bind(models.MetaTagRecordUpsert{}), s.metaTagRecordUpsert)
+	r.Post("/metaTags/swap", withOrg, ready, bind(models.MetaTagRecordSwap{}), s.metaTagRecordSwap)
 	r.Get("/metaTags", withOrg, ready, s.getMetaTagRecords)
 
 	// Prometheus endpoints

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -292,9 +292,9 @@ mst@mst-nb1:~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags | jq
 POST /metaTags/swap
 ```
 
-This route is an alternative to the above "upsert". It accepts a list of meta tag records and
-replaces all existing records with the new ones. This is useful for users who
-first generate all of their meta tag records and then want to simply replace all the records in 
+This route is an alternative to the above "upsert". It accepts a list of meta tag records
+and replaces all existing records with the new ones. This is useful for users who first
+generate all of their meta tag records and then want to simply replace all the records in
 Metrictank with the generated ones.
 
 ## Example

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -286,6 +286,48 @@ mst@mst-nb1:~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags | jq
 []
 ```
 
+## Batch updating all Meta Records
+
+```
+POST /metaTags/swap
+```
+
+This route is an alternative to the above "upsert". It accepts a list of meta records and
+replaces all currently present records with the given ones. This is useful for users who
+first generate all their meta records and then want to simply replace all the records in 
+metrictank with the generated ones.
+
+## Example
+
+```
+~$ curl -s -H 'X-Org-Id: 1' 'http://localhost:6070/metaTags/swap' -H 'Content-Type: application/json' -d '{"propagate": true, "records":[{"metaTags": ["meta=tag"], "expressions": ["name=~.*[2-7]$"]}]}' | jq
+{
+  "local": {
+    "deleted": 0,
+    "added": 0
+  },
+  "peerResults": {
+    "metrictank0": {
+      "deleted": 0,
+      "added": 1
+    },
+    "metrictank1": {
+      "deleted": 0,
+      "added": 1
+    },
+    "metrictank2": {
+      "deleted": 0,
+      "added": 1
+    },
+    "metrictank3": {
+      "deleted": 0,
+      "added": 1
+    }
+  },
+  "peerErrors": null
+}
+```
+
 ## Misc
 
 ### Tspec

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -286,16 +286,16 @@ mst@mst-nb1:~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags | jq
 []
 ```
 
-## Batch updating all Meta Records
+## Batch updating all Meta Tag Records
 
 ```
 POST /metaTags/swap
 ```
 
-This route is an alternative to the above "upsert". It accepts a list of meta records and
-replaces all currently present records with the given ones. This is useful for users who
-first generate all their meta records and then want to simply replace all the records in 
-metrictank with the generated ones.
+This route is an alternative to the above "upsert". It accepts a list of meta tag records and
+replaces all existing records with the new ones. This is useful for users who
+first generate all of their meta tag records and then want to simply replace all the records in 
+Metrictank with the generated ones.
 
 ## Example
 

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -162,5 +162,8 @@ type MetricIndex interface {
 	// of that given org.
 	MetaTagRecordList(orgId uint32) []tagquery.MetaTagRecord
 
+	// MetaTagRecordSwap takes a set of meta tag records and completely replaces
+	// the current ones with the new given ones.
+	// It returns how many records have been added, deleted and potential errors
 	MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -163,7 +163,7 @@ type MetricIndex interface {
 	MetaTagRecordList(orgId uint32) []tagquery.MetaTagRecord
 
 	// MetaTagRecordSwap takes a set of meta tag records and completely replaces
-	// the current ones with the new given ones.
+	// the existing ones with the new ones.
 	// It returns how many records have been added, deleted and potential errors
 	MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error)
 }

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -161,4 +161,6 @@ type MetricIndex interface {
 	// MetaTagRecordList takes an org id and returns the list of all meta tag records
 	// of that given org.
 	MetaTagRecordList(orgId uint32) []tagquery.MetaTagRecord
+
+	MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error)
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"flag"
 	"fmt"
+	"math/rand"
 	"os"
 	"regexp"
 	"sort"
@@ -507,6 +508,10 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 	}
 
 	return res, true, nil
+}
+
+func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error) {
+	return rand.Uint32(), rand.Uint32(), nil
 }
 
 func (m *UnpartitionedMemoryIdx) MetaTagRecordList(orgId uint32) []tagquery.MetaTagRecord {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -460,9 +460,9 @@ func (m *UnpartitionedMemoryIdx) UpdateArchiveLastSave(id schema.MKey, partition
 func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord) (tagquery.MetaTagRecord, bool, error) {
 	res := tagquery.MetaTagRecord{}
 
-	if !TagSupport {
-		log.Warn("memory-idx: received meta-tag query, but tag support is disabled")
-		return res, false, errors.NewBadRequest("Tag support is disabled")
+	if !TagSupport || !metaTagSupport {
+		log.Warn("memory-idx: received tag/meta-tag query, but that feature is disabled")
+		return res, false, errors.NewBadRequest("Tag/Meta-Tag support is disabled")
 	}
 
 	var mtr *metaTagRecords
@@ -510,9 +510,9 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 }
 
 func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error) {
-	if !TagSupport {
-		log.Warn("memory-idx: received meta-tag query, but tag support is disabled")
-		return 0, 0, errors.NewBadRequest("Tag support is disabled")
+	if !TagSupport || !metaTagSupport {
+		log.Warn("memory-idx: received a tag/meta-tag query, but that feature is disabled")
+		return 0, 0, errors.NewBadRequest("Tag/Meta-Tag support is disabled")
 	}
 
 	newMtr := newMetaTagRecords()

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -535,8 +535,10 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagqu
 	m.Lock()
 	defer m.Unlock()
 
-	oldMti := m.metaTagIndex[orgId]
-	deletedRecords = uint32(len(oldMti))
+	oldMtr, ok := m.metaTagRecords[orgId]
+	if ok {
+		deletedRecords = uint32(len(oldMtr.records))
+	}
 
 	m.metaTagRecords[orgId] = newMtr
 	m.metaTagIndex[orgId] = newMti

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -350,9 +350,9 @@ func testTagDetailsWithFilter(t *testing.T) {
 }
 
 func TestTagDetailsWithMetaTagSupportWithoutFilter(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testTagDetailsWithMetaTagSupportWithoutFilter)(t)
 }
 
@@ -381,9 +381,9 @@ func testTagDetailsWithMetaTagSupportWithoutFilter(t *testing.T) {
 }
 
 func TestTagDetailsWithMetaTagSupportWithFilter(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testTagDetailsWithMetaTagSupportWithFilter)(t)
 }
 
@@ -458,9 +458,9 @@ func testTagKeysWithFilter(t *testing.T) {
 }
 
 func TestTagKeysWithMetaTagSupportWithFilter(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testTagKeysWithMetaTagSupportWithFilter)(t)
 }
 
@@ -490,9 +490,9 @@ func testTagKeysWithMetaTagSupportWithFilter(t *testing.T) {
 }
 
 func TestTagKeysWithMetaTagSupportWithoutFilters(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testTagKeysWithMetaTagSupportWithoutFilters)(t)
 }
 
@@ -621,9 +621,9 @@ func testAutoCompleteTags(t *testing.T) {
 }
 
 func TestAutoCompleteTagsWithMetaTagSupport(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testAutoCompleteTagsWithMetaTagSupport)(t)
 }
 
@@ -749,9 +749,9 @@ func testAutoCompleteTagsWithQuery(t *testing.T) {
 }
 
 func TestAutoCompleteTagsWithQueryWithMetaTagSupport(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testAutoCompleteTagsWithQueryWithMetaTagSupport)(t)
 }
 
@@ -861,9 +861,9 @@ func testAutoCompleteTagValues(t *testing.T) {
 }
 
 func TestAutoCompleteTagValuesWithMetaTagSupport(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testAutoCompleteTagValuesWithMetaTagSupport)(t)
 }
 
@@ -1008,9 +1008,9 @@ func testAutoCompleteTagValuesWithQuery(t *testing.T) {
 }
 
 func TestAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	withAndWithoutPartitonedIndex(testAutoCompleteTagValuesWithQueryWithMetaTagSupport)(t)
 }
 

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -191,13 +191,12 @@ func withAndWithoutPartitonedIndex(f func(*testing.T)) func(*testing.T) {
 func withAndWithoutMetaTagSupport(f func(*testing.T)) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
-		_metaTagSupport := tagquery.MetaTagSupport
-		defer func() { tagquery.MetaTagSupport = _metaTagSupport }()
+		reset := enableMetaTagSupport()
+		defer reset()
 
-		tagquery.MetaTagSupport = false
-		t.Run("withoutMetaTagSupport", f)
-		tagquery.MetaTagSupport = true
 		t.Run("withMetaTagSupport", f)
+		disableMetaTagSupport()
+		t.Run("withoutMetaTagSupport", f)
 	}
 }
 
@@ -1029,8 +1028,10 @@ func testSingleNodeMetric(t *testing.T) {
 	}
 	ix.AddOrUpdate(mkey, data, getPartition(data))
 }
-
 func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
+	reset := enableMetaTagSupport()
+	defer reset()
+
 	ix := NewUnpartitionedMemoryIdx()
 
 	record1, err := tagquery.ParseMetaTagRecord([]string{"a=b", "c=d"}, []string{"name=~a.+", "__tag^=a"})
@@ -1273,12 +1274,11 @@ func benchWithAndWithoutPartitonedIndex(f func(*testing.B)) func(*testing.B) {
 func benchWithAndWithoutMetaTagSupport(f func(*testing.B)) func(*testing.B) {
 	return func(b *testing.B) {
 		b.Helper()
-		_metaTagSupport := tagquery.MetaTagSupport
-		defer func() { tagquery.MetaTagSupport = _metaTagSupport }()
+		reset := enableMetaTagSupport()
+		defer reset()
 
-		tagquery.MetaTagSupport = true
 		b.Run("withMetaTagSupport", f)
-		tagquery.MetaTagSupport = false
+		disableMetaTagSupport()
 		b.Run("withoutMetaTagSupport", f)
 	}
 }

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -69,9 +69,8 @@ func queryAndCompareResultsWithMetaTags(t *testing.T, idx *UnpartitionedMemoryId
 }
 
 func TestSimpleMetaTagQueryWithSingleEqualExpression(t *testing.T) {
-	_metaTagSupport := tagquery.MetaTagSupport
-	tagquery.MetaTagSupport = true
-	defer func() { tagquery.MetaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
 
 	metaTagRecord, err := tagquery.ParseMetaTagRecord([]string{"metatag1=value1"}, []string{"tag1=iterator3"})
 	if err != nil {
@@ -89,9 +88,8 @@ func TestSimpleMetaTagQueryWithSingleEqualExpression(t *testing.T) {
 }
 
 func TestSimpleMetaTagQueryWithMatchAndUnequalExpression(t *testing.T) {
-	_metaTagSupport := tagquery.MetaTagSupport
-	tagquery.MetaTagSupport = true
-	defer func() { tagquery.MetaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
 
 	metaTagRecord, err := tagquery.ParseMetaTagRecord([]string{"metatag1=value1"}, []string{"tag1=~iterator[3-4]", "tag1!=iterator3"})
 	if err != nil {
@@ -109,9 +107,8 @@ func TestSimpleMetaTagQueryWithMatchAndUnequalExpression(t *testing.T) {
 }
 
 func TestSimpleMetaTagQueryWithMatchAndNotMatchExpression(t *testing.T) {
-	_metaTagSupport := tagquery.MetaTagSupport
-	tagquery.MetaTagSupport = true
-	defer func() { tagquery.MetaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
 
 	metaTagRecord, err := tagquery.ParseMetaTagRecord([]string{"metatag1=value1"}, []string{"tag1=~iterator[3-9]", "tag1!=~iterator[4-8]"})
 	if err != nil {
@@ -129,9 +126,8 @@ func TestSimpleMetaTagQueryWithMatchAndNotMatchExpression(t *testing.T) {
 }
 
 func TestSimpleMetaTagQueryWithManyTypesOfExpression(t *testing.T) {
-	_metaTagSupport := tagquery.MetaTagSupport
-	tagquery.MetaTagSupport = true
-	defer func() { tagquery.MetaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
 
 	metaTagRecord, err := tagquery.ParseMetaTagRecord(
 		[]string{"metatag1=value1"},
@@ -157,9 +153,8 @@ func TestSimpleMetaTagQueryWithManyTypesOfExpression(t *testing.T) {
 }
 
 func TestMetaTagEnrichmentForQueryByMetricTag(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
 
 	metaTagRecord, err := tagquery.ParseMetaTagRecord(
 		[]string{"metatag1=value1"},
@@ -213,9 +208,8 @@ func TestMetaTagEnrichmentForQueryByMetricTag(t *testing.T) {
 }
 
 func TestMetaTagEnrichmentForQueryByMetaTag(t *testing.T) {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = true
-	defer func() { metaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
 
 	metaTagRecord1, err := tagquery.ParseMetaTagRecord(
 		[]string{"metatag1=value1"},
@@ -291,9 +285,8 @@ func TestMetaTagEnrichmentForQueryByMetaTag(t *testing.T) {
 }
 
 func BenchmarkMetaTagEnricher(b *testing.B) {
-	_metaTagSupport := tagquery.MetaTagSupport
-	tagquery.MetaTagSupport = true
-	defer func() { tagquery.MetaTagSupport = _metaTagSupport }()
+	reset := enableMetaTagSupport()
+	defer reset()
 
 	var err error
 	metaTagRecords1 := make([]tagquery.MetaTagRecord, 1000)

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -549,6 +549,10 @@ func (p *PartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, rawRecord tagqu
 	return record, created, nil
 }
 
+func (p *PartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error) {
+	return 0, 0, nil
+}
+
 func mergePartitionStringResults(partitionResults [][]string) []string {
 	// merge our results into the unique set of strings
 	merged := map[string]struct{}{}

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -553,8 +553,8 @@ func (p *PartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquer
 	g, _ := errgroup.WithContext(context.Background())
 
 	results := make([]struct {
-		Added   uint32
-		Deleted uint32
+		added   uint32
+		deleted uint32
 	}, len(p.Partition))
 
 	var i int
@@ -562,7 +562,7 @@ func (p *PartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquer
 		m, partNum := m, i
 		g.Go(func() error {
 			var err error
-			results[partNum].Added, results[partNum].Deleted, err = m.MetaTagRecordSwap(orgId, records)
+			results[partNum].added, results[partNum].deleted, err = m.MetaTagRecordSwap(orgId, records)
 			return err
 		})
 		i++
@@ -571,8 +571,8 @@ func (p *PartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquer
 	err := g.Wait()
 	var added, deleted uint32
 	for _, result := range results {
-		added += result.Added
-		deleted += result.Deleted
+		added += result.added
+		deleted += result.deleted
 	}
 
 	if err != nil {

--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -53,7 +53,7 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 			defaultDecision:  expr.GetDefaultDecision(),
 		}
 
-		if !tagquery.MetaTagSupport {
+		if !metaTagSupport {
 			continue
 		}
 

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -92,7 +92,7 @@ func testFilterByMetaTagWithEqual(t *testing.T) {
 
 	_, mds := getTestArchives(10)
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch := []schema.MetricDefinition{mds[3], mds[5], mds[6]}
 		expectedFail := append(append(mds[:3], mds[4]), mds[7:]...)
 
@@ -142,7 +142,7 @@ func testFilterByMetaTagWithNotEqualAndWithNotHasTag(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[0], mds[1], mds[2], mds[4], mds[7], mds[8], mds[9]}
 		expectedFail = []schema.MetricDefinition{mds[3], mds[5], mds[6]}
 	} else {
@@ -192,7 +192,7 @@ func testFilterByMetaTagWithEqualAndWithHasTag(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[3], mds[5], mds[6]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[2], mds[4], mds[7], mds[8], mds[9]}
 	} else {
@@ -267,7 +267,7 @@ func testFilterByMetaTagWithPatternMatching(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[2], mds[3]}
 		expectedFail = append(mds[:2], mds[4:]...)
 	} else {
@@ -327,7 +327,7 @@ func testFilterByMetaTagWithTagOperators(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[7], mds[9]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[2], mds[3], mds[4], mds[5], mds[6], mds[8]}
 	} else {
@@ -413,7 +413,7 @@ func testFilterByMultipleOfManyMetaTagValues(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[2], mds[3], mds[4], mds[5]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[6], mds[7], mds[8], mds[9]}
 	} else {
@@ -497,7 +497,7 @@ func testFilterByMultipleOfManyMetaTags(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[2], mds[3]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[4], mds[5], mds[6], mds[7], mds[8], mds[9]}
 	} else {
@@ -561,7 +561,7 @@ func testFilterByOverlappingMetaTags(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[1]}
 		expectedFail = append(mds[2:], mds[0])
 	} else {
@@ -613,7 +613,7 @@ func testFilterSubtractingMetricTagsFromMetaTag(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[1], mds[3], mds[5]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[2], mds[4], mds[6], mds[7], mds[8], mds[9]}
 	} else {

--- a/idx/memory/tag_query_id_selector.go
+++ b/idx/memory/tag_query_id_selector.go
@@ -53,7 +53,7 @@ func (i *idSelector) getIds() (chan schema.MKey, chan struct{}) {
 	// i.rawResCh and deduplicates its ids before inserting them into i.resCh.
 	// if meta tag support is not enabled, then this is not necessary and we don't
 	// need to start the deduplication routine.
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		go i.deduplicateRawResults()
 	}
 
@@ -70,7 +70,7 @@ func (i *idSelector) getIds() (chan schema.MKey, chan struct{}) {
 
 	// if meta tag support is enabled we return i.resCh because that channel has
 	// been deduplicated by i.deduplicateRawResults()
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		return i.resCh, i.stopCh
 	}
 
@@ -108,7 +108,7 @@ func (i *idSelector) byTagValue() {
 	// otherwise we'd risk to create a loop of sub queries creating
 	// each other
 	// same when meta tag support is disabled in the config
-	if !tagquery.MetaTagSupport || i.ctx.subQuery {
+	if !metaTagSupport || i.ctx.subQuery {
 		i.workerWg.Done()
 		return
 	}
@@ -203,7 +203,7 @@ func (i *idSelector) byTag() {
 	// otherwise we'd risk to create a loop of sub queries creating
 	// each other
 	// same when meta tag support is disabled in the config
-	if !tagquery.MetaTagSupport || i.ctx.subQuery {
+	if !metaTagSupport || i.ctx.subQuery {
 		i.workerWg.Done()
 		return
 	}

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -117,7 +117,7 @@ func testSelectByMetaTag(t *testing.T) {
 
 	// with meta tag support disabled we expect an empty result set
 	expectedRes := make(IdSet)
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[5].Id: struct{}{}}
 	}
 
@@ -157,7 +157,7 @@ func testSelectByMetaTagAndMetricTagUsingSameKeyAndValue(t *testing.T) {
 	}
 
 	var expectedRes IdSet
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		// if meta tag support is enabled we expect mds[3] to get returned based on its metric tag tag1=value3
 		// and we also expect mds[4] to get returned based on its associated meta tag tag1=value3
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[4].Id: struct{}{}}
@@ -203,7 +203,7 @@ func testSelectByMetaTagAndMetricTagUsingDifferentKeyAndValue(t *testing.T) {
 	}
 
 	var expectedRes IdSet
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		// if meta tag support is enabled we expect mds[3] to get returned based on its metric tag tag1=value2.3
 		// and we also expect mds[4] to get returned based on its associated meta tag tag1=value3
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[4].Id: struct{}{}}
@@ -249,7 +249,7 @@ func testSelectMetaTagWhichConflictsMetricTag(t *testing.T) {
 	}
 
 	var expectedRes IdSet
-	if tagquery.MetaTagSupport {
+	if metaTagSupport {
 		// if meta tag support is enabled we expect mds[3] to get returned based on its metric tag tag1=value2.3
 		// and we also expect mds[4] to get returned based on its associated meta tag tag1=value3
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[4].Id: struct{}{}, mds[5].Id: struct{}{}}


### PR DESCRIPTION
This adds an API endpoint to batch update all meta records. It also allows the user to specify a `propagate` flag, which makes MT fan out the update to all known peers. This is useful for users who want to first pre-generate all their meta records, and then completely replace the currently active set of records with the new generated one.

Additionally this PR cleans up the meta tags feature gate a bit. The `MetaTagSupport` flag exists in two packages, in `idx.memory` and `expr.tagquery`. Previously there were unnecessary cross-references between those two packages, which have been cleaned up now.