### PR TITLE
[WIP] Regularly reload meta records

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -619,7 +619,7 @@ func (s *Server) indexMetaTagRecordUpsert(ctx *middleware.Context, req models.In
 		return
 	}
 
-	result, created, err := s.MetricIndex.MetaTagRecordUpsert(req.OrgId, record)
+	result, created, err := s.MetricIndex.MetaTagRecordUpsert(req.OrgId, record, false)
 	if err != nil {
 		response.Write(ctx, response.WrapError(err))
 		return

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -648,7 +648,7 @@ func (s *Server) indexMetaTagRecordSwap(ctx *middleware.Context, req models.Inde
 		}
 	}
 
-	added, deleted, err := s.MetricIndex.MetaTagRecordSwap(req.OrgId, metaTagRecords)
+	added, deleted, err := s.MetricIndex.MetaTagRecordSwap(req.OrgId, metaTagRecords, false)
 	if err != nil {
 		response.Write(ctx, response.WrapError(fmt.Errorf("Error when swapping meta tag records: %s", err)))
 		return

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1436,7 +1436,7 @@ func (s *Server) metaTagRecordSwap(ctx *middleware.Context, swapRequest models.M
 	var added, deleted uint32
 	if s.MetricIndex != nil {
 		var err error
-		added, deleted, err = s.MetricIndex.MetaTagRecordSwap(ctx.OrgId, metaTagRecords)
+		added, deleted, err = s.MetricIndex.MetaTagRecordSwap(ctx.OrgId, metaTagRecords, swapRequest.Propagate)
 		if err != nil {
 			response.Write(ctx, response.WrapError(err))
 			return

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1361,7 +1361,7 @@ func (s *Server) metaTagRecordUpsert(ctx *middleware.Context, upsertRequest mode
 	var created bool
 	if s.MetricIndex != nil {
 		var err error
-		localResult, created, err = s.MetricIndex.MetaTagRecordUpsert(ctx.OrgId, record)
+		localResult, created, err = s.MetricIndex.MetaTagRecordUpsert(ctx.OrgId, record, upsertRequest.Propagate)
 		if err != nil {
 			response.Write(ctx, response.WrapError(err))
 			return

--- a/cmd/mt-index-prune/main.go
+++ b/cmd/mt-index-prune/main.go
@@ -110,7 +110,7 @@ func main() {
 	cassIdx := cassandra.New(cassandra.CliConfig)
 	err = cassIdx.InitBare()
 	perror(err)
-	err = cassIdx.EnsureArchiveTableExists(nil)
+	err = cassIdx.EnsureTableExists(nil, cassIdx.Config.SchemaFile, "schema_archive_table", cassIdx.Config.ArchiveTable)
 	perror(err)
 
 	// we don't want to filter any metric definitions during the loading

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -392,6 +392,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = cassandra:9042
 #cql protocol version to use

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -440,6 +440,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -392,6 +392,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = cassandra:9042
 #cql protocol version to use

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -440,6 +440,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -392,6 +392,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = cassandra:9042
 #cql protocol version to use

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -440,6 +440,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -392,6 +392,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = cassandra:9042
 #cql protocol version to use

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -440,6 +440,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/docs/config.md
+++ b/docs/config.md
@@ -514,6 +514,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/docs/config.md
+++ b/docs/config.md
@@ -463,6 +463,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = localhost:9042
 #cql protocol version to use

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -244,6 +244,9 @@ If the new record has no meta tags associated with it, then an existing record w
 same set of expressions gets deleted.
 When an existing record gets updated the returned property `created` is `false`,
 otherwise it's `true`.
+If the `propagate` argument is `true` and the Metrictank instance which receives this
+upsert request has index updating enabled, the modification will be persisted in the
+persistent index. This is currently only implemented in the Cassandra index.
 
 ## Example
 
@@ -304,6 +307,9 @@ This route is an alternative to the above "upsert". It accepts a list of meta ta
 and replaces all existing records with the new ones. This is useful for users who first
 generate all of their meta tag records and then want to simply replace all the records in
 Metrictank with the generated ones.
+If the `propagate` argument is `true` and the Metrictank instance which receives this swap
+request has index updating enabled, the swap will also be persisted in the persistent
+index. This is currently only implemented in the Cassandra index.
 
 ## Example
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -116,6 +116,8 @@ cass config flags:
     	Number of partitions to load concurrently on startup. (default 1)
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
+  -meta-record-table string
+    	Cassandra table to store meta records. (default "meta_records")
   -num-conns int
     	number of concurrent connections to cassandra (default 10)
   -password string
@@ -257,6 +259,8 @@ cass config flags:
     	Number of partitions to load concurrently on startup. (default 1)
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
+  -meta-record-table string
+    	Cassandra table to store meta records. (default "meta_records")
   -num-conns int
     	number of concurrent connections to cassandra (default 10)
   -password string

--- a/expr/tagquery/expression.go
+++ b/expr/tagquery/expression.go
@@ -59,6 +59,22 @@ func (e Expressions) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Strings())
 }
 
+func (e *Expressions) UnmarshalJSON(data []byte) error {
+	var expressionStrings []string
+	err := json.Unmarshal(data, &expressionStrings)
+	if err != nil {
+		return err
+	}
+
+	parsed, err := ParseExpressions(expressionStrings)
+	if err != nil {
+		return err
+	}
+
+	*e = parsed
+	return nil
+}
+
 // Expression represents one expression inside a query of one or many expressions.
 // It provides all the necessary methods that are required to do a tag lookup from an index keyed by
 // tags & values, such as the type memory.TagIndex or the type memory.metaTagIndex.

--- a/expr/tagquery/tag.go
+++ b/expr/tagquery/tag.go
@@ -77,6 +77,22 @@ func (t Tags) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Strings())
 }
 
+func (t *Tags) UnmarshalJSON(data []byte) error {
+	var tagStrings []string
+	err := json.Unmarshal(data, &tagStrings)
+	if err != nil {
+		return err
+	}
+
+	parsed, err := ParseTags(tagStrings)
+	if err != nil {
+		return err
+	}
+
+	*t = parsed
+	return nil
+}
+
 type Tag struct {
 	Key   string
 	Value string

--- a/expr/tagquery/tag.go
+++ b/expr/tagquery/tag.go
@@ -22,7 +22,7 @@ func ParseTags(tags []string) (Tags, error) {
 		res[i] = tag
 	}
 
-	sort.Sort(res)
+	res.Sort()
 
 	return res, nil
 }
@@ -46,18 +46,18 @@ func ParseTagsFromMetricName(name string) (Tags, error) {
 	}
 
 	res = append(res, Tag{Key: "name", Value: nameValue})
-	sort.Sort(res)
+	res.Sort()
 
 	return res, nil
 }
 
-func (t Tags) Len() int      { return len(t) }
-func (t Tags) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
-func (t Tags) Less(i, j int) bool {
-	if t[i].Key == t[j].Key {
-		return t[i].Value < t[j].Value
-	}
-	return t[i].Key < t[j].Key
+func (t Tags) Sort() {
+	sort.Slice(t, func(i, j int) bool {
+		if t[i].Key == t[j].Key {
+			return t[i].Value < t[j].Value
+		}
+		return t[i].Key < t[j].Key
+	})
 }
 
 func (t Tags) Strings() []string {

--- a/expr/tagquery/tag_test.go
+++ b/expr/tagquery/tag_test.go
@@ -310,3 +310,19 @@ func TestTag_StringIntoBuilder(t *testing.T) {
 		})
 	}
 }
+
+func TestTagSorting(t *testing.T) {
+	tags1 := Tags{Tag{Key: "key1", Value: "value1"}, Tag{Key: "key2", Value: "value2"}}
+	tags2 := Tags{Tag{Key: "key2", Value: "value2"}, Tag{Key: "key1", Value: "value1"}}
+
+	if reflect.DeepEqual(tags1, tags2) {
+		t.Fatalf("Expected tags1 and tags2 to be different")
+	}
+
+	tags1.Sort()
+	tags2.Sort()
+
+	if !reflect.DeepEqual(tags1, tags2) {
+		t.Fatalf("Expected tags1 and tags2 to be the same")
+	}
+}

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -423,22 +423,20 @@ func (c *CasIdx) loadMetaRecords() map[uint32][]tagquery.MetaTagRecord {
 
 func (c *CasIdx) applyMetaRecords(orgId uint32, records []tagquery.MetaTagRecord) {
 	for _, record := range records {
-		_, _, err := c.MemoryIndex.MetaTagRecordUpsert(orgId, record)
+		_, _, err := c.MemoryIndex.MetaTagRecordUpsert(orgId, record, false)
 		if err != nil {
 			log.Errorf("cassandra-idx: applyMetaRecords() failed to apply meta record: %s", err)
 		}
 	}
 }
 
-func (c *CasIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord) (tagquery.MetaTagRecord, bool, error) {
-	record, created, err := c.MemoryIndex.MetaTagRecordUpsert(orgId, upsertRecord)
+func (c *CasIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord, persist bool) (tagquery.MetaTagRecord, bool, error) {
+	record, created, err := c.MemoryIndex.MetaTagRecordUpsert(orgId, upsertRecord, persist)
 	if err != nil {
 		return record, created, err
 	}
 
-	// TODO figure out how to determine which of the MT instances with updateCassIdx == true should flush a given record,
-	// currently they'll all flush it
-	if c.Config.updateCassIdx {
+	if c.Config.updateCassIdx && persist {
 		var err error
 
 		// if a record has no meta tags associated with it, then we delete it

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -517,22 +517,24 @@ func (c *CasIdx) persistMetaRecord(orgId uint32, record tagquery.MetaTagRecord, 
 	now := time.Now().UnixNano() / 1000000
 
 	if created {
-		qry := fmt.Sprintf("INSERT INTO %s (orgid, expressions, metatags, createdat, lastupdate) VALUES (?, ?, ?, ?, ?)", c.Config.MetaRecordTable)
+		qry := fmt.Sprintf("INSERT INTO %s (orgid, expressions, metatags, createdat, lastupdate) VALUES (?, ?, ?, ?, ?) USING TIMESTAMP ?", c.Config.MetaRecordTable)
 		return c.Session.Query(
 			qry,
 			orgId,
 			expressions,
 			metaTags,
 			now,
+			now,
 			now).RetryPolicy(&metaRecordRetryPolicy).Exec()
 	}
 
-	qry := fmt.Sprintf("INSERT INTO %s (orgid, expressions, metatags, lastupdate) VALUES (?, ?, ?, ?)", c.Config.MetaRecordTable)
+	qry := fmt.Sprintf("INSERT INTO %s (orgid, expressions, metatags, lastupdate) VALUES (?, ?, ?, ?) USING TIMESTAMP ?", c.Config.MetaRecordTable)
 	return c.Session.Query(
 		qry,
 		orgId,
 		expressions,
 		metaTags,
+		now,
 		now).RetryPolicy(&metaRecordRetryPolicy).Exec()
 }
 
@@ -542,9 +544,10 @@ func (c *CasIdx) deleteMetaRecord(orgId uint32, record tagquery.MetaTagRecord) e
 		return fmt.Errorf("Failed to marshal record expressions: %s", err)
 	}
 
-	qry := fmt.Sprintf("DELETE FROM %s WHERE orgid=? AND expressions=?", c.Config.MetaRecordTable)
+	qry := fmt.Sprintf("DELETE FROM %s USING TIMESTAMP ? WHERE orgid=? AND expressions=?", c.Config.MetaRecordTable)
 	return c.Session.Query(
 		qry,
+		time.Now().UnixNano()/1000000,
 		orgId,
 		expressions,
 	).RetryPolicy(&metaRecordRetryPolicy).Exec()

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -506,6 +506,7 @@ func (c *CasIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecor
 			if err != nil {
 				return 0, 0, fmt.Errorf("Failed to marshal expressions: %s", err)
 			}
+			record.MetaTags.Sort()
 			metaTags, err = record.MetaTags.MarshalJSON()
 			if err != nil {
 				return 0, 0, fmt.Errorf("Failed to marshal meta tags: %s", err)

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -432,11 +432,9 @@ func (c *CasIdx) loadMetaRecords() map[uint32][]tagquery.MetaTagRecord {
 }
 
 func (c *CasIdx) applyMetaRecords(orgId uint32, records []tagquery.MetaTagRecord) {
-	for _, record := range records {
-		_, _, err := c.MemoryIndex.MetaTagRecordUpsert(orgId, record, false)
-		if err != nil {
-			log.Errorf("cassandra-idx: applyMetaRecords() failed to apply meta record: %s", err)
-		}
+	_, _, err := c.MemoryIndex.MetaTagRecordSwap(orgId, records, false)
+	if err != nil {
+		log.Errorf("cassandra-idx: applyMetaRecords() failed to apply meta record: %s", err)
 	}
 }
 

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -463,7 +463,7 @@ func (c *CasIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTag
 
 func (c *CasIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord, persist bool) (uint32, uint32, error) {
 	added, deleted, err := c.MemoryIndex.MetaTagRecordSwap(orgId, records, persist)
-	if !c.Config.updateCassIdx || err != nil {
+	if !c.Config.updateCassIdx || err != nil || !persist {
 		return added, deleted, err
 	}
 

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -52,10 +52,14 @@ var (
 	statSaveSkipped = stats.NewCounter32("idx.cassandra.save.skipped")
 	errmetrics      = cassandra.NewErrMetrics("idx.cassandra")
 
+	// try executing each query 10 times
+	// when a query fails we retry 9 times with the following sleep times in-between
+	// 100ms, 200ms, 400ms, 800ms, 1.6s, 3.2s, 6.4s, 12.8s, 20s
+	// the total time to fail is 45.5s, which is less than the default http timeout
 	metaRecordRetryPolicy = gocql.ExponentialBackoffRetryPolicy{
-		NumRetries: 10,
-		Min:        time.Millisecond * time.Duration(10),
-		Max:        time.Second,
+		NumRetries: 9,
+		Min:        time.Millisecond * time.Duration(100),
+		Max:        time.Second * time.Duration(20),
 	}
 )
 

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -409,7 +409,11 @@ func (c *CasIdx) rebuildIndex() {
 
 func (c *CasIdx) metaRecordLoader() {
 	c.loadMetaRecordsTicker = make(chan struct{})
-	ticker := time.NewTicker(time.Second * time.Duration(10))
+	if memory.MetaTagRecordReloadInterval == 0 {
+		return
+	}
+
+	ticker := time.NewTicker(memory.MetaTagRecordReloadInterval)
 
 	go func() {
 		defer ticker.Stop()

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -479,6 +479,7 @@ func (c *CasIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecor
 	var qry string
 
 	for _, record := range records {
+		record.Expressions.Sort()
 		expressions, err = record.Expressions.MarshalJSON()
 		if err != nil {
 			return 0, 0, fmt.Errorf("Failed to marshal expressions: %s", err)

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -32,6 +32,7 @@ type IdxConfig struct {
 	Keyspace                 string
 	Table                    string
 	ArchiveTable             string
+	MetaRecordTable          string
 	Hosts                    string
 	CaPath                   string
 	Username                 string
@@ -52,6 +53,7 @@ func NewIdxConfig() *IdxConfig {
 		Keyspace:                 "metrictank",
 		Table:                    "metric_idx",
 		ArchiveTable:             "metric_idx_archive",
+		MetaRecordTable:          "meta_records",
 		Consistency:              "one",
 		Timeout:                  time.Second,
 		NumConns:                 10,
@@ -93,6 +95,7 @@ func ConfigSetup() *flag.FlagSet {
 	casIdx.StringVar(&CliConfig.Keyspace, "keyspace", CliConfig.Keyspace, "Cassandra keyspace to store metricDefinitions in.")
 	casIdx.StringVar(&CliConfig.Table, "table", CliConfig.Table, "Cassandra table to store metricDefinitions in.")
 	casIdx.StringVar(&CliConfig.ArchiveTable, "archive-table", CliConfig.ArchiveTable, "Cassandra table to archive metricDefinitions in.")
+	casIdx.StringVar(&CliConfig.MetaRecordTable, "meta-record-table", CliConfig.MetaRecordTable, "Cassandra table to store meta records.")
 	casIdx.StringVar(&CliConfig.Consistency, "consistency", CliConfig.Consistency, "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
 	casIdx.DurationVar(&CliConfig.Timeout, "timeout", CliConfig.Timeout, "cassandra request timeout")
 	casIdx.IntVar(&CliConfig.NumConns, "num-conns", CliConfig.NumConns, "number of concurrent connections to cassandra")

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -156,7 +156,7 @@ type MetricIndex interface {
 	// 1) The relevant meta record as it is after this operation
 	// 2) A bool that is true if the record has been created, or false if updated
 	// 3) An error which is nil if no error has occurred
-	MetaTagRecordUpsert(orgId uint32, record tagquery.MetaTagRecord) (tagquery.MetaTagRecord, bool, error)
+	MetaTagRecordUpsert(orgId uint32, record tagquery.MetaTagRecord, persist bool) (tagquery.MetaTagRecord, bool, error)
 
 	// MetaTagRecordList takes an org id and returns the list of all meta tag records
 	// of that given org.

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -165,5 +165,5 @@ type MetricIndex interface {
 	// MetaTagRecordSwap takes a set of meta tag records and completely replaces
 	// the existing ones with the new ones.
 	// It returns how many records have been added, deleted and potential errors
-	MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error)
+	MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord, persist bool) (uint32, uint32, error)
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -67,6 +67,7 @@ var (
 	matchCacheSize               = 1000
 	enrichmentCacheSize          = 10000
 	MetaTagSupport               = false
+	MetaTagRecordReloadInterval  = 10 * time.Second
 )
 
 func ConfigSetup() *flag.FlagSet {
@@ -88,6 +89,7 @@ func ConfigSetup() *flag.FlagSet {
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
 	memoryIdx.IntVar(&enrichmentCacheSize, "enrichment-cache-size", 10000, "size of the meta tag enrichment cache")
 	memoryIdx.BoolVar(&MetaTagSupport, "meta-tag-support", false, "enables/disables querying based on meta tags which get defined via meta tag rules")
+	memoryIdx.DurationVar(&MetaTagRecordReloadInterval, "meta-tag-record-reload-interval", 10*time.Second, "the interval at which meta records get reloaded from the backend store")
 	globalconf.Register("memory-idx", memoryIdx, flag.ExitOnError)
 	return memoryIdx
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -511,7 +511,7 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 	return res, true, nil
 }
 
-func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error) {
+func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord, _ bool) (uint32, uint32, error) {
 	if !TagSupport || !MetaTagSupport {
 		log.Warn("memory-idx: received a tag/meta-tag query, but that feature is disabled")
 		return 0, 0, errors.NewBadRequest("Tag/Meta-Tag support is disabled")

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -528,8 +528,6 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagqu
 
 	var addedRecords, deletedRecords uint32
 	for _, record := range records {
-		record.Expressions.Sort()
-
 		recordId, _, _, _, err := newMtr.upsert(record)
 		if err != nil {
 			return 0, 0, err

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -459,7 +459,7 @@ func (m *UnpartitionedMemoryIdx) UpdateArchiveLastSave(id schema.MKey, partition
 // 1) The relevant meta record as it is after this operation
 // 2) A bool that is true if the record has been created, or false if updated
 // 3) An error which is nil if no error has occurred
-func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord) (tagquery.MetaTagRecord, bool, error) {
+func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord, _ bool) (tagquery.MetaTagRecord, bool, error) {
 	res := tagquery.MetaTagRecord{}
 
 	if !TagSupport || !MetaTagSupport {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -66,7 +66,7 @@ var (
 	writeMaxBatchSize            = 5000
 	matchCacheSize               = 1000
 	enrichmentCacheSize          = 10000
-	metaTagSupport               = false
+	MetaTagSupport               = false
 )
 
 func ConfigSetup() *flag.FlagSet {
@@ -87,7 +87,7 @@ func ConfigSetup() *flag.FlagSet {
 	memoryIdx.StringVar(&maxPruneLockTimeStr, "max-prune-lock-time", "100ms", "Maximum duration each second a prune job can lock the index.")
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
 	memoryIdx.IntVar(&enrichmentCacheSize, "enrichment-cache-size", 10000, "size of the meta tag enrichment cache")
-	memoryIdx.BoolVar(&metaTagSupport, "meta-tag-support", false, "enables/disables querying based on meta tags which get defined via meta tag rules")
+	memoryIdx.BoolVar(&MetaTagSupport, "meta-tag-support", false, "enables/disables querying based on meta tags which get defined via meta tag rules")
 	globalconf.Register("memory-idx", memoryIdx, flag.ExitOnError)
 	return memoryIdx
 }
@@ -114,7 +114,7 @@ func ConfigProcess() {
 		log.Fatal("find-cache-invalidate-max-size should be smaller than find-cache-invalidate-queue-size")
 	}
 
-	tagquery.MetaTagSupport = metaTagSupport
+	tagquery.MetaTagSupport = MetaTagSupport
 	tagquery.MatchCacheSize = matchCacheSize
 }
 
@@ -462,7 +462,7 @@ func (m *UnpartitionedMemoryIdx) UpdateArchiveLastSave(id schema.MKey, partition
 func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord) (tagquery.MetaTagRecord, bool, error) {
 	res := tagquery.MetaTagRecord{}
 
-	if !TagSupport || !metaTagSupport {
+	if !TagSupport || !MetaTagSupport {
 		log.Warn("memory-idx: received tag/meta-tag query, but that feature is disabled")
 		return res, false, errors.NewBadRequest("Tag/Meta-Tag support is disabled")
 	}
@@ -512,7 +512,7 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 }
 
 func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error) {
-	if !TagSupport || !metaTagSupport {
+	if !TagSupport || !MetaTagSupport {
 		log.Warn("memory-idx: received a tag/meta-tag query, but that feature is disabled")
 		return 0, 0, errors.NewBadRequest("Tag/Meta-Tag support is disabled")
 	}
@@ -836,7 +836,7 @@ func (m *UnpartitionedMemoryIdx) FindByTag(orgId uint32, query tagquery.Query) [
 	}
 
 	var enricher *enricher
-	if metaTagSupport {
+	if MetaTagSupport {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
 			enricher = mtr.getEnricher(tagIndex.idHasTag)
@@ -911,7 +911,7 @@ func (m *UnpartitionedMemoryIdx) Tags(orgId uint32, filter *regexp.Regexp) []str
 		res = append(res, tag)
 	}
 
-	if !metaTagSupport {
+	if !MetaTagSupport {
 		sort.Strings(res)
 		return res
 	}
@@ -958,7 +958,7 @@ func (m *UnpartitionedMemoryIdx) TagDetails(orgId uint32, key string, filter *re
 		res[value] += uint64(len(ids))
 	}
 
-	if !metaTagSupport {
+	if !MetaTagSupport {
 		return res
 	}
 
@@ -1030,7 +1030,7 @@ func (m *UnpartitionedMemoryIdx) FindTags(orgId uint32, prefix string, limit uin
 		}
 	}
 
-	if !metaTagSupport {
+	if !MetaTagSupport {
 		return m.finalizeResult(res, limit, false)
 	}
 
@@ -1074,7 +1074,7 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 	resMap := make(map[string]struct{})
 
 	var enricher *enricher
-	if metaTagSupport {
+	if MetaTagSupport {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
 			enricher = mtr.getEnricher(tags.idHasTag)
@@ -1153,7 +1153,7 @@ func (m *UnpartitionedMemoryIdx) FindTagValues(orgId uint32, tag, prefix string,
 		}
 	}
 
-	if !metaTagSupport {
+	if !MetaTagSupport {
 		return m.finalizeResult(res, limit, false)
 	}
 
@@ -1192,7 +1192,7 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 	resMap := make(map[string]struct{})
 
 	var enricher *enricher
-	if metaTagSupport {
+	if MetaTagSupport {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
 			enricher = mtr.getEnricher(tags.idHasTag)

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -471,6 +471,10 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 	var mti metaTagIndex
 	var ok bool
 
+	// expressions need to be sorted because the unique ID of a meta record is
+	// its sorted set of expressions
+	upsertRecord.Expressions.Sort()
+
 	m.Lock()
 	defer m.Unlock()
 
@@ -522,6 +526,8 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagqu
 
 	var addedRecords, deletedRecords uint32
 	for _, record := range records {
+		record.Expressions.Sort()
+
 		recordId, _, _, _, err := newMtr.upsert(record)
 		if err != nil {
 			return 0, 0, err

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -540,10 +540,21 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagqu
 		addedRecords++
 	}
 
+	m.RLock()
+	oldMtr, ok := m.metaTagRecords[orgId]
+	if ok {
+		if oldMtr.hashRecords() == newMtr.hashRecords() {
+			// the old and the new records are the same, so there is no need to change anyting
+			m.RUnlock()
+			return 0, 0, nil
+		}
+	}
+
+	m.RUnlock()
 	m.Lock()
 	defer m.Unlock()
 
-	oldMtr, ok := m.metaTagRecords[orgId]
+	oldMtr, ok = m.metaTagRecords[orgId]
 	if ok {
 		deletedRecords = uint32(len(oldMtr.records))
 	}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -368,7 +368,7 @@ func testTagDetailsWithMetaTagSupportWithoutFilter(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "dc", Value: "all"}},
 		Expressions: tagquery.Expressions{metaRecordExpression},
-	})
+	}, false)
 
 	expected := make(map[string]uint64)
 	expected["all"] = 168000
@@ -399,7 +399,7 @@ func testTagDetailsWithMetaTagSupportWithFilter(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "dc", Value: "dc5"}},
 		Expressions: tagquery.Expressions{metaRecordExpression},
-	})
+	}, false)
 
 	expected := make(map[string]uint64)
 	expected["dc3"] = 33600
@@ -476,11 +476,11 @@ func testTagKeysWithMetaTagSupportWithFilter(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "directionMeta", Value: "read"}},
 		Expressions: tagquery.Expressions{metaRecordExpression},
-	})
+	}, false)
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "directionMeta2", Value: "read"}},
 		Expressions: tagquery.Expressions{metaRecordExpression},
-	})
+	}, false)
 
 	expected := []string{"dc", "device", "disk", "direction", "directionMeta", "directionMeta2"}
 	queryAndCompareTagKeys(t, "d", expected)
@@ -508,7 +508,7 @@ func testTagKeysWithMetaTagSupportWithoutFilters(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "all", Value: "metrics"}},
 		Expressions: tagquery.Expressions{metaRecordExpression},
-	})
+	}, false)
 
 	expected := []string{"all", "dc", "host", "device", "cpu", "metric", "direction", "disk", "name"}
 	queryAndCompareTagKeys(t, "", expected)
@@ -638,7 +638,7 @@ func testAutoCompleteTagsWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "host2", Value: "all"}},
 		Expressions: tagquery.Expressions{metaRecordExpression1},
-	})
+	}, false)
 
 	metaRecordExpression2, err := tagquery.ParseExpression("name=~.+")
 	if err != nil {
@@ -647,7 +647,7 @@ func testAutoCompleteTagsWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "all", Value: "metrics"}},
 		Expressions: tagquery.Expressions{metaRecordExpression2},
-	})
+	}, false)
 
 	type testCase struct {
 		prefix string
@@ -767,7 +767,7 @@ func testAutoCompleteTagsWithQueryWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "another", Value: "tag"}, tagquery.Tag{Key: "meta", Value: "tag"}},
 		Expressions: tagquery.Expressions{metaRecordExpression},
