### PR TITLE
correctly clear enrichment cache on upsert

### DIFF
--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -40,7 +40,7 @@ func newMetaTagRecords() *metaTagRecords {
 // 3) The id of the record that has been replaced if an update was performed
 // 4) Pointer to the metaTagRecord that has been replaced if an update was performed, otherwise nil
 // 5) Error if an error occurred, otherwise it's nil
-func (m metaTagRecords) upsert(record tagquery.MetaTagRecord) (recordId, *tagquery.MetaTagRecord, recordId, *tagquery.MetaTagRecord, error) {
+func (m *metaTagRecords) upsert(record tagquery.MetaTagRecord) (recordId, *tagquery.MetaTagRecord, recordId, *tagquery.MetaTagRecord, error) {
 	// after altering meta records we need to reinstantiate the enricher the next time we want to use it
 	defer atomic.StorePointer(&m.enricher, nil)
 


### PR DESCRIPTION
Fixes a bug which causes that the enrichment cache never gets cleared. Because the upsert method is not a pointer receiver the instruction that's supposed to clear the cache is using a copy of the pointer to the cache, instead of the one we actually want to clear. By changing the method to a pointer receiver we clear the correct pointer instead of a copy of it.