### PR TITLE
Fix terminology mixup

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -613,7 +613,7 @@ func (s *Server) indexMetaTagRecordUpsert(ctx *middleware.Context, req models.In
 		return
 	}
 
-	record, err := tagquery.ParseMetaTagRecord(req.MetaTags, req.Queries)
+	record, err := tagquery.ParseMetaTagRecord(req.MetaTags, req.Expressions)
 	if err != nil {
 		response.Write(ctx, response.WrapError(err))
 		return
@@ -626,9 +626,9 @@ func (s *Server) indexMetaTagRecordUpsert(ctx *middleware.Context, req models.In
 	}
 
 	response.Write(ctx, response.NewMsgp(200, &models.MetaTagRecordUpsertResult{
-		MetaTags: result.MetaTags.Strings(),
-		Queries:  result.Expressions.Strings(),
-		Created:  created,
+		MetaTags:    result.MetaTags.Strings(),
+		Expressions: result.Expressions.Strings(),
+		Created:     created,
 	}))
 }
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -808,7 +808,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 
 // getTagQueryExpressions takes a query string which includes multiple tag query expressions
 // example string: "'a=b', 'c=d', 'e!=~f.*'"
-// it then returns a slice of strings where each string is one of the queries, and an error
+// it then returns a slice of strings where each string is one of the expressions, and an error
 // which is non-nil if there was an error in the expression validation
 // all expressions get validated and an error is returned if one or more are invalid
 func getTagQueryExpressions(expressions string) (tagquery.Expressions, error) {

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1369,9 +1369,9 @@ func (s *Server) metaTagRecordUpsert(ctx *middleware.Context, upsertRequest mode
 
 		if !upsertRequest.Propagate {
 			response.Write(ctx, response.NewJson(200, models.MetaTagRecordUpsertResult{
-				MetaTags: localResult.MetaTags.Strings(),
-				Queries:  localResult.Expressions.Strings(),
-				Created:  created,
+				MetaTags:    localResult.MetaTags.Strings(),
+				Expressions: localResult.Expressions.Strings(),
+				Created:     created,
 			}, ""))
 			return
 		}
@@ -1381,16 +1381,16 @@ func (s *Server) metaTagRecordUpsert(ctx *middleware.Context, upsertRequest mode
 
 	res := models.MetaTagRecordUpsertResultByNode{
 		Local: models.MetaTagRecordUpsertResult{
-			MetaTags: localResult.MetaTags.Strings(),
-			Queries:  localResult.Expressions.Strings(),
-			Created:  created,
+			MetaTags:    localResult.MetaTags.Strings(),
+			Expressions: localResult.Expressions.Strings(),
+			Created:     created,
 		},
 	}
 
 	indexUpsertRequest := models.IndexMetaTagRecordUpsert{
-		OrgId:    ctx.OrgId,
-		MetaTags: upsertRequest.MetaTags,
-		Queries:  upsertRequest.Expressions,
+		OrgId:       ctx.OrgId,
+		MetaTags:    upsertRequest.MetaTags,
+		Expressions: upsertRequest.Expressions,
 	}
 
 	results, errors := s.peerQuery(ctx.Req.Context(), indexUpsertRequest, "metaTagRecordUpsert", "/index/metaTags/upsert")

--- a/api/models/meta_records.go
+++ b/api/models/meta_records.go
@@ -33,22 +33,22 @@ type MetaTagRecordUpsertResultByNode struct {
 }
 
 type MetaTagRecordUpsertResult struct {
-	MetaTags []string `json:"metaTags"`
-	Queries  []string `json:"queries"`
-	Created  bool     `json:"created"`
+	MetaTags    []string `json:"metaTags"`
+	Expressions []string `json:"expressions"`
+	Created     bool     `json:"created"`
 }
 
 type IndexMetaTagRecordUpsert struct {
-	OrgId    uint32   `json:"orgId" binding:"Required"`
-	MetaTags []string `json:"metaTags" binding:"Required"`
-	Queries  []string `json:"queries" binding:"Required"`
+	OrgId       uint32   `json:"orgId" binding:"Required"`
+	MetaTags    []string `json:"metaTags" binding:"Required"`
+	Expressions []string `json:"expressions" binding:"Required"`
 }
 
 func (m IndexMetaTagRecordUpsert) Trace(span opentracing.Span) {
 	span.SetTag("orgId", m.OrgId)
 	span.LogFields(
 		traceLog.String("metaTags", fmt.Sprintf("%q", m.MetaTags)),
-		traceLog.String("queries", fmt.Sprintf("%q", m.Queries)),
+		traceLog.String("expressions", fmt.Sprintf("%q", m.Expressions)),
 	)
 }
 

--- a/api/models/meta_records_gen.go
+++ b/api/models/meta_records_gen.go
@@ -220,22 +220,22 @@ func (z *IndexMetaTagRecordUpsert) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-		case "Queries":
+		case "Expressions":
 			var zb0003 uint32
 			zb0003, err = dc.ReadArrayHeader()
 			if err != nil {
-				err = msgp.WrapError(err, "Queries")
+				err = msgp.WrapError(err, "Expressions")
 				return
 			}
-			if cap(z.Queries) >= int(zb0003) {
-				z.Queries = (z.Queries)[:zb0003]
+			if cap(z.Expressions) >= int(zb0003) {
+				z.Expressions = (z.Expressions)[:zb0003]
 			} else {
-				z.Queries = make([]string, zb0003)
+				z.Expressions = make([]string, zb0003)
 			}
-			for za0002 := range z.Queries {
-				z.Queries[za0002], err = dc.ReadString()
+			for za0002 := range z.Expressions {
+				z.Expressions[za0002], err = dc.ReadString()
 				if err != nil {
-					err = msgp.WrapError(err, "Queries", za0002)
+					err = msgp.WrapError(err, "Expressions", za0002)
 					return
 				}
 			}
@@ -280,20 +280,20 @@ func (z *IndexMetaTagRecordUpsert) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	}
-	// write "Queries"
-	err = en.Append(0xa7, 0x51, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73)
+	// write "Expressions"
+	err = en.Append(0xab, 0x45, 0x78, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73)
 	if err != nil {
 		return
 	}
-	err = en.WriteArrayHeader(uint32(len(z.Queries)))
+	err = en.WriteArrayHeader(uint32(len(z.Expressions)))
 	if err != nil {
-		err = msgp.WrapError(err, "Queries")
+		err = msgp.WrapError(err, "Expressions")
 		return
 	}
-	for za0002 := range z.Queries {
-		err = en.WriteString(z.Queries[za0002])
+	for za0002 := range z.Expressions {
+		err = en.WriteString(z.Expressions[za0002])
 		if err != nil {
-			err = msgp.WrapError(err, "Queries", za0002)
+			err = msgp.WrapError(err, "Expressions", za0002)
 			return
 		}
 	}
@@ -313,11 +313,11 @@ func (z *IndexMetaTagRecordUpsert) MarshalMsg(b []byte) (o []byte, err error) {
 	for za0001 := range z.MetaTags {
 		o = msgp.AppendString(o, z.MetaTags[za0001])
 	}
-	// string "Queries"
-	o = append(o, 0xa7, 0x51, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73)
-	o = msgp.AppendArrayHeader(o, uint32(len(z.Queries)))
-	for za0002 := range z.Queries {
-		o = msgp.AppendString(o, z.Queries[za0002])
+	// string "Expressions"
+	o = append(o, 0xab, 0x45, 0x78, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Expressions)))
+	for za0002 := range z.Expressions {
+		o = msgp.AppendString(o, z.Expressions[za0002])
 	}
 	return
 }
@@ -365,22 +365,22 @@ func (z *IndexMetaTagRecordUpsert) UnmarshalMsg(bts []byte) (o []byte, err error
 					return
 				}
 			}
-		case "Queries":
+		case "Expressions":
 			var zb0003 uint32
 			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Queries")
+				err = msgp.WrapError(err, "Expressions")
 				return
 			}
-			if cap(z.Queries) >= int(zb0003) {
-				z.Queries = (z.Queries)[:zb0003]
+			if cap(z.Expressions) >= int(zb0003) {
+				z.Expressions = (z.Expressions)[:zb0003]
 			} else {
-				z.Queries = make([]string, zb0003)
+				z.Expressions = make([]string, zb0003)
 			}
-			for za0002 := range z.Queries {
-				z.Queries[za0002], bts, err = msgp.ReadStringBytes(bts)
+			for za0002 := range z.Expressions {
+				z.Expressions[za0002], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Queries", za0002)
+					err = msgp.WrapError(err, "Expressions", za0002)
 					return
 				}
 			}
@@ -402,9 +402,9 @@ func (z *IndexMetaTagRecordUpsert) Msgsize() (s int) {
 	for za0001 := range z.MetaTags {
 		s += msgp.StringPrefixSize + len(z.MetaTags[za0001])
 	}
-	s += 8 + msgp.ArrayHeaderSize
-	for za0002 := range z.Queries {
-		s += msgp.StringPrefixSize + len(z.Queries[za0002])
+	s += 12 + msgp.ArrayHeaderSize
+	for za0002 := range z.Expressions {
+		s += msgp.StringPrefixSize + len(z.Expressions[za0002])
 	}
 	return
 }
@@ -1635,22 +1635,22 @@ func (z *MetaTagRecordUpsertResult) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-		case "Queries":
+		case "Expressions":
 			var zb0003 uint32
 			zb0003, err = dc.ReadArrayHeader()
 			if err != nil {
-				err = msgp.WrapError(err, "Queries")
+				err = msgp.WrapError(err, "Expressions")
 				return
 			}
-			if cap(z.Queries) >= int(zb0003) {
-				z.Queries = (z.Queries)[:zb0003]
+			if cap(z.Expressions) >= int(zb0003) {
+				z.Expressions = (z.Expressions)[:zb0003]
 			} else {
-				z.Queries = make([]string, zb0003)
+				z.Expressions = make([]string, zb0003)
 			}
-			for za0002 := range z.Queries {
-				z.Queries[za0002], err = dc.ReadString()
+			for za0002 := range z.Expressions {
+				z.Expressions[za0002], err = dc.ReadString()
 				if err != nil {
-					err = msgp.WrapError(err, "Queries", za0002)
+					err = msgp.WrapError(err, "Expressions", za0002)
 					return
 				}
 			}
@@ -1691,20 +1691,20 @@ func (z *MetaTagRecordUpsertResult) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	}
-	// write "Queries"
-	err = en.Append(0xa7, 0x51, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73)
+	// write "Expressions"
+	err = en.Append(0xab, 0x45, 0x78, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73)
 	if err != nil {
 		return
 	}
-	err = en.WriteArrayHeader(uint32(len(z.Queries)))
+	err = en.WriteArrayHeader(uint32(len(z.Expressions)))
 	if err != nil {
-		err = msgp.WrapError(err, "Queries")
+		err = msgp.WrapError(err, "Expressions")
 		return
 	}
-	for za0002 := range z.Queries {
-		err = en.WriteString(z.Queries[za0002])
+	for za0002 := range z.Expressions {
+		err = en.WriteString(z.Expressions[za0002])
 		if err != nil {
-			err = msgp.WrapError(err, "Queries", za0002)
+			err = msgp.WrapError(err, "Expressions", za0002)
 			return
 		}
 	}
@@ -1731,11 +1731,11 @@ func (z *MetaTagRecordUpsertResult) MarshalMsg(b []byte) (o []byte, err error) {
 	for za0001 := range z.MetaTags {
 		o = msgp.AppendString(o, z.MetaTags[za0001])
 	}
-	// string "Queries"
-	o = append(o, 0xa7, 0x51, 0x75, 0x65, 0x72, 0x69, 0x65, 0x73)
-	o = msgp.AppendArrayHeader(o, uint32(len(z.Queries)))
-	for za0002 := range z.Queries {
-		o = msgp.AppendString(o, z.Queries[za0002])
+	// string "Expressions"
+	o = append(o, 0xab, 0x45, 0x78, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Expressions)))
+	for za0002 := range z.Expressions {
+		o = msgp.AppendString(o, z.Expressions[za0002])
 	}
 	// string "Created"
 	o = append(o, 0xa7, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64)
@@ -1780,22 +1780,22 @@ func (z *MetaTagRecordUpsertResult) UnmarshalMsg(bts []byte) (o []byte, err erro
 					return
 				}
 			}
-		case "Queries":
+		case "Expressions":
 			var zb0003 uint32
 			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Queries")
+				err = msgp.WrapError(err, "Expressions")
 				return
 			}
-			if cap(z.Queries) >= int(zb0003) {
-				z.Queries = (z.Queries)[:zb0003]
+			if cap(z.Expressions) >= int(zb0003) {
+				z.Expressions = (z.Expressions)[:zb0003]
 			} else {
-				z.Queries = make([]string, zb0003)
+				z.Expressions = make([]string, zb0003)
 			}
-			for za0002 := range z.Queries {
-				z.Queries[za0002], bts, err = msgp.ReadStringBytes(bts)
+			for za0002 := range z.Expressions {
+				z.Expressions[za0002], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Queries", za0002)
+					err = msgp.WrapError(err, "Expressions", za0002)
 					return
 				}
 			}
@@ -1823,9 +1823,9 @@ func (z *MetaTagRecordUpsertResult) Msgsize() (s int) {
 	for za0001 := range z.MetaTags {
 		s += msgp.StringPrefixSize + len(z.MetaTags[za0001])
 	}
-	s += 8 + msgp.ArrayHeaderSize
-	for za0002 := range z.Queries {
-		s += msgp.StringPrefixSize + len(z.Queries[za0002])
+	s += 12 + msgp.ArrayHeaderSize
+	for za0002 := range z.Expressions {
+		s += msgp.StringPrefixSize + len(z.Expressions[za0002])
 	}
 	s += 8 + msgp.BoolSize
 	return

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -237,11 +237,11 @@ POST /metaTags/upsert
 ```
 
 This route can be used to create, update and delete meta tag records. Each record is
-identified by its set of queries, if a record gets posted to this URL which has a set
-of queries that doesn't exist yet, a new meta record gets created. If this set of
-queries already exists, the existing meta record will be updated. If the new record
-has no meta tags associated with it, then an existing record with the same set of
-queries gets deleted.
+identified by its set of query expressions, if a record gets posted to this URL which
+has a set of expressions that doesn't exist yet, a new meta record gets created. If
+its set of query expressions already exists, the existing meta record will be updated.
+If the new record has no meta tags associated with it, then an existing record with the
+same set of expressions gets deleted.
 When an existing record gets updated the returned property `created` is `false`,
 otherwise it's `true`.
 
@@ -250,12 +250,12 @@ otherwise it's `true`.
 ```
 ~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags | jq
 []
-~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags/upsert -H 'Content-Type: application/json' -d '{"metaTags": ["mytag=value"], "queries": ["a=b", "c=d"]}' | jq
+~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags/upsert -H 'Content-Type: application/json' -d '{"metaTags": ["mytag=value"], "expressions": ["a=b", "c=d"]}' | jq
 {
   "metaTags": [
     "mytag=value"
   ],
-  "queries": [
+  "expressions": [
     "a=b",
     "c=d"
   ],
@@ -267,16 +267,16 @@ otherwise it's `true`.
     "MetaTags": [
       "mytag=value"
     ],
-    "Queries": [
+    "Expressions": [
       "a=b",
       "c=d"
     ]
   }
 ]
-~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags/upsert -H 'Content-Type: application/json' -d '{"metaTags": [], "queries": ["a=b", "c=d"]}' | jq
+~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags/upsert -H 'Content-Type: application/json' -d '{"metaTags": [], "expressions": ["a=b", "c=d"]}' | jq
 {
   "metaTags": [],
-  "queries": [
+  "expressions": [
     "a=b",
     "c=d"
   ],
@@ -284,6 +284,14 @@ otherwise it's `true`.
 }
 mst@mst-nb1:~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags | jq
 []
+```
+
+The optional boolean parameter "propagate" tells the receiving node that this
+upsert request needs to be propagated among all cluster nodes. Then the request
+would look like this:
+
+```
+~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags/upsert -H 'Content-Type: application/json' -d '{"metaTags": ["mytag=value"], "expressions": ["a=b", "c=d"], "propagate": true}' | jq
 ```
 
 ## Batch updating all Meta Tag Records

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -264,10 +264,10 @@ otherwise it's `true`.
 ~$ curl -s -H 'X-Org-Id: 1' http://localhost:6070/metaTags | jq
 [
   {
-    "MetaTags": [
+    "metaTags": [
       "mytag=value"
     ],
-    "Expressions": [
+    "expressions": [
       "a=b",
       "c=d"
     ]


### PR DESCRIPTION
In multiple places I mixed up the terms `queries` and `expressions`. This should clean up the terminology in the API endpoints, the according docs, and some comments.

It does not change any logic