### PR TITLE
Don't validate MaxChunkSpan if BigTable store is disabled

### DIFF
--- a/store/bigtable/config.go
+++ b/store/bigtable/config.go
@@ -41,8 +41,10 @@ func (cfg *StoreConfig) Validate(schemaMaxChunkSpan uint32) error {
 	if CliConfig.MaxChunkSpan%time.Second != 0 {
 		return errors.New("max-chunkspan must be a whole number of seconds")
 	}
-	if uint32(CliConfig.MaxChunkSpan.Seconds()) < schemaMaxChunkSpan {
-		return fmt.Errorf("max-chunkspan must be at least as high as the max chunkspan used in your storage-schemas (which is %d)", schemaMaxChunkSpan)
+	if CliConfig.Enabled {
+		if uint32(CliConfig.MaxChunkSpan.Seconds()) < schemaMaxChunkSpan {
+			return fmt.Errorf("max-chunkspan must be at least as high as the max chunkspan used in your storage-schemas (which is %d)", schemaMaxChunkSpan)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Hi,
i'm using metrictank with cassandra as storage, but metrictank refues to start because of the bigtable store setting "max-chunkspan" being set to low.

> 2019/09/19 13:06:16 bigtable-store: Config validation error. max-chunkspan must be at least as high as the max chunkspan used in your storage-schemas (which is 86400)

This means i have to adjust settings for a storage i'm not using.

I would suggest to skip the validation of max-chunkspan if the bigtable store is not enabled.