### PR TITLE
calculate TTL relative to now when inserting into cassandra

### DIFF
--- a/mdata/chunk/spans.go
+++ b/mdata/chunk/spans.go
@@ -48,7 +48,7 @@ func init() {
 // SpanOfChunk takes a chunk and tries to determine its span.
 // It returns 0 if it failed to determine the span, this could fail
 // either because the given chunk is invalid or because it has an old format
-func SpanOfChunk(chunk []byte) uint32 {
+func ExtractChunkSpan(chunk []byte) uint32 {
 	if len(chunk) < 2 {
 		return 0
 	}

--- a/mdata/chunk/spans.go
+++ b/mdata/chunk/spans.go
@@ -56,8 +56,7 @@ func SpanOfChunk(chunk []byte) (uint32, error) {
 		return 0, ErrUnknownChunkSpan
 	}
 
-	format := Format(chunk[0])
-	if format != FormatStandardGoTszWithSpan && format != FormatGoTszLongWithSpan {
+	if Format(chunk[0]) != FormatStandardGoTszWithSpan && Format(chunk[0]) != FormatGoTszLongWithSpan {
 		return 0, ErrUnknownChunkSpan
 	}
 

--- a/mdata/chunk/spans.go
+++ b/mdata/chunk/spans.go
@@ -1,7 +1,5 @@
 package chunk
 
-import "fmt"
-
 type SpanCode uint8
 
 var ChunkSpans = [32]uint32{
@@ -40,7 +38,6 @@ var ChunkSpans = [32]uint32{
 }
 
 var RevChunkSpans = make(map[uint32]SpanCode, len(ChunkSpans))
-var ErrUnknownChunkSpan = fmt.Errorf("Cannot determine span of chunk")
 
 func init() {
 	for k, v := range ChunkSpans {
@@ -49,20 +46,20 @@ func init() {
 }
 
 // SpanOfChunk takes a chunk and tries to determine its span.
-// It returns an error if it failed to determine the span, this could fail
+// It returns 0 if it failed to determine the span, this could fail
 // either because the given chunk is invalid or because it has an old format
-func SpanOfChunk(chunk []byte) (uint32, error) {
+func SpanOfChunk(chunk []byte) uint32 {
 	if len(chunk) < 2 {
-		return 0, ErrUnknownChunkSpan
+		return 0
 	}
 
 	if Format(chunk[0]) != FormatStandardGoTszWithSpan && Format(chunk[0]) != FormatGoTszLongWithSpan {
-		return 0, ErrUnknownChunkSpan
+		return 0
 	}
 
 	if int(chunk[1]) >= len(ChunkSpans) {
-		return 0, ErrUnknownChunkSpan
+		return 0
 	}
 
-	return ChunkSpans[SpanCode(chunk[1])], nil
+	return ChunkSpans[SpanCode(chunk[1])]
 }

--- a/store/cassandra/cassandra.go
+++ b/store/cassandra/cassandra.go
@@ -355,7 +355,7 @@ func (c *CassandraStore) insertChunk(key string, t0, ttl uint32, data []byte) er
 		return nil
 	}
 
-	span := chunk.SpanOfChunk(data)
+	span := chunk.ExtractChunkSpan(data)
 	if span == 0 {
 		span = mdata.MaxChunkSpan()
 	}

--- a/store/cassandra/cassandra.go
+++ b/store/cassandra/cassandra.go
@@ -355,6 +355,21 @@ func (c *CassandraStore) insertChunk(key string, t0, ttl uint32, data []byte) er
 		return nil
 	}
 
+	// we calculate ttl like this:
+	// - the chunk's t0 plus maxChunkSpan is the ts of last possible datapoint in the chunk
+	// - the timestamp of the last datapoint + ttl is the timestamp until when we want to keep this chunk
+	// - then we subtract the current time stamp to get the difference relative to now
+	// - the result is the ttl in seconds relative to now
+	relativeTtl := int64(t0+mdata.MaxChunkSpan()+ttl) - time.Now().Unix()
+
+	// if the ttl relative to now is <=0 then we can omit the insert
+	if relativeTtl <= 0 {
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("Omitting insert of chunk with ttl %d: %s, %d", relativeTtl, key, t0)
+		}
+		return nil
+	}
+
 	table, ok := c.TTLTables[ttl]
 	if !ok {
 		return errTableNotFound
@@ -363,7 +378,7 @@ func (c *CassandraStore) insertChunk(key string, t0, ttl uint32, data []byte) er
 	row_key := fmt.Sprintf("%s_%d", key, t0/Month_sec) // "month number" based on unix timestamp (rounded down)
 	pre := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
-	ret := c.Session.Query(table.QueryWrite, row_key, t0, data, ttl).WithContext(ctx).Exec()
+	ret := c.Session.Query(table.QueryWrite, row_key, t0, data, uint32(relativeTtl)).WithContext(ctx).Exec()
 	cancel()
 	cassPutExecDuration.Value(time.Now().Sub(pre))
 	return ret

--- a/store/cassandra/cassandra.go
+++ b/store/cassandra/cassandra.go
@@ -355,8 +355,8 @@ func (c *CassandraStore) insertChunk(key string, t0, ttl uint32, data []byte) er
 		return nil
 	}
 
-	span, err := chunk.SpanOfChunk(data)
-	if err != nil {
+	span := chunk.SpanOfChunk(data)
+	if span == 0 {
 		span = mdata.MaxChunkSpan()
 	}
 


### PR DESCRIPTION
Calculate the TTL relative to now before inserting into cassandra. If it is `<=0` then we just skip the insert.