### PR TITLE
meta tag records must be optional in meta tag upsert requests

### DIFF
--- a/api/models/meta_records.go
+++ b/api/models/meta_records.go
@@ -10,7 +10,7 @@ import (
 //go:generate msgp
 
 type MetaTagRecordUpsert struct {
-	MetaTags    []string `json:"metaTags" binding:"Required"`
+	MetaTags    []string `json:"metaTags"`
 	Expressions []string `json:"expressions" binding:"Required"`
 	Propagate   bool     `json:"propagate"`
 }
@@ -40,7 +40,7 @@ type MetaTagRecordUpsertResult struct {
 
 type IndexMetaTagRecordUpsert struct {
 	OrgId       uint32   `json:"orgId" binding:"Required"`
-	MetaTags    []string `json:"metaTags" binding:"Required"`
+	MetaTags    []string `json:"metaTags"`
 	Expressions []string `json:"expressions" binding:"Required"`
 }
 


### PR DESCRIPTION
This fixes a bug.

Specifying meta tags in upsert requests must be optional, because if none are specified then this results in the deletion of an existing meta record. This behavior is documented here:

https://github.com/grafana/metrictank/blob/master/docs/http-api.md#adding-updating-deleting-meta-records