### PR TITLE
Fix bug in get enricher

### DIFF
--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -80,7 +80,7 @@ func (m metaTagRecords) upsert(record tagquery.MetaTagRecord) (recordId, *tagque
 	return 0, nil, 0, nil, errors.NewInternal("Could not find a free ID to insert record")
 }
 
-func (m metaTagRecords) getEnricher(lookup tagquery.IdTagLookup) *enricher {
+func (m *metaTagRecords) getEnricher(lookup tagquery.IdTagLookup) *enricher {
 	res := (*enricher)(atomic.LoadPointer(&m.enricher))
 	if res != nil {
 		return res

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -351,7 +351,6 @@ func BenchmarkMetaTagEnricher(b *testing.B) {
 	}
 
 	memoryIdx, keys := getTestIndexWithMetaTags(b, allMetaTagRecords, 1000)
-	enricher := memoryIdx.metaTagRecords[1].getEnricher(memoryIdx.tags[1].idHasTag)
 
 	defs := make([]idx.Archive, len(keys))
 	i := 0
@@ -367,7 +366,7 @@ func BenchmarkMetaTagEnricher(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		def = &defs[i%1000]
-		metaTags := enricher.enrich(def.Id, def.Name, def.Tags)
+		metaTags := memoryIdx.metaTagRecords[1].getEnricher(memoryIdx.tags[1].idHasTag).enrich(def.Id, def.Name, def.Tags)
 		if len(metaTags) != 3 {
 			b.Fatalf("Expected result to have length 3, but it had %d", len(metaTags))
 		}


### PR DESCRIPTION
This first modifies the benchmark `BenchmarkMetaTagEnricher` so it also tests obtaining the enricher, then it changes the getEnricher() method so that it can actually reuse the instantiated enricher.
```
replay@mst-nb:~/go/src/github.com/grafana/metrictank/idx/memory$ benchcmp /tmp/bench1 /tmp/bench2
benchmark                       old ns/op     new ns/op     delta
BenchmarkMetaTagEnricher-12     2006728       792810        -60.49%

benchmark                       old allocs     new allocs     delta
BenchmarkMetaTagEnricher-12     27022          2045           -92.43%

benchmark                       old bytes     new bytes     delta
BenchmarkMetaTagEnricher-12     985807        103507        -89.50%
```