-	})
+	}, false)
 
 	type testCase struct {
 		prefix string
@@ -878,7 +878,7 @@ func testAutoCompleteTagValuesWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "metric", Value: "all"}},
 		Expressions: tagquery.Expressions{metaRecordExpression1},
-	})
+	}, false)
 
 	metaRecordExpression2, err := tagquery.ParseExpression("metric=~disk_.+")
 	if err != nil {
@@ -887,7 +887,7 @@ func testAutoCompleteTagValuesWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "metric", Value: "disk_all"}},
 		Expressions: tagquery.Expressions{metaRecordExpression2},
-	})
+	}, false)
 
 	metaRecordExpression3, err := tagquery.ParseExpression("name!=")
 	if err != nil {
@@ -896,7 +896,7 @@ func testAutoCompleteTagValuesWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "meta1", Value: "all_metrics"}},
 		Expressions: tagquery.Expressions{metaRecordExpression3},
-	})
+	}, false)
 
 	type testCase struct {
 		tag    string
@@ -1025,7 +1025,7 @@ func testAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "direction", Value: "none"}},
 		Expressions: tagquery.Expressions{metaRecordExpression1},
-	})
+	}, false)
 
 	metaRecordExpression2, err := tagquery.ParseExpression("name!=")
 	if err != nil {
@@ -1034,7 +1034,7 @@ func testAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {
 	ix.MetaTagRecordUpsert(1, tagquery.MetaTagRecord{
 		MetaTags:    tagquery.Tags{tagquery.Tag{Key: "all", Value: "metrics"}},
 		Expressions: tagquery.Expressions{metaRecordExpression2},
-	})
+	}, false)
 
 	type testCase struct {
 		tag    string

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -1047,7 +1047,7 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 		t.Fatalf("Unexpected error when parsing meta tag record: %q", err)
 	}
 
