### PR TITLE
lower default max chunk cache size to 512MB

### DIFF
--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -202,9 +202,9 @@ buffer-size = 20000
 
 ## chunk cache ##
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 
 ## http api ##
 [http]

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -202,9 +202,9 @@ buffer-size = 20000
 
 ## chunk cache ##
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 
 ## http api ##
 [http]

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -202,9 +202,9 @@ buffer-size = 20000
 
 ## chunk cache ##
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 
 ## http api ##
 [http]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -202,9 +202,9 @@ buffer-size = 20000
 
 ## chunk cache ##
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 
 ## http api ##
 [http]

--- a/docs/config.md
+++ b/docs/config.md
@@ -248,9 +248,9 @@ buffer-size = 20000
 
 ```
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 ```
 
 ## http api ##

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -24,8 +24,8 @@ var (
 
 func init() {
 	flags := flag.NewFlagSet("chunk-cache", flag.ExitOnError)
-	// (1024 ^ 3) * 4 = 4294967296 = 4G
-	flags.Uint64Var(&maxSize, "max-size", 4294967296, "Maximum size of chunk cache in bytes. 0 disables cache")
+	// 512 MB = (1024 ^ 2) * 512 = 536870912
+	flags.Uint64Var(&maxSize, "max-size", 536870912, "Maximum size of chunk cache in bytes. 0 disables cache")
 	globalconf.Register("chunk-cache", flags, flag.ExitOnError)
 }
 

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -205,9 +205,9 @@ buffer-size = 20000
 
 ## chunk cache ##
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 
 ## http api ##
 [http]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -202,9 +202,9 @@ buffer-size = 20000
 
 ## chunk cache ##
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 
 ## http api ##
 [http]

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -202,9 +202,9 @@ buffer-size = 20000
 
 ## chunk cache ##
 [chunk-cache]
-# maximum size of chunk cache in bytes. (1024 ^ 3) * 4 = 4294967296 = 4G
+# maximum size of chunk cache in bytes. 512 MB = (1024 ^ 2) * 512 = 536870912
 # 0 disables cache
-max-size = 4294967296
+max-size = 536870912
 
 ## http api ##
 [http]


### PR DESCRIPTION
4GB by default is too much. most deployments will keep filling their
cache with chunks that become stale.