### PR TITLE
in cluster calls, set user agent

### DIFF
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"time"
@@ -289,6 +290,8 @@ func (n HTTPNode) Post(ctx context.Context, name, path string, body Traceable) (
 		log.Errorf("CLU failed to inject span into headers: %s", err.Error())
 	}
 	req.Header.Add("Content-Type", "application/json")
+	ua := fmt.Sprintf("metrictank/%s (mode %s; state %s) Go/%s", n.Version, n.Mode.String(), n.State.String(), runtime.Version())
+	req.Header.Set("User-Agent", ua)
 	rsp, err := client.Do(req)
 
 	select {


### PR DESCRIPTION
### before
```
POST /index/find HTTP/1.1.
Host: 10.36.10.50:6060.
User-Agent: Go-http-client/1.1.
Content-Length: 58.
Content-Type: application/json.
Uber-Trace-Id: 1d0fc4fe63bc4740:711fa951aa00a28b:188525e7ddc4c59b:0.
Accept-Encoding: gzip.
.
{"patterns":["some.id.of.a.metric.1*"],"orgId":1,"from":0}
```
### after
```
POST /index/find HTTP/1.1.
Host: 172.23.0.15:6060.
User-Agent: metrictank/v0.13.0-7-g267c5bb (mode Shard; state NodeReady) Go/go1.13.
Content-Length: 58.
Content-Type: application/json.
Uber-Trace-Id: 5ef53711c1016414:3c63b8cea9962f65:1353d9db56dae1b7:1.
Accept-Encoding: gzip.
.
{"patterns":["some.id.of.a.metric.1*"],"orgId":1,"from":0}
```