### PR TITLE
Fix uneven length panics

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -756,8 +756,7 @@ func newRequestContext(ctx context.Context, req *models.Req, consolidator consol
 		// but because we eventually want to consolidate into a point with ts=60, we also need the points that will be fix-adjusted to 40 and 50.
 		// so From needs to be lowered by 20 to become 35 (or 31 if adjusted).
 
-		firstPointTs := alignForward(rc.From, req.ArchInterval)          // e.g. alignForward(55/51, 10) = 60.
-		remainder := (firstPointTs - req.ArchInterval) % req.OutInterval // (60-10) % 30 = 20
+		remainder := alignBackward(rc.From, req.ArchInterval) % req.OutInterval // (60-10) % 30 = 20
 
 		if rc.From > remainder {
 			rc.From -= remainder

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -48,16 +48,16 @@ type getTargetsResp struct {
 
 // alignForward aligns ts to the next timestamp that divides by the interval, except if it is already aligned
 func alignForward(ts, interval uint32) uint32 {
-	first := ts
 	remain := ts % interval
-	if remain != 0 {
-		first = ts + interval - remain
+	if remain == 0 {
+		return ts
 	}
-	return first
+	return ts + interval - remain
 }
 
-func alignBackward(ts uint32, span uint32) uint32 {
-	return ts - ((ts-1)%span + 1)
+// alignBackward aligns the ts to the previous ts that divides by the interval, even if it is already aligned
+func alignBackward(ts uint32, interval uint32) uint32 {
+	return ts - ((ts-1)%interval + 1)
 }
 
 // Fix assures a series is in quantized form:

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -720,7 +720,7 @@ func newRequestContext(ctx context.Context, req *models.Req, consolidator consol
 	// timestamps and could not include either of them.
 	// so the caller can just compare rc.From and rc.To and if equal, immediately return [] to the client.
 
-	if consolidator == consolidation.None {
+	if req.Archive == 0 {
 		rc.From = prevBoundary(req.From, req.ArchInterval) + 1
 		rc.To = prevBoundary(req.To, req.ArchInterval) + 1
 		rc.AMKey = schema.AMKey{MKey: req.MKey}

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -379,8 +379,8 @@ func (s *Server) getTarget(ctx context.Context, ss *models.StorageStats, req mod
 			}
 			return divideContext(
 				ctx,
-				consolidation.Consolidate(sumFixed, req.AggNum, consolidation.Sum),
-				consolidation.Consolidate(cntFixed, req.AggNum, consolidation.Sum),
+				consolidation.ConsolidateContext(ctx, sumFixed, req.AggNum, consolidation.Sum),
+				consolidation.ConsolidateContext(ctx, cntFixed, req.AggNum, consolidation.Sum),
 			), req.OutInterval, nil
 		} else {
 			fixed, err := s.getSeriesFixed(ctx, ss, req, req.Consolidator)

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -371,6 +371,7 @@ func TestGetSeriesFixed(t *testing.T) {
 				metric.Add(30+offset, 40) // this point will always be quantized to 40
 				metric.Add(40+offset, 50) // this point will always be quantized to 50
 				req := models.NewReq(id, "", "", from, to, 1000, 10, consolidation.Avg, 0, cluster.Manager.ThisNode(), 0, 0)
+				req.Archive = 0
 				req.ArchInterval = 10
 				points, err := srv.getSeriesFixed(test.NewContext(), &models.StorageStats{}, req, consolidation.None)
 				if err != nil {
@@ -386,6 +387,7 @@ func TestGetSeriesFixed(t *testing.T) {
 
 func reqRaw(key schema.MKey, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator, schemaId, aggId uint16) models.Req {
 	req := models.NewReq(key, "", "", from, to, maxPoints, rawInterval, consolidator, 0, cluster.Manager.ThisNode(), schemaId, aggId)
+	req.Archive = 0
 	return req
 }
 func reqOut(key schema.MKey, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator, schemaId, aggId uint16, archive int, archInterval, ttl, outInterval, aggNum uint32) models.Req {

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -311,6 +311,26 @@ type pbCase struct {
 	boundary uint32
 }
 
+func TestAlignForward(t *testing.T) {
+	cases := []pbCase{
+		{1, 60, 60},
+		{2, 60, 60},
+		{3, 60, 60},
+		{57, 60, 60},
+		{58, 60, 60},
+		{59, 60, 60},
+		{60, 60, 60},
+		{61, 60, 120},
+		{62, 60, 120},
+		{63, 60, 120},
+	}
+	for _, c := range cases {
+		if ret := alignForward(c.ts, c.span); ret != c.boundary {
+			t.Fatalf("alignBackward for ts %d with span %d should be %d, not %d", c.ts, c.span, c.boundary, ret)
+		}
+	}
+}
+
 func TestAlignBackward(t *testing.T) {
 	cases := []pbCase{
 		{1, 60, 0},

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -311,7 +311,7 @@ type pbCase struct {
 	boundary uint32
 }
 
-func TestPrevBoundary(t *testing.T) {
+func TestAlignBackward(t *testing.T) {
 	cases := []pbCase{
 		{1, 60, 0},
 		{2, 60, 0},
@@ -325,8 +325,8 @@ func TestPrevBoundary(t *testing.T) {
 		{63, 60, 60},
 	}
 	for _, c := range cases {
-		if ret := prevBoundary(c.ts, c.span); ret != c.boundary {
-			t.Fatalf("prevBoundary for ts %d with span %d should be %d, not %d", c.ts, c.span, c.boundary, ret)
+		if ret := alignBackward(c.ts, c.span); ret != c.boundary {
+			t.Fatalf("alignBackward for ts %d with span %d should be %d, not %d", c.ts, c.span, c.boundary, ret)
 		}
 	}
 }

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -385,6 +385,198 @@ func TestGetSeriesFixed(t *testing.T) {
 	}
 }
 
+// TestGetSeriesFixedVariableOutInterval tests that getSeriesFixed returns series in pre-canonical form.
+func TestGetSeriesFixedVariableOutInterval(t *testing.T) {
+	cluster.Init("default", "test", time.Now(), "http", 6060)
+	store := mdata.NewMockStore()
+	store.Drop = true
+
+	mdata.SetSingleAgg(conf.Sum, conf.Avg, conf.Min, conf.Max)
+	mdata.SetSingleSchema(conf.NewRetentionMT(10, 100, 600, 10, 0))
+
+	cache := cache.NewCCache()
+	metrics := mdata.NewAggMetrics(store, cache, false, nil, 0, 0, 0)
+	srv, _ := NewServer()
+	srv.BindBackendStore(store)
+	srv.BindMemoryStore(metrics)
+	srv.BindCache(cache)
+
+	cases := []struct {
+		in           []schema.Point
+		from         uint32
+		to           uint32
+		outInterval  uint32
+		archInterval uint32
+		out          []schema.Point
+	}{
+		{
+			in: []schema.Point{
+				{Val: 1, Ts: 10},
+				{Val: 2, Ts: 20},
+				{Val: 3, Ts: 30},
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60},
+				{Val: 7, Ts: 70},
+			},
+			from:         40,
+			to:           60,
+			outInterval:  10, // no normalizing
+			archInterval: 10,
+			out: []schema.Point{
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+			},
+		},
+		{
+			in: []schema.Point{
+				{Val: 1, Ts: 10},
+				{Val: 2, Ts: 20},
+				{Val: 3, Ts: 30},
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60},
+				{Val: 7, Ts: 70},
+			},
+			from:         30,
+			to:           65,
+			outInterval:  30, // aggNum=3
+			archInterval: 10,
+			out: []schema.Point{
+				{Val: 1, Ts: 10},
+				{Val: 2, Ts: 20},
+				{Val: 3, Ts: 30}, // first point after normalizing
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60}, // second point after normalizing
+			},
+		},
+		{
+			in: []schema.Point{
+				{Val: 1, Ts: 10},
+				{Val: 2, Ts: 20},
+				{Val: 3, Ts: 30},
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60},
+				{Val: 7, Ts: 70},
+			},
+			from:         21,
+			to:           65,
+			outInterval:  30, // aggNum=3
+			archInterval: 10,
+			out: []schema.Point{
+				{Val: 1, Ts: 10},
+				{Val: 2, Ts: 20},
+				{Val: 3, Ts: 30}, // first point after normalizing
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60}, // second point after normalizing
+			},
+		},
+		{
+			// here Fix will also be involved
+			in: []schema.Point{
+				{Val: 1, Ts: 8},
+				{Val: 2, Ts: 19},
+				{Val: 3, Ts: 28},
+				{Val: 4, Ts: 36},
+				{Val: 5, Ts: 47},
+				{Val: 6, Ts: 58},
+				{Val: 7, Ts: 69},
+			},
+			from:         21,
+			to:           65,
+			outInterval:  30, // aggNum=3
+			archInterval: 10,
+			out: []schema.Point{
+				{Val: 1, Ts: 10},
+				{Val: 2, Ts: 20},
+				{Val: 3, Ts: 30}, // first point after normalizing
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60}, // second point after normalizing
+			},
+		},
+		{
+			// here Fix will also be involved
+			in: []schema.Point{
+				{Val: 1, Ts: 8},
+				{Val: 2, Ts: 19},
+				{Val: 3, Ts: 28},
+				{Val: 4, Ts: 36},
+				{Val: 5, Ts: 47},
+				{Val: 6, Ts: 58},
+				{Val: 7, Ts: 69},
+				{Val: 8, Ts: 77},
+				{Val: 9, Ts: 88},
+				{Val: 10, Ts: 99},
+			},
+			from:         21,
+			to:           85,
+			outInterval:  30, // aggNum=3. a native 30s would end at 60. so we should too
+			archInterval: 10,
+			out: []schema.Point{
+				{Val: 1, Ts: 10},
+				{Val: 2, Ts: 20},
+				{Val: 3, Ts: 30}, // first point after normalizing
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60}, // second point after normalizing
+			},
+		},
+		{
+			// here Fix will also be involved
+			in: []schema.Point{
+				{Val: 1, Ts: 8},
+				{Val: 2, Ts: 19},
+				{Val: 3, Ts: 28},
+				{Val: 4, Ts: 36},
+				{Val: 5, Ts: 47},
+				{Val: 6, Ts: 58},
+				{Val: 7, Ts: 69},
+				{Val: 8, Ts: 77},
+				{Val: 9, Ts: 88},
+				{Val: 10, Ts: 99},
+			},
+			from:         21,
+			to:           85,
+			outInterval:  10, // in contrast with the previous case we don't have to be canonical wrt a 30s series, and can now honor the 10s interval
+			archInterval: 10,
+			out: []schema.Point{
+				{Val: 3, Ts: 30},
+				{Val: 4, Ts: 40},
+				{Val: 5, Ts: 50},
+				{Val: 6, Ts: 60},
+				{Val: 7, Ts: 70},
+				{Val: 8, Ts: 80},
+			},
+		},
+	}
+
+	for num, testCase := range cases {
+		// create metric and add data points
+		id := test.GetMKey(num)
+		metric := metrics.GetOrCreate(id, 0, 1, testCase.archInterval)
+		for _, dataPoint := range testCase.in {
+			metric.Add(dataPoint.Ts, dataPoint.Val)
+		}
+
+		req := models.NewReq(id, "", "", testCase.from, testCase.to, 1000, testCase.archInterval, consolidation.Avg, 0, cluster.Manager.ThisNode(), 0, 0)
+		req.Archive = 0
+		req.ArchInterval = testCase.archInterval
+		req.OutInterval = testCase.outInterval
+		req.AggNum = testCase.outInterval / req.ArchInterval
+		result, err := srv.getSeriesFixed(test.NewContext(), &models.StorageStats{}, req, consolidation.None)
+		if err != nil {
+			t.Errorf("case %d: interval %d, aggNum %d, from %d to %d -> error: %s", num, testCase.outInterval, req.AggNum, testCase.from, testCase.to, err)
+		}
+		if !reflect.DeepEqual(testCase.out, result) {
+			t.Errorf("case %d: interval %d, aggNum %d, from %d to %d -> expected: %v - got %v", num, testCase.outInterval, req.AggNum, testCase.from, testCase.to, testCase.out, result)
+		}
+	}
+}
+
 func reqRaw(key schema.MKey, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator, schemaId, aggId uint16) models.Req {
 	req := models.NewReq(key, "", "", from, to, maxPoints, rawInterval, consolidator, 0, cluster.Manager.ThisNode(), schemaId, aggId)
 	req.Archive = 0

--- a/consolidation/consolidate.go
+++ b/consolidation/consolidate.go
@@ -30,6 +30,8 @@ func ConsolidateNudged(points []schema.Point, interval, maxDataPoints uint32, co
 
 // Consolidate consolidates `in`, aggNum points at a time via the given function
 // note: the returned slice repurposes in's backing array.
+// it will always aggregate aggNum-sized groups of points together, with the timestamp of the last of them, and it always starts at the beginning,
+// possibly having a point at the end that didn't incorporate as much data
 func Consolidate(in []schema.Point, aggNum uint32, consolidator Consolidator) []schema.Point {
 	num := int(aggNum)
 	aggFunc := GetAggFunc(consolidator)

--- a/consolidation/consolidate_test.go
+++ b/consolidation/consolidate_test.go
@@ -276,8 +276,9 @@ func TestConsolidateStableShouldBeStableWithPrevious(t *testing.T) {
 func TestConsolidateStableABitMoreData(t *testing.T) {
 	testConsolidateStable(
 		// another trimming example with a bit more data
-		// logic is as follows: 13 points, mdp 3 => aggregate every 5
-		// so first agg point should be 10,20,30,40,50, which is incomplete
+		// logic is as follows: 13 points, mdp 3 => aggregate every 5.
+		// so first agg point needs input points with ts 10,20,30,40,50,
+		// but the bucket is incomplete (there is no point with ts 10)
 		// so nudge it away.
 		// this actually leaves us with only 9 points, so in theory we could
 		// use more and smaller buckets of 3 or 4 points,

--- a/consolidation/consolidate_test.go
+++ b/consolidation/consolidate_test.go
@@ -194,8 +194,8 @@ func TestConsolidationFunctions(t *testing.T) {
 	validate(cases, t)
 }
 
-func TestConsolidateStableNoAgg(t *testing.T) {
-	testConsolidateStable(
+func TestConsolidateNudgedNoAgg(t *testing.T) {
+	testConsolidateNudged(
 		[]schema.Point{
 			{Val: 1, Ts: 10},
 			{Val: 2, Ts: 20},
@@ -211,8 +211,8 @@ func TestConsolidateStableNoAgg(t *testing.T) {
 		t)
 }
 
-func TestConsolidateStableNoTrimDueToNotManyPoints(t *testing.T) {
-	testConsolidateStable(
+func TestConsolidateNudgedNoTrimDueToNotManyPoints(t *testing.T) {
+	testConsolidateNudged(
 		[]schema.Point{
 			{Val: 1, Ts: 20},
 			{Val: 2, Ts: 30},
@@ -227,8 +227,8 @@ func TestConsolidateStableNoTrimDueToNotManyPoints(t *testing.T) {
 		40,
 		t)
 }
-func TestConsolidateStableShouldTrim(t *testing.T) {
-	testConsolidateStable(
+func TestConsolidateNudgedShouldTrim(t *testing.T) {
+	testConsolidateNudged(
 		// more points, we should trim to get proper alignment
 		[]schema.Point{
 			{Val: 1, Ts: 20},
@@ -248,8 +248,8 @@ func TestConsolidateStableShouldTrim(t *testing.T) {
 		20,
 		t)
 }
-func TestConsolidateStableShouldBeStableWithPrevious(t *testing.T) {
-	testConsolidateStable(
+func TestConsolidateNudgedShouldBeStableWithPrevious(t *testing.T) {
+	testConsolidateNudged(
 		// and now we learn why
 		// one point out of the window and a new one at the back
 		// should result in the same consolidated points for everything in the middle
@@ -273,8 +273,8 @@ func TestConsolidateStableShouldBeStableWithPrevious(t *testing.T) {
 		t)
 }
 
-func TestConsolidateStableABitMoreData(t *testing.T) {
-	testConsolidateStable(
+func TestConsolidateNudgedABitMoreData(t *testing.T) {
+	testConsolidateNudged(
 		// another trimming example with a bit more data
 		// logic is as follows: 13 points, mdp 3 => aggregate every 5.
 		// so first agg point needs input points with ts 10,20,30,40,50,
@@ -309,8 +309,8 @@ func TestConsolidateStableABitMoreData(t *testing.T) {
 		50,
 		t)
 }
-func TestConsolidateStableABitMoreDataEven(t *testing.T) {
-	testConsolidateStable(
+func TestConsolidateNudgedABitMoreDataEven(t *testing.T) {
+	testConsolidateNudged(
 		// now we actually have a clean start at 10, so we can incorporate it
 		[]schema.Point{
 			{Val: 1, Ts: 10},   // bucket 1
@@ -338,8 +338,8 @@ func TestConsolidateStableABitMoreDataEven(t *testing.T) {
 		50,
 		t)
 }
-func testConsolidateStable(in []schema.Point, inInt uint32, mdp uint32, expOut []schema.Point, expOutInt uint32, t *testing.T) {
-	out, outInt := ConsolidateStable(in, inInt, mdp, Sum)
+func testConsolidateNudged(in []schema.Point, inInt uint32, mdp uint32, expOut []schema.Point, expOutInt uint32, t *testing.T) {
+	out, outInt := ConsolidateNudged(in, inInt, mdp, Sum)
 	if outInt != expOutInt {
 		t.Fatalf("output interval mismatch: expected: %v, got: %v", expOutInt, outInt)
 	}

--- a/docs/render-path
+++ b/docs/render-path
@@ -1,0 +1,93 @@
+# definitions
+
+## quantized form
+
+a raw is quantized when the timestamps are adjusted to be regular.
+E.g. an input stream that has:
+* an interval of 10
+* points with timestamps 58, 67, 75, 95 
+
+is quantized to a series with points with timestamps 60, 70, 80, 90 (this one has no data), 100.
+
+## fixed form
+
+a series is fixed, with respect to a query with from/to time, when
+* it is quantized.
+* contains a point for each interval (possibly null).
+* contains only timestamps such that `from <= timestams < to`.
+
+## canonical form
+
+canonical form comes into play when we need to normalize (through consolidation of points) a series, to be at a higher interval.
+It essentially means a series looks like a "native" fixed series of that higher interval,
+with respect to how many points it contains and which timestamps they have.
+
+It is important here to keep in mind that consolidated points get the timestamp of the last of its input points.
+
+Continuing the above example, if we need to normalize the above series with aggNum 3 (OutInterval is 30s)
+We would normally get a series of (60,70,80), (90, 100, 110 - this one has no data), so 80, 110.
+But this is not the quantized form of a series with an interval of 30.
+
+So, what typically happens to make a series canonical, is at fetch time, also fetch some extra earlier data.
+such that after aggregation, the series looks like (40, 50, 60) (70, 80, 90) (100, 110 -no data, 120 - no data) or 60, 90, 120.
+Technically speaking we don't have to fetch the earlier points, we could leave them null, but then the data would be misleading.
+It's better for the first aggregate point to have received its full input set of raw data points.
+
+The other thing is, if the query provided a `to` of 140, a 30s series would have the point 120 as the last one as 150 is out of bounds.
+But if we simply fetched our 10s series with the same `to` it would include point 130, which when consolidated results in a group of
+(130, 140, 150), which would get output timestamp of 150, which should not have been included.
+
+Thus, at fetch time we also adjust the `to` value such that no values are included that would produce an out-of-bounds timestamp after
+consolidation.
+
+
+Why is this important? Well I'm glad you asked!
+After a serie is fetched and normalized, it is often combined with other series:
+
+1) used in cross-serie aggregates (e.g. sumSeries).
+2) merged with other series. (e.g. user changed interval of their metric and we stitch them together)
+
+For these aggregations and merging to work well, the series need to have the same length and the same timestamps.
+Note that the other series don't necessarily have to be series that are "native" series of that interval.
+Continuing the example again, it could be another series that had a raw interval of 15s and is normalized with AggNum=2.
+
+## pre-canonical
+
+a pre-canonical series is simply a series that after normalizing, will be canonical.
+I.O.W. is a series that is fetched in such a way that when it is fed to Consolidate(), will produce a canonical series.
+See above for more details.
+
+## nudging
+in graphite, nudging happens when doing MDP-based consolidation:
+after determining the post-consolidation interval (here referred to as postInterval)
+it removes a few points from the beginning of the series (if needed),
+such that:
+* each aggregation bucket has a full set of input points (except possibly the last one)
+  (i.o.w. the first point in the series is the first point for an aggregation bucket)
+* across different requests, where points arrive on the right and leave the window on the left,
+  the same timestamps are always aggregated together, and the timestamp is always consistent
+  and diviseble by the postInterval.
+
+
+
+In metrictank we do the same, via nudge(), invoked when doing MDP-based consolidation.
+Except, when we have only few points, strict applicating of nudging may result in confusing,
+strongly altered results. We only nudge when we have points > 2 * postAggInterval's worth.
+This means that in cases of few points and a low MDP value, where we don't nudge,
+we do not provide the above 2 guarantees, but a more useful result.
+
+
+## normalizing
+
+given multiple series being fetched of different resolution, normalizing is runtime consolidation
+but only for the purpose of bringing series of different resolutions to a common, lower resolution
+such that they can be used together (for aggregating, merging, etc)
+
+
+## request flow
+
+
+TODO talk about
+alignRequests -> getTargets -> mergeSeries -> sort Series -> plan.Run (executes functions and does MDP consolidation with nudging)
+
+talk more about what happens at each step, how data is manipulated etc

--- a/expr/plan.go
+++ b/expr/plan.go
@@ -233,7 +233,7 @@ func (p Plan) Run(input map[Req][]models.Series) ([]models.Series, error) {
 			if o.Consolidator == 0 {
 				o.Consolidator = consolidation.Avg
 			}
-			out[i].Datapoints, out[i].Interval = consolidation.ConsolidateStable(o.Datapoints, o.Interval, p.MaxDataPoints, o.Consolidator)
+			out[i].Datapoints, out[i].Interval = consolidation.ConsolidateNudged(o.Datapoints, o.Interval, p.MaxDataPoints, o.Consolidator)
 		}
 	}
 	return out, nil

--- a/mdata/store_mock.go
+++ b/mdata/store_mock.go
@@ -2,7 +2,6 @@ package mdata
 
 import (
 	"context"
-	"errors"
 
 	"github.com/grafana/metrictank/schema"
 
@@ -55,7 +54,7 @@ func (c *MockStore) Search(ctx context.Context, metric schema.AMKey, ttl, start,
 	var ok bool
 
 	if itgens, ok = c.results[metric]; !ok {
-		return res, errors.New("metric not found")
+		return res, nil
 	}
 
 	for _, itgen := range itgens {


### PR DESCRIPTION
Document concepts better and in particular introduce new concept of a "canonical series".
Now we massage the fetch and fix parameters such that a high resolution series will always look like a native lower resolution serie (one that has the same interval as what we're normalizing to).
In particular, they will now have corresponding timestamps, and the same amount of points.

fix #913  (panic in mergeSeries) - tried the repro case. can't repro anymore.
fix #1095 (mergeSeries and sumSeries) - can not repo either one with this code.
fix #874 (dupe)