### PR TITLE
fix stack overflow in tag expression

### DIFF
--- a/expr/tagquery/expression.go
+++ b/expr/tagquery/expression.go
@@ -13,7 +13,7 @@ import (
 type InvalidExpressionError string
 
 func (i InvalidExpressionError) Error() string {
-	return fmt.Sprintf("Invalid expression: %q", i)
+	return fmt.Sprintf("Invalid expression: %q", string(i))
 }
 
 type Expressions []Expression

--- a/expr/tagquery/expression.go
+++ b/expr/tagquery/expression.go
@@ -13,7 +13,7 @@ import (
 type InvalidExpressionError string
 
 func (i InvalidExpressionError) Error() string {
-	return fmt.Sprintf("Invalid expression: %q", string(i))
+	return fmt.Sprintf("Invalid expression: %s", string(i))
 }
 
 type Expressions []Expression


### PR DESCRIPTION
Fixes stack overflow in tagquery/expression.go caused by recursive calls to string.