-	createdRecord, created, err := ix.MetaTagRecordUpsert(1, record1)
+	createdRecord, created, err := ix.MetaTagRecordUpsert(1, record1, false)
 	if err != nil {
 		t.Fatalf("Unexpected error when upserting meta tag record: %q", err)
 	}
@@ -1058,7 +1058,7 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 		t.Fatalf("Expected returned record to look same as added record, but it does not:\nExpected:\n%+v\nGot:\n%+v\n", record1, createdRecord)
 	}
 
-	createdRecord, created, err = ix.MetaTagRecordUpsert(1, record2)
+	createdRecord, created, err = ix.MetaTagRecordUpsert(1, record2, false)
 	if err != nil {
 		t.Fatalf("Unexpected error when upserting meta tag record: %q", err)
 	}
@@ -1106,7 +1106,7 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 	}
 
 	// record3 has the same queries as record2, so it should completely replace it
-	createdRecord, created, err = ix.MetaTagRecordUpsert(1, record3)
+	createdRecord, created, err = ix.MetaTagRecordUpsert(1, record3, false)
 	if err != nil {
 		t.Fatalf("Unexpected error when upserting meta tag record: %q", err)
 	}

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -34,7 +34,7 @@ func getTestIndexWithMetaTags(t testing.TB, metaTags []tagquery.MetaTagRecord, c
 	}
 
 	for i := range metaTags {
-		idx.MetaTagRecordUpsert(1, metaTags[i])
+		idx.MetaTagRecordUpsert(1, metaTags[i], false)
 	}
 
 	return idx, mkeys

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -13,13 +13,13 @@ import (
 // before enableMetaTagSupport was called
 func enableMetaTagSupport() func() {
 	_tagSupport := TagSupport
-	_metaTagSupport := metaTagSupport
+	_metaTagSupport := MetaTagSupport
 	TagSupport = true
-	metaTagSupport = true
+	MetaTagSupport = true
 	tagquery.MetaTagSupport = true
 	return func() {
 		TagSupport = _tagSupport
-		metaTagSupport = _metaTagSupport
+		MetaTagSupport = _metaTagSupport
 		tagquery.MetaTagSupport = _metaTagSupport
 	}
 }
@@ -28,11 +28,11 @@ func enableMetaTagSupport() func() {
 // modify the tag-support feature flag
 // it returns a function to reset the meta-tag-support to the previous setting
 func disableMetaTagSupport() func() {
-	_metaTagSupport := metaTagSupport
-	metaTagSupport = false
+	_metaTagSupport := MetaTagSupport
+	MetaTagSupport = false
 	tagquery.MetaTagSupport = false
 	return func() {
-		metaTagSupport = _metaTagSupport
+		MetaTagSupport = _metaTagSupport
 		tagquery.MetaTagSupport = _metaTagSupport
 	}
 }

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -520,7 +520,7 @@ func (p *PartitionedMemoryIdx) MetaTagRecordList(orgId uint32) []tagquery.MetaTa
 	return nil
 }
 
-func (p *PartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, rawRecord tagquery.MetaTagRecord) (tagquery.MetaTagRecord, bool, error) {
+func (p *PartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, rawRecord tagquery.MetaTagRecord, persist bool) (tagquery.MetaTagRecord, bool, error) {
 	g, _ := errgroup.WithContext(context.Background())
 
 	var i int
@@ -531,9 +531,9 @@ func (p *PartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, rawRecord tagqu
 		g.Go(func() error {
 			var err error
 			if partNum == 0 {
-				record, created, err = m.MetaTagRecordUpsert(orgId, rawRecord)
+				record, created, err = m.MetaTagRecordUpsert(orgId, rawRecord, persist)
 			} else {
-				_, _, err = m.MetaTagRecordUpsert(orgId, rawRecord)
+				_, _, err = m.MetaTagRecordUpsert(orgId, rawRecord, persist)
 			}
 
 			return err

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -549,7 +549,7 @@ func (p *PartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, rawRecord tagqu
 	return record, created, nil
 }
 
-func (p *PartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) (uint32, uint32, error) {
+func (p *PartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord, persist bool) (uint32, uint32, error) {
 	g, _ := errgroup.WithContext(context.Background())
 
 	results := make([]struct {
@@ -562,7 +562,7 @@ func (p *PartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquer
 		m, partNum := m, i
 		g.Go(func() error {
 			var err error
-			results[partNum].added, results[partNum].deleted, err = m.MetaTagRecordSwap(orgId, records)
+			results[partNum].added, results[partNum].deleted, err = m.MetaTagRecordSwap(orgId, records, persist)
 			return err
 		})
 		i++

--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -53,7 +53,7 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 			defaultDecision:  expr.GetDefaultDecision(),
 		}
 
-		if !metaTagSupport {
+		if !MetaTagSupport {
 			continue
 		}
 

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -92,7 +92,7 @@ func testFilterByMetaTagWithEqual(t *testing.T) {
 
 	_, mds := getTestArchives(10)
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch := []schema.MetricDefinition{mds[3], mds[5], mds[6]}
 		expectedFail := append(append(mds[:3], mds[4]), mds[7:]...)
 
@@ -142,7 +142,7 @@ func testFilterByMetaTagWithNotEqualAndWithNotHasTag(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[0], mds[1], mds[2], mds[4], mds[7], mds[8], mds[9]}
 		expectedFail = []schema.MetricDefinition{mds[3], mds[5], mds[6]}
 	} else {
@@ -192,7 +192,7 @@ func testFilterByMetaTagWithEqualAndWithHasTag(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[3], mds[5], mds[6]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[2], mds[4], mds[7], mds[8], mds[9]}
 	} else {
@@ -267,7 +267,7 @@ func testFilterByMetaTagWithPatternMatching(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[2], mds[3]}
 		expectedFail = append(mds[:2], mds[4:]...)
 	} else {
@@ -327,7 +327,7 @@ func testFilterByMetaTagWithTagOperators(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[7], mds[9]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[2], mds[3], mds[4], mds[5], mds[6], mds[8]}
 	} else {
@@ -413,7 +413,7 @@ func testFilterByMultipleOfManyMetaTagValues(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[2], mds[3], mds[4], mds[5]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[6], mds[7], mds[8], mds[9]}
 	} else {
@@ -497,7 +497,7 @@ func testFilterByMultipleOfManyMetaTags(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[2], mds[3]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[1], mds[4], mds[5], mds[6], mds[7], mds[8], mds[9]}
 	} else {
@@ -561,7 +561,7 @@ func testFilterByOverlappingMetaTags(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[1]}
 		expectedFail = append(mds[2:], mds[0])
 	} else {
@@ -613,7 +613,7 @@ func testFilterSubtractingMetricTagsFromMetaTag(t *testing.T) {
 	var expectedMatch []schema.MetricDefinition
 	var expectedFail []schema.MetricDefinition
 
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedMatch = []schema.MetricDefinition{mds[1], mds[3], mds[5]}
 		expectedFail = []schema.MetricDefinition{mds[0], mds[2], mds[4], mds[6], mds[7], mds[8], mds[9]}
 	} else {

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -20,7 +20,7 @@ func filterAndCompareResults(t *testing.T, expressions tagquery.Expressions, met
 	}
 
 	for i := range metaRecords {
-		index.MetaTagRecordUpsert(1, metaRecords[i])
+		index.MetaTagRecordUpsert(1, metaRecords[i], false)
 	}
 
 	ctx := &TagQueryContext{

--- a/idx/memory/tag_query_id_selector.go
+++ b/idx/memory/tag_query_id_selector.go
@@ -53,7 +53,7 @@ func (i *idSelector) getIds() (chan schema.MKey, chan struct{}) {
 	// i.rawResCh and deduplicates its ids before inserting them into i.resCh.
 	// if meta tag support is not enabled, then this is not necessary and we don't
 	// need to start the deduplication routine.
-	if metaTagSupport {
+	if MetaTagSupport {
 		go i.deduplicateRawResults()
 	}
 
@@ -70,7 +70,7 @@ func (i *idSelector) getIds() (chan schema.MKey, chan struct{}) {
 
 	// if meta tag support is enabled we return i.resCh because that channel has
 	// been deduplicated by i.deduplicateRawResults()
-	if metaTagSupport {
+	if MetaTagSupport {
 		return i.resCh, i.stopCh
 	}
 
@@ -108,7 +108,7 @@ func (i *idSelector) byTagValue() {
 	// otherwise we'd risk to create a loop of sub queries creating
 	// each other
 	// same when meta tag support is disabled in the config
-	if !metaTagSupport || i.ctx.subQuery {
+	if !MetaTagSupport || i.ctx.subQuery {
 		i.workerWg.Done()
 		return
 	}
@@ -203,7 +203,7 @@ func (i *idSelector) byTag() {
 	// otherwise we'd risk to create a loop of sub queries creating
 	// each other
 	// same when meta tag support is disabled in the config
-	if !metaTagSupport || i.ctx.subQuery {
+	if !MetaTagSupport || i.ctx.subQuery {
 		i.workerWg.Done()
 		return
 	}

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -117,7 +117,7 @@ func testSelectByMetaTag(t *testing.T) {
 
 	// with meta tag support disabled we expect an empty result set
 	expectedRes := make(IdSet)
-	if metaTagSupport {
+	if MetaTagSupport {
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[5].Id: struct{}{}}
 	}
 
@@ -157,7 +157,7 @@ func testSelectByMetaTagAndMetricTagUsingSameKeyAndValue(t *testing.T) {
 	}
 
 	var expectedRes IdSet
-	if metaTagSupport {
+	if MetaTagSupport {
 		// if meta tag support is enabled we expect mds[3] to get returned based on its metric tag tag1=value3
 		// and we also expect mds[4] to get returned based on its associated meta tag tag1=value3
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[4].Id: struct{}{}}
@@ -203,7 +203,7 @@ func testSelectByMetaTagAndMetricTagUsingDifferentKeyAndValue(t *testing.T) {
 	}
 
 	var expectedRes IdSet
-	if metaTagSupport {
+	if MetaTagSupport {
 		// if meta tag support is enabled we expect mds[3] to get returned based on its metric tag tag1=value2.3
 		// and we also expect mds[4] to get returned based on its associated meta tag tag1=value3
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[4].Id: struct{}{}}
@@ -249,7 +249,7 @@ func testSelectMetaTagWhichConflictsMetricTag(t *testing.T) {
 	}
 
 	var expectedRes IdSet
-	if metaTagSupport {
+	if MetaTagSupport {
 		// if meta tag support is enabled we expect mds[3] to get returned based on its metric tag tag1=value2.3
 		// and we also expect mds[4] to get returned based on its associated meta tag tag1=value3
 		expectedRes = IdSet{mds[3].Id: struct{}{}, mds[4].Id: struct{}{}, mds[5].Id: struct{}{}}

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -42,7 +42,7 @@ func selectAndCompareResults(t *testing.T, expression tagquery.Expression, metaR
 	}
 
 	for i := range metaRecords {
-		index.MetaTagRecordUpsert(1, metaRecords[i])
+		index.MetaTagRecordUpsert(1, metaRecords[i], false)
 	}
 
 	ctx := &TagQueryContext{

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -443,6 +443,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -395,6 +395,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = localhost:9042
 #cql protocol version to use

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -392,6 +392,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = cassandra:9042
 #cql protocol version to use

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -440,6 +440,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -392,6 +392,8 @@ keyspace = metrictank
 table = metric_idx
 # Cassandra table to archive metricDefinitions in.
 archive-table = metric_idx_archive
+# Cassandra table to store meta records.
+meta-record-table = meta_records
 # comma separated list of cassandra addresses in host:port form
 hosts = localhost:9042
 #cql protocol version to use

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -440,6 +440,8 @@ enabled = false
 tag-support = false
 # enables/disables querying based on meta tags
 meta-tag-support = false
+# the interval at which meta records get reloaded from the backend store
+meta-tag-record-reload-interval = 10s
 # number of workers to spin up to evaluate tag queries
 tag-query-workers = 50
 # size of regular expression cache in tag query evaluation

--- a/scripts/config/schema-idx-cassandra.toml
+++ b/scripts/config/schema-idx-cassandra.toml
@@ -42,6 +42,6 @@ CREATE TABLE IF NOT EXISTS %s.%s (
     metatags text,
     createdat bigint,
     lastupdate bigint,
-    PRIMARY KEY ((orgid, expressions))
+    PRIMARY KEY (orgid, expressions)
 )
 """

--- a/scripts/config/schema-idx-cassandra.toml
+++ b/scripts/config/schema-idx-cassandra.toml
@@ -40,7 +40,6 @@ CREATE TABLE IF NOT EXISTS %s.%s (
     orgid int,
     expressions text,
     metatags text,
-    createdat bigint,
     lastupdate bigint,
     PRIMARY KEY (orgid, expressions)
 )

--- a/scripts/config/schema-idx-cassandra.toml
+++ b/scripts/config/schema-idx-cassandra.toml
@@ -34,3 +34,14 @@ CREATE TABLE IF NOT EXISTS %s.%s (
 ) WITH compaction = {'class': 'SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
 """
+
+schema_meta_record_table = """
+CREATE TABLE IF NOT EXISTS %s.%s (
+    orgid int,
+    expressions text,
+    metatags text,
+    createdat bigint,
+    lastupdate bigint,
+    PRIMARY KEY ((orgid, expressions))
+)
+"""


### PR DESCRIPTION
This PR is based on the branch of #1471. Reviewing it only makes sense if #1471 has already been merged.

Implements the functionality to reload the meta records from the Cassandra store at a defined interval, this is necessary for reaching consistency eventually. Additionally, it adds a method to hash all present meta records and compare the hashes between sets of meta records, this is necessary to avoid clearing the enrichment cache when none of the meta records have changed.