### PR TITLE
Rollup indicator

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -352,17 +352,18 @@ func (s *Server) getTarget(ctx context.Context, ss *models.StorageStats, req mod
 		QueryTo:      req.To,
 		QueryCons:    req.ConsReq,
 		Consolidator: req.Consolidator,
-		Meta:         make(map[models.SeriesMetaProperties]uint32),
+		Meta: []models.SeriesMetaProperties{
+			{
+				// note that for simplicity, we pretend that a read of rollup avg data is a read of 1 "avg series"
+				// rather than a runtime divide of 2 series
+				SchemaID:              req.SchemaId,
+				Archive:               req.Archive,
+				AggNumNorm:            req.AggNum,
+				ConsolidatorNormFetch: req.Consolidator,
+				Count:                 1,
+			},
+		},
 	}
-	// note that for simplicity, we pretend that a read of rollup avg data is a read of 1 "avg series"
-	// rather than a runtime divide of 2 series
-	props := models.SeriesMetaProperties{
-		SchemaID:              req.SchemaId,
-		Archive:               req.Archive,
-		AggNumNorm:            req.AggNum,
-		ConsolidatorNormFetch: req.Consolidator,
-	}
-	out.Meta[props] = 1
 
 	// the easy case: we're reading the raw data.
 	if req.Archive == 0 {
@@ -661,7 +662,7 @@ func mergeSeries(in []models.Series) []models.Series {
 			}
 			merged[i] = series[0]
 			for j := 1; j < len(series); j++ {
-				merged[i].Meta.Merge(series[j].Meta)
+				merged[i].Meta = merged[i].Meta.Merge(series[j].Meta)
 			}
 		}
 		i++

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -352,7 +352,17 @@ func (s *Server) getTarget(ctx context.Context, ss *models.StorageStats, req mod
 		QueryTo:      req.To,
 		QueryCons:    req.ConsReq,
 		Consolidator: req.Consolidator,
+		Meta:         make(map[models.SeriesMetaProperties]uint32),
 	}
+	// note that for simplicity, we pretend that a read of rollup avg data is a read of 1 "avg series"
+	// rather than a runtime divide of 2 series
+	props := models.SeriesMetaProperties{
+		SchemaID:              req.SchemaId,
+		Archive:               req.Archive,
+		AggNumNorm:            req.AggNum,
+		ConsolidatorNormFetch: req.Consolidator,
+	}
+	out.Meta[props] = 1
 
 	// the easy case: we're reading the raw data.
 	if req.Archive == 0 {
@@ -650,6 +660,9 @@ func mergeSeries(in []models.Series) []models.Series {
 				pointSlicePool.Put(series[j].Datapoints[:0])
 			}
 			merged[i] = series[0]
+			for j := 1; j < len(series); j++ {
+				merged[i].Meta.Merge(series[j].Meta)
+			}
 		}
 		i++
 	}

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -602,7 +602,7 @@ func reqRaw(key schema.MKey, from, to, maxPoints, rawInterval uint32, consolidat
 	req.Archive = 0
 	return req
 }
-func reqOut(key schema.MKey, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator, schemaId, aggId uint16, archive int, archInterval, ttl, outInterval, aggNum uint32) models.Req {
+func reqOut(key schema.MKey, from, to, maxPoints, rawInterval uint32, consolidator consolidation.Consolidator, schemaId, aggId uint16, archive uint8, archInterval, ttl, outInterval, aggNum uint32) models.Req {
 	req := models.NewReq(key, "", "", from, to, maxPoints, rawInterval, consolidator, 0, cluster.Manager.ThisNode(), schemaId, aggId)
 	req.Archive = archive
 	req.ArchInterval = archInterval

--- a/api/models/graphite_render_meta.go
+++ b/api/models/graphite_render_meta.go
@@ -15,7 +15,7 @@ func (rwm ResponseWithMeta) MarshalJSONFast(b []byte) ([]byte, error) {
 	b = append(b, `{"version":"v0.1","meta":`...)
 	b, _ = rwm.Meta.MarshalJSONFast(b)
 	b = append(b, `,"series":`...)
-	b, _ = rwm.Series.MarshalJSONFast(b)
+	b, _ = rwm.Series.MarshalJSONFastWithMeta(b)
 	b = append(b, '}')
 	return b, nil
 }

--- a/api/models/request.go
+++ b/api/models/request.go
@@ -35,33 +35,29 @@ type Req struct {
 	SchemaId uint16                     `json:"schemaId"`
 	AggId    uint16                     `json:"aggId"`
 
-	// these fields need some more coordination and are typically set later
-	Archive      int    `json:"archive"`      // 0 means original data, 1 means first agg level, 2 means 2nd, etc.
+	// these fields need some more coordination and are typically set later (after request alignment)
+	Archive      uint8  `json:"archive"`      // 0 means original data, 1 means first agg level, 2 means 2nd, etc.
 	ArchInterval uint32 `json:"archInterval"` // the interval corresponding to the archive we'll fetch
 	TTL          uint32 `json:"ttl"`          // the ttl of the archive we'll fetch
 	OutInterval  uint32 `json:"outInterval"`  // the interval of the output data, after any runtime consolidation
 	AggNum       uint32 `json:"aggNum"`       // how many points to consolidate together at runtime, after fetching from the archive (normalization)
 }
 
+// NewReq creates a new request. It sets all properties minus the ones that need request alignment
 func NewReq(key schema.MKey, target, patt string, from, to, maxPoints, rawInterval uint32, cons, consReq consolidation.Consolidator, node cluster.Node, schemaId, aggId uint16) Req {
 	return Req{
-		key,
-		target,
-		patt,
-		from,
-		to,
-		maxPoints,
-		rawInterval,
-		cons,
-		consReq,
-		node,
-		schemaId,
-		aggId,
-		-1, // this is supposed to be updated still!
-		0,  // this is supposed to be updated still
-		0,  // this is supposed to be updated still
-		0,  // this is supposed to be updated still
-		0,  // this is supposed to be updated still
+		MKey:         key,
+		Target:       target,
+		Pattern:      patt,
+		From:         from,
+		To:           to,
+		MaxPoints:    maxPoints,
+		RawInterval:  rawInterval,
+		Consolidator: cons,
+		ConsReq:      consReq,
+		Node:         node,
+		SchemaId:     schemaId,
+		AggId:        aggId,
 	}
 }
 
@@ -83,20 +79,20 @@ func (r Req) TraceLog(span opentracing.Span) {
 		log.Object("key", r.MKey),
 		log.String("target", r.Target),
 		log.String("pattern", r.Pattern),
-		log.Int("from", int(r.From)),
-		log.Int("to", int(r.To)),
-		log.Int("span", int(r.To-r.From-1)),
-		log.Int("mdp", int(r.MaxPoints)),
-		log.Int("rawInterval", int(r.RawInterval)),
+		log.Uint32("from", r.From),
+		log.Uint32("to", r.To),
+		log.Uint32("span", r.To-r.From-1),
+		log.Uint32("mdp", r.MaxPoints),
+		log.Uint32("rawInterval", r.RawInterval),
 		log.String("cons", r.Consolidator.String()),
 		log.String("consReq", r.ConsReq.String()),
-		log.Int("schemaId", int(r.SchemaId)),
-		log.Int("aggId", int(r.AggId)),
-		log.Int("archive", r.Archive),
-		log.Int("archInterval", int(r.ArchInterval)),
-		log.Int("TTL", int(r.TTL)),
-		log.Int("outInterval", int(r.OutInterval)),
-		log.Int("aggNum", int(r.AggNum)),
+		log.Uint32("schemaId", uint32(r.SchemaId)),
+		log.Uint32("aggId", uint32(r.AggId)),
+		log.Uint32("archive", uint32(r.Archive)),
+		log.Uint32("archInterval", r.ArchInterval),
+		log.Uint32("TTL", r.TTL),
+		log.Uint32("outInterval", r.OutInterval),
+		log.Uint32("aggNum", r.AggNum),
 	)
 }
 

--- a/api/models/series.go
+++ b/api/models/series.go
@@ -18,7 +18,6 @@ import (
 type Series struct {
 	Target       string            // for fetched data, set from models.Req.Target, i.e. the metric graphite key. for function output, whatever should be shown as target string (legend)
 	Tags         map[string]string // Must be set initially via call to `SetTags()`
-	Datapoints   []schema.Point
 	Interval     uint32
 	QueryPatt    string                     // to tie series back to request it came from. e.g. foo.bar.*, or if series outputted by func it would be e.g. scale(foo.bar.*,0.123456)
 	QueryFrom    uint32                     // to tie series back to request it came from
@@ -26,6 +25,7 @@ type Series struct {
 	QueryCons    consolidation.Consolidator // to tie series back to request it came from (may be 0 to mean use configured default)
 	Consolidator consolidation.Consolidator // consolidator to actually use (for fetched series this may not be 0, default must be resolved. if series created by function, may be 0)
 	Meta         SeriesMeta                 // note: this series could be a "just fetched" series, or one derived from many other series
+	Datapoints   []schema.Point
 }
 
 // SeriesMeta counts the number of series for each set of meta properties
@@ -178,16 +178,6 @@ func (s Series) Copy(emptyDatapoints []schema.Point) Series {
 		Consolidator: s.Consolidator,
 		Meta:         s.Meta.Copy(),
 	}
-}
-
-// CopyBare returns a bare copy.
-// The returned value does not link to the same memory space for any of the properties
-// because it resets all reference types
-func (s Series) CopyBare() Series {
-	s.Datapoints = nil
-	s.Tags = nil
-	s.Meta = nil
-	return s
 }
 
 // CopyTags makes a deep copy of the tags

--- a/api/models/series.go
+++ b/api/models/series.go
@@ -40,8 +40,8 @@ type SeriesMetaProperties struct {
 	AggNumNorm            uint32                     // aggNum for normalization
 	AggNumRC              uint32                     // aggNum runtime consolidation
 	ConsolidatorNormFetch consolidation.Consolidator // consolidator used for normalization and reading from store (if applicable)
-	ConsolidatorRC        consolidation.Consolidator // consolidator used for runtime consolidation (if applicable)
-	Count                 uint32
+	ConsolidatorRC        consolidation.Consolidator // consolidator used for runtime consolidation to honor maxdatapoints (if applicable).
+	Count                 uint32                     // number of series corresponding to these properties
 }
 
 // Merge merges SeriesMeta b into a

--- a/api/models/series.go
+++ b/api/models/series.go
@@ -72,7 +72,7 @@ func (a SeriesMeta) Copy() SeriesMeta {
 	return out
 }
 
-// CopyWithChange creates a copy of SeriesMeta, but executes the requested change on each each SeriesMetaProperties
+// CopyWithChange creates a copy of SeriesMeta, but executes the requested change on each SeriesMetaProperties
 func (a SeriesMeta) CopyWithChange(fn func(in SeriesMetaProperties) SeriesMetaProperties) SeriesMeta {
 	out := make(SeriesMeta, len(a))
 	for i, v := range a {

--- a/api/models/series_gen.go
+++ b/api/models/series_gen.go
@@ -116,6 +116,25 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Consolidator")
 				return
 			}
+		case "Meta":
+			var zb0004 uint32
+			zb0004, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Meta")
+				return
+			}
+			if cap(z.Meta) >= int(zb0004) {
+				z.Meta = (z.Meta)[:zb0004]
+			} else {
+				z.Meta = make(SeriesMeta, zb0004)
+			}
+			for za0004 := range z.Meta {
+				err = z.Meta[za0004].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Meta", za0004)
+					return
+				}
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -129,9 +148,9 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 9
+	// map header, size 10
 	// write "Target"
-	err = en.Append(0x89, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
+	err = en.Append(0x8a, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
 	if err != nil {
 		return
 	}
@@ -239,15 +258,32 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Consolidator")
 		return
 	}
+	// write "Meta"
+	err = en.Append(0xa4, 0x4d, 0x65, 0x74, 0x61)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Meta)))
+	if err != nil {
+		err = msgp.WrapError(err, "Meta")
+		return
+	}
+	for za0004 := range z.Meta {
+		err = z.Meta[za0004].EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Meta", za0004)
+			return
+		}
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 9
+	// map header, size 10
 	// string "Target"
-	o = append(o, 0x89, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
+	o = append(o, 0x8a, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
 	o = msgp.AppendString(o, z.Target)
 	// string "Datapoints"
 	o = append(o, 0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
@@ -291,6 +327,16 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 	if err != nil {
 		err = msgp.WrapError(err, "Consolidator")
 		return
+	}
+	// string "Meta"
+	o = append(o, 0xa4, 0x4d, 0x65, 0x74, 0x61)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Meta)))
+	for za0004 := range z.Meta {
+		o, err = z.Meta[za0004].MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Meta", za0004)
+			return
+		}
 	}
 	return
 }
@@ -404,6 +450,25 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Consolidator")
 				return
 			}
+		case "Meta":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Meta")
+				return
+			}
+			if cap(z.Meta) >= int(zb0004) {
+				z.Meta = (z.Meta)[:zb0004]
+			} else {
+				z.Meta = make(SeriesMeta, zb0004)
+			}
+			for za0004 := range z.Meta {
+				bts, err = z.Meta[za0004].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Meta", za0004)
+					return
+				}
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -429,7 +494,10 @@ func (z *Series) Msgsize() (s int) {
 			s += msgp.StringPrefixSize + len(za0002) + msgp.StringPrefixSize + len(za0003)
 		}
 	}
-	s += 9 + msgp.Uint32Size + 10 + msgp.StringPrefixSize + len(z.QueryPatt) + 10 + msgp.Uint32Size + 8 + msgp.Uint32Size + 10 + z.QueryCons.Msgsize() + 13 + z.Consolidator.Msgsize()
+	s += 9 + msgp.Uint32Size + 10 + msgp.StringPrefixSize + len(z.QueryPatt) + 10 + msgp.Uint32Size + 8 + msgp.Uint32Size + 10 + z.QueryCons.Msgsize() + 13 + z.Consolidator.Msgsize() + 5 + msgp.ArrayHeaderSize
+	for za0004 := range z.Meta {
+		s += z.Meta[za0004].Msgsize()
+	}
 	return
 }
 
@@ -876,5 +944,353 @@ func (z SeriesListForPickle) Msgsize() (s int) {
 	for zb0003 := range z {
 		s += z[zb0003].Msgsize()
 	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *SeriesMeta) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zb0002 uint32
+	zb0002, err = dc.ReadArrayHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	if cap((*z)) >= int(zb0002) {
+		(*z) = (*z)[:zb0002]
+	} else {
+		(*z) = make(SeriesMeta, zb0002)
+	}
+	for zb0001 := range *z {
+		err = (*z)[zb0001].DecodeMsg(dc)
+		if err != nil {
+			err = msgp.WrapError(err, zb0001)
+			return
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z SeriesMeta) EncodeMsg(en *msgp.Writer) (err error) {
+	err = en.WriteArrayHeader(uint32(len(z)))
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0003 := range z {
+		err = z[zb0003].EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, zb0003)
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z SeriesMeta) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendArrayHeader(o, uint32(len(z)))
+	for zb0003 := range z {
+		o, err = z[zb0003].MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, zb0003)
+			return
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SeriesMeta) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var zb0002 uint32
+	zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	if cap((*z)) >= int(zb0002) {
+		(*z) = (*z)[:zb0002]
+	} else {
+		(*z) = make(SeriesMeta, zb0002)
+	}
+	for zb0001 := range *z {
+		bts, err = (*z)[zb0001].UnmarshalMsg(bts)
+		if err != nil {
+			err = msgp.WrapError(err, zb0001)
+			return
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z SeriesMeta) Msgsize() (s int) {
+	s = msgp.ArrayHeaderSize
+	for zb0003 := range z {
+		s += z[zb0003].Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *SeriesMetaProperties) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "SchemaID":
+			z.SchemaID, err = dc.ReadUint16()
+			if err != nil {
+				err = msgp.WrapError(err, "SchemaID")
+				return
+			}
+		case "Archive":
+			z.Archive, err = dc.ReadUint8()
+			if err != nil {
+				err = msgp.WrapError(err, "Archive")
+				return
+			}
+		case "AggNumNorm":
+			z.AggNumNorm, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "AggNumNorm")
+				return
+			}
+		case "AggNumRC":
+			z.AggNumRC, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "AggNumRC")
+				return
+			}
+		case "ConsolidatorNormFetch":
+			err = z.ConsolidatorNormFetch.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "ConsolidatorNormFetch")
+				return
+			}
+		case "ConsolidatorRC":
+			err = z.ConsolidatorRC.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "ConsolidatorRC")
+				return
+			}
+		case "Count":
+			z.Count, err = dc.ReadUint32()
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *SeriesMetaProperties) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 7
+	// write "SchemaID"
+	err = en.Append(0x87, 0xa8, 0x53, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x49, 0x44)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint16(z.SchemaID)
+	if err != nil {
+		err = msgp.WrapError(err, "SchemaID")
+		return
+	}
+	// write "Archive"
+	err = en.Append(0xa7, 0x41, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint8(z.Archive)
+	if err != nil {
+		err = msgp.WrapError(err, "Archive")
+		return
+	}
+	// write "AggNumNorm"
+	err = en.Append(0xaa, 0x41, 0x67, 0x67, 0x4e, 0x75, 0x6d, 0x4e, 0x6f, 0x72, 0x6d)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.AggNumNorm)
+	if err != nil {
+		err = msgp.WrapError(err, "AggNumNorm")
+		return
+	}
+	// write "AggNumRC"
+	err = en.Append(0xa8, 0x41, 0x67, 0x67, 0x4e, 0x75, 0x6d, 0x52, 0x43)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.AggNumRC)
+	if err != nil {
+		err = msgp.WrapError(err, "AggNumRC")
+		return
+	}
+	// write "ConsolidatorNormFetch"
+	err = en.Append(0xb5, 0x43, 0x6f, 0x6e, 0x73, 0x6f, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x72, 0x6d, 0x46, 0x65, 0x74, 0x63, 0x68)
+	if err != nil {
+		return
+	}
+	err = z.ConsolidatorNormFetch.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "ConsolidatorNormFetch")
+		return
+	}
+	// write "ConsolidatorRC"
+	err = en.Append(0xae, 0x43, 0x6f, 0x6e, 0x73, 0x6f, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x52, 0x43)
+	if err != nil {
+		return
+	}
+	err = z.ConsolidatorRC.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "ConsolidatorRC")
+		return
+	}
+	// write "Count"
+	err = en.Append(0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.Count)
+	if err != nil {
+		err = msgp.WrapError(err, "Count")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *SeriesMetaProperties) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 7
+	// string "SchemaID"
+	o = append(o, 0x87, 0xa8, 0x53, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x49, 0x44)
+	o = msgp.AppendUint16(o, z.SchemaID)
+	// string "Archive"
+	o = append(o, 0xa7, 0x41, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65)
+	o = msgp.AppendUint8(o, z.Archive)
+	// string "AggNumNorm"
+	o = append(o, 0xaa, 0x41, 0x67, 0x67, 0x4e, 0x75, 0x6d, 0x4e, 0x6f, 0x72, 0x6d)
+	o = msgp.AppendUint32(o, z.AggNumNorm)
+	// string "AggNumRC"
+	o = append(o, 0xa8, 0x41, 0x67, 0x67, 0x4e, 0x75, 0x6d, 0x52, 0x43)
+	o = msgp.AppendUint32(o, z.AggNumRC)
+	// string "ConsolidatorNormFetch"
+	o = append(o, 0xb5, 0x43, 0x6f, 0x6e, 0x73, 0x6f, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x4e, 0x6f, 0x72, 0x6d, 0x46, 0x65, 0x74, 0x63, 0x68)
+	o, err = z.ConsolidatorNormFetch.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "ConsolidatorNormFetch")
+		return
+	}
+	// string "ConsolidatorRC"
+	o = append(o, 0xae, 0x43, 0x6f, 0x6e, 0x73, 0x6f, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x52, 0x43)
+	o, err = z.ConsolidatorRC.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "ConsolidatorRC")
+		return
+	}
+	// string "Count"
+	o = append(o, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	o = msgp.AppendUint32(o, z.Count)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SeriesMetaProperties) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "SchemaID":
+			z.SchemaID, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SchemaID")
+				return
+			}
+		case "Archive":
+			z.Archive, bts, err = msgp.ReadUint8Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Archive")
+				return
+			}
+		case "AggNumNorm":
+			z.AggNumNorm, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AggNumNorm")
+				return
+			}
+		case "AggNumRC":
+			z.AggNumRC, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AggNumRC")
+				return
+			}
+		case "ConsolidatorNormFetch":
+			bts, err = z.ConsolidatorNormFetch.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ConsolidatorNormFetch")
+				return
+			}
+		case "ConsolidatorRC":
+			bts, err = z.ConsolidatorRC.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ConsolidatorRC")
+				return
+			}
+		case "Count":
+			z.Count, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *SeriesMetaProperties) Msgsize() (s int) {
+	s = 1 + 9 + msgp.Uint16Size + 8 + msgp.Uint8Size + 11 + msgp.Uint32Size + 9 + msgp.Uint32Size + 22 + z.ConsolidatorNormFetch.Msgsize() + 15 + z.ConsolidatorRC.Msgsize() + 6 + msgp.Uint32Size
 	return
 }

--- a/api/models/series_gen.go
+++ b/api/models/series_gen.go
@@ -31,54 +31,35 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Target")
 				return
 			}
-		case "Datapoints":
-			var zb0002 uint32
-			zb0002, err = dc.ReadArrayHeader()
-			if err != nil {
-				err = msgp.WrapError(err, "Datapoints")
-				return
-			}
-			if cap(z.Datapoints) >= int(zb0002) {
-				z.Datapoints = (z.Datapoints)[:zb0002]
-			} else {
-				z.Datapoints = make([]schema.Point, zb0002)
-			}
-			for za0001 := range z.Datapoints {
-				err = z.Datapoints[za0001].DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "Datapoints", za0001)
-					return
-				}
-			}
 		case "Tags":
-			var zb0003 uint32
-			zb0003, err = dc.ReadMapHeader()
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Tags")
 				return
 			}
 			if z.Tags == nil {
-				z.Tags = make(map[string]string, zb0003)
+				z.Tags = make(map[string]string, zb0002)
 			} else if len(z.Tags) > 0 {
 				for key := range z.Tags {
 					delete(z.Tags, key)
 				}
 			}
-			for zb0003 > 0 {
-				zb0003--
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
 				var za0002 string
-				var za0003 string
-				za0002, err = dc.ReadString()
+				za0001, err = dc.ReadString()
 				if err != nil {
 					err = msgp.WrapError(err, "Tags")
 					return
 				}
-				za0003, err = dc.ReadString()
+				za0002, err = dc.ReadString()
 				if err != nil {
-					err = msgp.WrapError(err, "Tags", za0002)
+					err = msgp.WrapError(err, "Tags", za0001)
 					return
 				}
-				z.Tags[za0002] = za0003
+				z.Tags[za0001] = za0002
 			}
 		case "Interval":
 			z.Interval, err = dc.ReadUint32()
@@ -117,21 +98,40 @@ func (z *Series) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Meta":
-			var zb0004 uint32
-			zb0004, err = dc.ReadArrayHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Meta")
 				return
 			}
-			if cap(z.Meta) >= int(zb0004) {
-				z.Meta = (z.Meta)[:zb0004]
+			if cap(z.Meta) >= int(zb0003) {
+				z.Meta = (z.Meta)[:zb0003]
 			} else {
-				z.Meta = make(SeriesMeta, zb0004)
+				z.Meta = make(SeriesMeta, zb0003)
 			}
-			for za0004 := range z.Meta {
-				err = z.Meta[za0004].DecodeMsg(dc)
+			for za0003 := range z.Meta {
+				err = z.Meta[za0003].DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "Meta", za0004)
+					err = msgp.WrapError(err, "Meta", za0003)
+					return
+				}
+			}
+		case "Datapoints":
+			var zb0004 uint32
+			zb0004, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Datapoints")
+				return
+			}
+			if cap(z.Datapoints) >= int(zb0004) {
+				z.Datapoints = (z.Datapoints)[:zb0004]
+			} else {
+				z.Datapoints = make([]schema.Point, zb0004)
+			}
+			for za0004 := range z.Datapoints {
+				err = z.Datapoints[za0004].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Datapoints", za0004)
 					return
 				}
 			}
@@ -159,23 +159,6 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Target")
 		return
 	}
-	// write "Datapoints"
-	err = en.Append(0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
-	if err != nil {
-		return
-	}
-	err = en.WriteArrayHeader(uint32(len(z.Datapoints)))
-	if err != nil {
-		err = msgp.WrapError(err, "Datapoints")
-		return
-	}
-	for za0001 := range z.Datapoints {
-		err = z.Datapoints[za0001].EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "Datapoints", za0001)
-			return
-		}
-	}
 	// write "Tags"
 	err = en.Append(0xa4, 0x54, 0x61, 0x67, 0x73)
 	if err != nil {
@@ -186,15 +169,15 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Tags")
 		return
 	}
-	for za0002, za0003 := range z.Tags {
-		err = en.WriteString(za0002)
+	for za0001, za0002 := range z.Tags {
+		err = en.WriteString(za0001)
 		if err != nil {
 			err = msgp.WrapError(err, "Tags")
 			return
 		}
-		err = en.WriteString(za0003)
+		err = en.WriteString(za0002)
 		if err != nil {
-			err = msgp.WrapError(err, "Tags", za0002)
+			err = msgp.WrapError(err, "Tags", za0001)
 			return
 		}
 	}
@@ -268,10 +251,27 @@ func (z *Series) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Meta")
 		return
 	}
-	for za0004 := range z.Meta {
-		err = z.Meta[za0004].EncodeMsg(en)
+	for za0003 := range z.Meta {
+		err = z.Meta[za0003].EncodeMsg(en)
 		if err != nil {
-			err = msgp.WrapError(err, "Meta", za0004)
+			err = msgp.WrapError(err, "Meta", za0003)
+			return
+		}
+	}
+	// write "Datapoints"
+	err = en.Append(0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Datapoints)))
+	if err != nil {
+		err = msgp.WrapError(err, "Datapoints")
+		return
+	}
+	for za0004 := range z.Datapoints {
+		err = z.Datapoints[za0004].EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Datapoints", za0004)
 			return
 		}
 	}
@@ -285,22 +285,12 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Target"
 	o = append(o, 0x8a, 0xa6, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74)
 	o = msgp.AppendString(o, z.Target)
-	// string "Datapoints"
-	o = append(o, 0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
-	o = msgp.AppendArrayHeader(o, uint32(len(z.Datapoints)))
-	for za0001 := range z.Datapoints {
-		o, err = z.Datapoints[za0001].MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Datapoints", za0001)
-			return
-		}
-	}
 	// string "Tags"
 	o = append(o, 0xa4, 0x54, 0x61, 0x67, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Tags)))
-	for za0002, za0003 := range z.Tags {
+	for za0001, za0002 := range z.Tags {
+		o = msgp.AppendString(o, za0001)
 		o = msgp.AppendString(o, za0002)
-		o = msgp.AppendString(o, za0003)
 	}
 	// string "Interval"
 	o = append(o, 0xa8, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c)
@@ -331,10 +321,20 @@ func (z *Series) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Meta"
 	o = append(o, 0xa4, 0x4d, 0x65, 0x74, 0x61)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Meta)))
-	for za0004 := range z.Meta {
-		o, err = z.Meta[za0004].MarshalMsg(o)
+	for za0003 := range z.Meta {
+		o, err = z.Meta[za0003].MarshalMsg(o)
 		if err != nil {
-			err = msgp.WrapError(err, "Meta", za0004)
+			err = msgp.WrapError(err, "Meta", za0003)
+			return
+		}
+	}
+	// string "Datapoints"
+	o = append(o, 0xaa, 0x44, 0x61, 0x74, 0x61, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Datapoints)))
+	for za0004 := range z.Datapoints {
+		o, err = z.Datapoints[za0004].MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Datapoints", za0004)
 			return
 		}
 	}
@@ -365,54 +365,35 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Target")
 				return
 			}
-		case "Datapoints":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Datapoints")
-				return
-			}
-			if cap(z.Datapoints) >= int(zb0002) {
-				z.Datapoints = (z.Datapoints)[:zb0002]
-			} else {
-				z.Datapoints = make([]schema.Point, zb0002)
-			}
-			for za0001 := range z.Datapoints {
-				bts, err = z.Datapoints[za0001].UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Datapoints", za0001)
-					return
-				}
-			}
 		case "Tags":
-			var zb0003 uint32
-			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Tags")
 				return
 			}
 			if z.Tags == nil {
-				z.Tags = make(map[string]string, zb0003)
+				z.Tags = make(map[string]string, zb0002)
 			} else if len(z.Tags) > 0 {
 				for key := range z.Tags {
 					delete(z.Tags, key)
 				}
 			}
-			for zb0003 > 0 {
+			for zb0002 > 0 {
+				var za0001 string
 				var za0002 string
-				var za0003 string
-				zb0003--
-				za0002, bts, err = msgp.ReadStringBytes(bts)
+				zb0002--
+				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Tags")
 					return
 				}
-				za0003, bts, err = msgp.ReadStringBytes(bts)
+				za0002, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Tags", za0002)
+					err = msgp.WrapError(err, "Tags", za0001)
 					return
 				}
-				z.Tags[za0002] = za0003
+				z.Tags[za0001] = za0002
 			}
 		case "Interval":
 			z.Interval, bts, err = msgp.ReadUint32Bytes(bts)
@@ -451,21 +432,40 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Meta":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Meta")
 				return
 			}
-			if cap(z.Meta) >= int(zb0004) {
-				z.Meta = (z.Meta)[:zb0004]
+			if cap(z.Meta) >= int(zb0003) {
+				z.Meta = (z.Meta)[:zb0003]
 			} else {
-				z.Meta = make(SeriesMeta, zb0004)
+				z.Meta = make(SeriesMeta, zb0003)
 			}
-			for za0004 := range z.Meta {
-				bts, err = z.Meta[za0004].UnmarshalMsg(bts)
+			for za0003 := range z.Meta {
+				bts, err = z.Meta[za0003].UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Meta", za0004)
+					err = msgp.WrapError(err, "Meta", za0003)
+					return
+				}
+			}
+		case "Datapoints":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Datapoints")
+				return
+			}
+			if cap(z.Datapoints) >= int(zb0004) {
+				z.Datapoints = (z.Datapoints)[:zb0004]
+			} else {
+				z.Datapoints = make([]schema.Point, zb0004)
+			}
+			for za0004 := range z.Datapoints {
+				bts, err = z.Datapoints[za0004].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Datapoints", za0004)
 					return
 				}
 			}
@@ -483,20 +483,20 @@ func (z *Series) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Series) Msgsize() (s int) {
-	s = 1 + 7 + msgp.StringPrefixSize + len(z.Target) + 11 + msgp.ArrayHeaderSize
-	for za0001 := range z.Datapoints {
-		s += z.Datapoints[za0001].Msgsize()
-	}
-	s += 5 + msgp.MapHeaderSize
+	s = 1 + 7 + msgp.StringPrefixSize + len(z.Target) + 5 + msgp.MapHeaderSize
 	if z.Tags != nil {
-		for za0002, za0003 := range z.Tags {
-			_ = za0003
-			s += msgp.StringPrefixSize + len(za0002) + msgp.StringPrefixSize + len(za0003)
+		for za0001, za0002 := range z.Tags {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + msgp.StringPrefixSize + len(za0002)
 		}
 	}
 	s += 9 + msgp.Uint32Size + 10 + msgp.StringPrefixSize + len(z.QueryPatt) + 10 + msgp.Uint32Size + 8 + msgp.Uint32Size + 10 + z.QueryCons.Msgsize() + 13 + z.Consolidator.Msgsize() + 5 + msgp.ArrayHeaderSize
-	for za0004 := range z.Meta {
-		s += z.Meta[za0004].Msgsize()
+	for za0003 := range z.Meta {
+		s += z.Meta[za0003].Msgsize()
+	}
+	s += 11 + msgp.ArrayHeaderSize
+	for za0004 := range z.Datapoints {
+		s += z.Datapoints[za0004].Msgsize()
 	}
 	return
 }

--- a/api/models/series_gen_test.go
+++ b/api/models/series_gen_test.go
@@ -460,3 +460,229 @@ func BenchmarkDecodeSeriesListForPickle(b *testing.B) {
 		}
 	}
 }
+
+func TestMarshalUnmarshalSeriesMeta(t *testing.T) {
+	v := SeriesMeta{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgSeriesMeta(b *testing.B) {
+	v := SeriesMeta{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSeriesMeta(b *testing.B) {
+	v := SeriesMeta{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSeriesMeta(b *testing.B) {
+	v := SeriesMeta{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeSeriesMeta(t *testing.T) {
+	v := SeriesMeta{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := SeriesMeta{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeSeriesMeta(b *testing.B) {
+	v := SeriesMeta{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeSeriesMeta(b *testing.B) {
+	v := SeriesMeta{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalSeriesMetaProperties(t *testing.T) {
+	v := SeriesMetaProperties{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgSeriesMetaProperties(b *testing.B) {
+	v := SeriesMetaProperties{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSeriesMetaProperties(b *testing.B) {
+	v := SeriesMetaProperties{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSeriesMetaProperties(b *testing.B) {
+	v := SeriesMetaProperties{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeSeriesMetaProperties(t *testing.T) {
+	v := SeriesMetaProperties{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := SeriesMetaProperties{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeSeriesMetaProperties(b *testing.B) {
+	v := SeriesMetaProperties{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeSeriesMetaProperties(b *testing.B) {
+	v := SeriesMetaProperties{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/conf/retention.go
+++ b/conf/retention.go
@@ -91,6 +91,10 @@ func NewRetentionMT(secondsPerPoint int, ttl, chunkSpan, numChunks, ready uint32
 // ParseRetentions parses retention definitions into a Retentions structure
 func ParseRetentions(defs string) (Retentions, error) {
 	retentions := make(Retentions, 0)
+	cnt := strings.Count(defs, ",")
+	if cnt > 254 {
+		return nil, errors.New("no more than 255 individual retensions per rule supported")
+	}
 	for i, def := range strings.Split(defs, ",") {
 		def = strings.TrimSpace(def)
 		parts := strings.Split(def, ":")

--- a/devdocs/expr.md
+++ b/devdocs/expr.md
@@ -86,9 +86,10 @@ consolidateBy(
     "max"
 )
 ```
-
-parsing starts at the root and continues until leaves are resolved.
-Execution follows, and it happens the other way around (first leaves are fetched, then functions are applied until we hit the root)
+There's 2 important information flows to be aware of: parsing and after it, execution.
+* Parsing starts at the root and continues until leaves are resolved, and we know which series need to be fetched.
+* Execution happens the other way around: first the data at the leaves is fetched, then functions are applied until we hit the root.
+  At that point function processing is complete; we can do some final work (like merging of series that are the same metric but a different raw interval, and maxDatapoints consolidation) and return the data back to the user.
 
 So:
 1) at parse time, consolidation settings encountered in consolidateBy calls are passed down the tree (e.g. via the context, typically until it hits the data request.

--- a/expr/func_absolute.go
+++ b/expr/func_absolute.go
@@ -31,24 +31,16 @@ func (s *FuncAbsolute) Exec(cache map[Req][]models.Series) ([]models.Series, err
 		return nil, err
 	}
 
-	out := make([]models.Series, len(series))
 	for i, serie := range series {
-		transformed := &out[i]
-		transformed.Target = fmt.Sprintf("absolute(%s)", serie.Target)
-		transformed.Tags = serie.CopyTagsWith("absolute", "1")
-		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
-		transformed.Interval = serie.Interval
-		transformed.QueryPatt = fmt.Sprintf("absolute(%s)", serie.QueryPatt)
-		transformed.QueryCons = serie.QueryCons
-		transformed.Consolidator = serie.Consolidator
-		transformed.Meta = serie.Meta
-
+		series[i].Target = fmt.Sprintf("absolute(%s)", serie.Target)
+		series[i].Tags = serie.CopyTagsWith("absolute", "1")
+		series[i].QueryPatt = fmt.Sprintf("absolute(%s)", serie.QueryPatt)
+		series[i].Datapoints = pointSlicePool.Get().([]schema.Point)
 		for _, p := range serie.Datapoints {
 			p.Val = math.Abs(p.Val)
-			transformed.Datapoints = append(transformed.Datapoints, p)
+			series[i].Datapoints = append(series[i].Datapoints, p)
 		}
-		cache[Req{}] = append(cache[Req{}], *transformed)
 	}
-
-	return out, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/func_absolute.go
+++ b/expr/func_absolute.go
@@ -35,18 +35,14 @@ func (s *FuncAbsolute) Exec(cache map[Req][]models.Series) ([]models.Series, err
 	for i, serie := range series {
 		transformed := &out[i]
 		transformed.Target = fmt.Sprintf("absolute(%s)", serie.Target)
-		transformed.QueryPatt = fmt.Sprintf("absolute(%s)", serie.QueryPatt)
-		transformed.Tags = make(map[string]string, len(serie.Tags)+1)
+		transformed.Tags = serie.CopyTagsWith("absolute", "1")
 		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
 		transformed.Interval = serie.Interval
-		transformed.Consolidator = serie.Consolidator
+		transformed.QueryPatt = fmt.Sprintf("absolute(%s)", serie.QueryPatt)
 		transformed.QueryCons = serie.QueryCons
-		transformed.Meta = serie.Meta.Copy()
+		transformed.Consolidator = serie.Consolidator
+		transformed.Meta = serie.Meta
 
-		for k, v := range serie.Tags {
-			transformed.Tags[k] = v
-		}
-		transformed.Tags["absolute"] = "1"
 		for _, p := range serie.Datapoints {
 			p.Val = math.Abs(p.Val)
 			transformed.Datapoints = append(transformed.Datapoints, p)

--- a/expr/func_absolute.go
+++ b/expr/func_absolute.go
@@ -41,6 +41,7 @@ func (s *FuncAbsolute) Exec(cache map[Req][]models.Series) ([]models.Series, err
 		transformed.Interval = serie.Interval
 		transformed.Consolidator = serie.Consolidator
 		transformed.QueryCons = serie.QueryCons
+		transformed.Meta = serie.Meta.Copy()
 
 		for k, v := range serie.Tags {
 			transformed.Tags[k] = v

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -50,10 +50,7 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 
 	// The tags for the aggregated series is only the tags that are
 	// common to all input series
-	commonTags := make(map[string]string, len(series[0].Tags))
-	for k, v := range series[0].Tags {
-		commonTags[k] = v
-	}
+	commonTags := series[0].CopyTags()
 
 	var meta models.SeriesMeta
 
@@ -70,12 +67,12 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 	name := s.agg.name + "Series(" + strings.Join(queryPatts, ",") + ")"
 	output := models.Series{
 		Target:       name,
-		QueryPatt:    name,
 		Tags:         commonTags,
 		Datapoints:   out,
 		Interval:     series[0].Interval,
-		Consolidator: cons,
+		QueryPatt:    name,
 		QueryCons:    queryCons,
+		Consolidator: cons,
 		Meta:         meta,
 	}
 	cache[Req{}] = append(cache[Req{}], output)

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -65,16 +65,15 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 
 	cons, queryCons := summarizeCons(series)
 	name := s.agg.name + "Series(" + strings.Join(queryPatts, ",") + ")"
-	output := models.Series{
-		Target:       name,
-		Tags:         commonTags,
-		Datapoints:   out,
-		Interval:     series[0].Interval,
-		QueryPatt:    name,
-		QueryCons:    queryCons,
-		Consolidator: cons,
-		Meta:         meta,
-	}
+	output := series[0]
+	output.Target = name
+	output.QueryPatt = name
+	output.Tags = commonTags
+	output.Datapoints = out
+	output.QueryCons = queryCons
+	output.Consolidator = cons
+	output.Meta = meta
+
 	cache[Req{}] = append(cache[Req{}], output)
 
 	return []models.Series{output}, nil

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -55,10 +55,10 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		commonTags[k] = v
 	}
 
-	meta := make(models.SeriesMeta)
+	var meta models.SeriesMeta
 
 	for _, serie := range series {
-		meta.Merge(serie.Meta)
+		meta = meta.Merge(serie.Meta)
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {
 				delete(commonTags, k)

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -55,7 +55,10 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		commonTags[k] = v
 	}
 
+	meta := make(models.SeriesMeta)
+
 	for _, serie := range series {
+		meta.Merge(serie.Meta)
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {
 				delete(commonTags, k)
@@ -73,6 +76,7 @@ func (s *FuncAggregate) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		Interval:     series[0].Interval,
 		Consolidator: cons,
 		QueryCons:    queryCons,
+		Meta:         meta,
 	}
 	cache[Req{}] = append(cache[Req{}], output)
 

--- a/expr/func_alias.go
+++ b/expr/func_alias.go
@@ -32,7 +32,7 @@ func (s *FuncAlias) Exec(cache map[Req][]models.Series) ([]models.Series, error)
 	for i := range series {
 		series[i].Target = s.alias
 		series[i].QueryPatt = s.alias
-		series[i].Tags["name"] = s.alias
+		series[i].Tags = series[i].CopyTagsWith("name", s.alias)
 	}
 	return series, nil
 }

--- a/expr/func_aliasbynode.go
+++ b/expr/func_aliasbynode.go
@@ -33,7 +33,7 @@ func (s *FuncAliasByNode) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		n := aggKey(serie, s.nodes)
 		series[i].Target = n
 		series[i].QueryPatt = n
-		series[i].Tags["name"] = n
+		series[i].Tags = series[i].CopyTagsWith("name", n)
 	}
 	return series, nil
 }

--- a/expr/func_aliassub.go
+++ b/expr/func_aliassub.go
@@ -48,7 +48,7 @@ func (s *FuncAliasSub) Exec(cache map[Req][]models.Series) ([]models.Series, err
 		name := s.search.ReplaceAllString(metric, replace)
 		series[i].Target = name
 		series[i].QueryPatt = name
-		series[i].Tags["name"] = name
+		series[i].Tags = series[i].CopyTagsWith("name", name)
 	}
 	return series, err
 }

--- a/expr/func_aspercent.go
+++ b/expr/func_aspercent.go
@@ -271,6 +271,8 @@ Loop:
 		Interval:     series[0].Interval,
 		Consolidator: cons,
 		QueryCons:    queryCons,
+		QueryFrom:    series[0].QueryFrom,
+		QueryTo:      series[0].QueryTo,
 		Tags:         map[string]string{"name": name},
 		Meta:         meta,
 	}

--- a/expr/func_aspercent.go
+++ b/expr/func_aspercent.go
@@ -119,6 +119,7 @@ func (s *FuncAsPercent) execWithNodes(series, totals []models.Series, cache map[
 				nonesSerie.QueryPatt = fmt.Sprintf("asPercent(%s,MISSING)", serie1.QueryPatt)
 				nonesSerie.Target = fmt.Sprintf("asPercent(%s,MISSING)", serie1.Target)
 				nonesSerie.Tags = map[string]string{"name": nonesSerie.Target}
+				nonesSerie.Meta = serie1.Meta.Copy()
 
 				if nones == nil {
 					nones = pointSlicePool.Get().([]schema.Point)
@@ -195,6 +196,7 @@ func (s *FuncAsPercent) execWithoutNodes(series, totals []models.Series, cache m
 			}
 			serie.Datapoints[i].Val = computeAsPercent(serie.Datapoints[i].Val, totalVal)
 		}
+		serie.Meta = serie.Meta.Merge(totalsSerie.Meta)
 		outSeries = append(outSeries, serie)
 		cache[Req{}] = append(cache[Req{}], serie)
 	}
@@ -247,9 +249,11 @@ func sumSeries(series []models.Series, cache map[Req][]models.Series) models.Ser
 	out := pointSlicePool.Get().([]schema.Point)
 	crossSeriesSum(series, &out)
 	var queryPatts []string
+	var meta models.SeriesMeta
 
 Loop:
 	for _, v := range series {
+		meta = meta.Merge(v.Meta)
 		// avoid duplicates
 		for _, qp := range queryPatts {
 			if qp == v.QueryPatt {
@@ -268,6 +272,7 @@ Loop:
 		Consolidator: cons,
 		QueryCons:    queryCons,
 		Tags:         map[string]string{"name": name},
+		Meta:         meta,
 	}
 	cache[Req{}] = append(cache[Req{}], sum)
 	return sum

--- a/expr/func_consolidateby.go
+++ b/expr/func_consolidateby.go
@@ -45,13 +45,11 @@ func (s *FuncConsolidateBy) Exec(cache map[Req][]models.Series) ([]models.Series
 		return nil, err
 	}
 	consolidator := consolidation.FromConsolidateBy(s.by)
-	var out []models.Series
-	for _, serie := range series {
-		serie.Target = fmt.Sprintf("consolidateBy(%s,\"%s\")", serie.Target, s.by)
-		serie.QueryPatt = fmt.Sprintf("consolidateBy(%s,\"%s\")", serie.QueryPatt, s.by)
-		serie.Consolidator = consolidator
-		serie.QueryCons = consolidator
-		out = append(out, serie)
+	for i, serie := range series {
+		series[i].Target = fmt.Sprintf("consolidateBy(%s,\"%s\")", serie.Target, s.by)
+		series[i].QueryPatt = fmt.Sprintf("consolidateBy(%s,\"%s\")", serie.QueryPatt, s.by)
+		series[i].Consolidator = consolidator
+		series[i].QueryCons = consolidator
 	}
-	return out, nil
+	return series, nil
 }

--- a/expr/func_countseries.go
+++ b/expr/func_countseries.go
@@ -50,16 +50,14 @@ func (s *FuncCountSeries) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		meta = meta.Merge(s.Meta)
 	}
 
-	output := models.Series{
-		Target:       name,
-		QueryPatt:    name,
-		Tags:         map[string]string{"name": name},
-		Datapoints:   out,
-		Interval:     series[0].Interval,
-		Consolidator: cons,
-		QueryCons:    queryCons,
-		Meta:         meta,
-	}
+	output := series[0]
+	output.Target = name
+	output.QueryPatt = name
+	output.Tags = map[string]string{"name": name}
+	output.Datapoints = out
+	output.Consolidator = cons
+	output.QueryCons = queryCons
+	output.Meta = meta
 	cache[Req{}] = append(cache[Req{}], output)
 
 	return []models.Series{output}, nil

--- a/expr/func_countseries.go
+++ b/expr/func_countseries.go
@@ -45,6 +45,11 @@ func (s *FuncCountSeries) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		out = append(out, p)
 	}
 
+	var meta models.SeriesMeta
+	for _, s := range series {
+		meta = meta.Merge(s.Meta)
+	}
+
 	output := models.Series{
 		Target:       name,
 		QueryPatt:    name,
@@ -53,6 +58,7 @@ func (s *FuncCountSeries) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		Interval:     series[0].Interval,
 		Consolidator: cons,
 		QueryCons:    queryCons,
+		Meta:         meta,
 	}
 	cache[Req{}] = append(cache[Req{}], output)
 

--- a/expr/func_derivative.go
+++ b/expr/func_derivative.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/schema"
 )
 
@@ -35,6 +36,8 @@ func (s *FuncDerivative) Exec(cache map[Req][]models.Series) ([]models.Series, e
 		series[i].Target = fmt.Sprintf("derivative(%s)", serie.Target)
 		series[i].Tags = serie.CopyTagsWith("derivative", "1")
 		series[i].QueryPatt = fmt.Sprintf("derivative(%s)", serie.QueryPatt)
+		series[i].Consolidator = consolidation.None
+		series[i].QueryCons = consolidation.None
 		out := pointSlicePool.Get().([]schema.Point)
 
 		prev := math.NaN()

--- a/expr/func_derivative.go
+++ b/expr/func_derivative.go
@@ -31,11 +31,10 @@ func (s *FuncDerivative) Exec(cache map[Req][]models.Series) ([]models.Series, e
 		return nil, err
 	}
 
-	outSeries := make([]models.Series, len(series))
 	for i, serie := range series {
-		serie.Target = fmt.Sprintf("derivative(%s)", serie.Target)
-		serie.Tags = serie.CopyTagsWith("derivative", "1")
-		serie.QueryPatt = fmt.Sprintf("derivative(%s)", serie.QueryPatt)
+		series[i].Target = fmt.Sprintf("derivative(%s)", serie.Target)
+		series[i].Tags = serie.CopyTagsWith("derivative", "1")
+		series[i].QueryPatt = fmt.Sprintf("derivative(%s)", serie.QueryPatt)
 		out := pointSlicePool.Get().([]schema.Point)
 
 		prev := math.NaN()
@@ -49,9 +48,8 @@ func (s *FuncDerivative) Exec(cache map[Req][]models.Series) ([]models.Series, e
 			prev = val
 			out = append(out, p)
 		}
-		serie.Datapoints = out
-		outSeries[i] = serie
+		series[i].Datapoints = out
 	}
-	cache[Req{}] = append(cache[Req{}], outSeries...)
-	return outSeries, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/func_derivative.go
+++ b/expr/func_derivative.go
@@ -34,15 +34,9 @@ func (s *FuncDerivative) Exec(cache map[Req][]models.Series) ([]models.Series, e
 	outSeries := make([]models.Series, len(series))
 	for i, serie := range series {
 		serie.Target = fmt.Sprintf("derivative(%s)", serie.Target)
+		serie.Tags = serie.CopyTagsWith("derivative", "1")
 		serie.QueryPatt = fmt.Sprintf("derivative(%s)", serie.QueryPatt)
 		out := pointSlicePool.Get().([]schema.Point)
-
-		newTags := make(map[string]string, len(serie.Tags)+1)
-		for k, v := range serie.Tags {
-			newTags[k] = v
-		}
-		newTags["derivative"] = "1"
-		serie.Tags = newTags
 
 		prev := math.NaN()
 		for _, p := range serie.Datapoints {

--- a/expr/func_divideseries.go
+++ b/expr/func_divideseries.go
@@ -67,6 +67,8 @@ func (s *FuncDivideSeries) Exec(cache map[Req][]models.Series) ([]models.Series,
 			Interval:     divisor.Interval,
 			Consolidator: dividend.Consolidator,
 			QueryCons:    dividend.QueryCons,
+			QueryFrom:    dividend.QueryFrom,
+			QueryTo:      dividend.QueryTo,
 			Meta:         dividend.Meta.Copy().Merge(divisor.Meta),
 		}
 		cache[Req{}] = append(cache[Req{}], output)

--- a/expr/func_divideseries.go
+++ b/expr/func_divideseries.go
@@ -67,6 +67,7 @@ func (s *FuncDivideSeries) Exec(cache map[Req][]models.Series) ([]models.Series,
 			Interval:     divisor.Interval,
 			Consolidator: dividend.Consolidator,
 			QueryCons:    dividend.QueryCons,
+			Meta:         dividend.Meta.Copy().Merge(divisor.Meta),
 		}
 		cache[Req{}] = append(cache[Req{}], output)
 		series = append(series, output)

--- a/expr/func_divideserieslists.go
+++ b/expr/func_divideserieslists.go
@@ -67,6 +67,7 @@ func (s *FuncDivideSeriesLists) Exec(cache map[Req][]models.Series) ([]models.Se
 			Interval:     divisor.Interval,
 			Consolidator: dividend.Consolidator,
 			QueryCons:    dividend.QueryCons,
+			Meta:         dividend.Meta.Copy().Merge(divisor.Meta),
 		}
 		cache[Req{}] = append(cache[Req{}], output)
 		series = append(series, output)

--- a/expr/func_divideserieslists.go
+++ b/expr/func_divideserieslists.go
@@ -67,6 +67,8 @@ func (s *FuncDivideSeriesLists) Exec(cache map[Req][]models.Series) ([]models.Se
 			Interval:     divisor.Interval,
 			Consolidator: dividend.Consolidator,
 			QueryCons:    dividend.QueryCons,
+			QueryFrom:    dividend.QueryFrom,
+			QueryTo:      dividend.QueryTo,
 			Meta:         dividend.Meta.Copy().Merge(divisor.Meta),
 		}
 		cache[Req{}] = append(cache[Req{}], output)

--- a/expr/func_get.go
+++ b/expr/func_get.go
@@ -24,6 +24,8 @@ func (s FuncGet) Context(context Context) Context {
 func (s FuncGet) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
 	series := cache[s.req]
 
+	// this function is the only exception to the COW pattern
+	// it is allowed to modify the series directly to set the needed tags
 	for k := range series {
 		series[k].SetTags()
 	}

--- a/expr/func_groupbytags.go
+++ b/expr/func_groupbytags.go
@@ -122,6 +122,8 @@ func (s *FuncGroupByTags) Exec(cache map[Req][]models.Series) ([]models.Series, 
 			Interval:     series[0].Interval,
 			Consolidator: cons,
 			QueryCons:    queryCons,
+			QueryFrom:    group.s[0].QueryFrom,
+			QueryTo:      group.s[0].QueryTo,
 			Meta:         group.m,
 		}
 		newSeries.SetTags()

--- a/expr/func_groupbytags.go
+++ b/expr/func_groupbytags.go
@@ -45,7 +45,11 @@ func (s *FuncGroupByTags) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		return nil, errors.New("No tags specified")
 	}
 
-	groups := make(map[string][]models.Series)
+	type Group struct {
+		s []models.Series
+		m models.SeriesMeta
+	}
+	groups := make(map[string]Group)
 	useName := false
 
 	groupTags := s.tags
@@ -99,15 +103,18 @@ func (s *FuncGroupByTags) Exec(cache map[Req][]models.Series) ([]models.Series, 
 
 		key := buffer.String()
 
-		groups[key] = append(groups[key], serie)
+		group := groups[key]
+		group.s = append(group.s, serie)
+		group.m = group.m.Merge(serie.Meta)
+		groups[key] = group
 	}
 
 	output := make([]models.Series, 0, len(groups))
 	aggFunc := getCrossSeriesAggFunc(s.aggregator)
 
 	// Now, for each key perform the requested aggregation
-	for name, groupSeries := range groups {
-		cons, queryCons := summarizeCons(groupSeries)
+	for name, group := range groups {
+		cons, queryCons := summarizeCons(group.s)
 
 		newSeries := models.Series{
 			Target:       name,
@@ -115,12 +122,13 @@ func (s *FuncGroupByTags) Exec(cache map[Req][]models.Series) ([]models.Series, 
 			Interval:     series[0].Interval,
 			Consolidator: cons,
 			QueryCons:    queryCons,
+			Meta:         group.m,
 		}
 		newSeries.SetTags()
 
 		newSeries.Datapoints = pointSlicePool.Get().([]schema.Point)
 
-		aggFunc(groupSeries, &newSeries.Datapoints)
+		aggFunc(group.s, &newSeries.Datapoints)
 		cache[Req{}] = append(cache[Req{}], newSeries)
 
 		output = append(output, newSeries)

--- a/expr/func_integral.go
+++ b/expr/func_integral.go
@@ -31,17 +31,11 @@ func (s *FuncIntegral) Exec(cache map[Req][]models.Series) ([]models.Series, err
 		return nil, err
 	}
 
-	out := make([]models.Series, len(series))
 	for i, serie := range series {
-		transformed := &out[i]
-		transformed.Target = fmt.Sprintf("integral(%s)", serie.Target)
-		transformed.Tags = serie.CopyTagsWith("integral", "1")
-		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
-		transformed.QueryPatt = fmt.Sprintf("integral(%s)", serie.QueryPatt)
-		transformed.Interval = serie.Interval
-		transformed.Consolidator = serie.Consolidator
-		transformed.QueryCons = serie.QueryCons
-		transformed.Meta = serie.Meta
+		series[i].Target = fmt.Sprintf("integral(%s)", serie.Target)
+		series[i].Tags = serie.CopyTagsWith("integral", "1")
+		series[i].QueryPatt = fmt.Sprintf("integral(%s)", serie.QueryPatt)
+		series[i].Datapoints = pointSlicePool.Get().([]schema.Point)
 
 		current := 0.0
 		for _, p := range serie.Datapoints {
@@ -49,10 +43,9 @@ func (s *FuncIntegral) Exec(cache map[Req][]models.Series) ([]models.Series, err
 				current += p.Val
 				p.Val = current
 			}
-			transformed.Datapoints = append(transformed.Datapoints, p)
+			series[i].Datapoints = append(series[i].Datapoints, p)
 		}
-		cache[Req{}] = append(cache[Req{}], *transformed)
 	}
-
-	return out, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/func_integral.go
+++ b/expr/func_integral.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/schema"
 )
 
@@ -36,6 +37,8 @@ func (s *FuncIntegral) Exec(cache map[Req][]models.Series) ([]models.Series, err
 		series[i].Tags = serie.CopyTagsWith("integral", "1")
 		series[i].QueryPatt = fmt.Sprintf("integral(%s)", serie.QueryPatt)
 		series[i].Datapoints = pointSlicePool.Get().([]schema.Point)
+		series[i].Consolidator = consolidation.None
+		series[i].QueryCons = consolidation.None
 
 		current := 0.0
 		for _, p := range serie.Datapoints {

--- a/expr/func_integral.go
+++ b/expr/func_integral.go
@@ -35,17 +35,13 @@ func (s *FuncIntegral) Exec(cache map[Req][]models.Series) ([]models.Series, err
 	for i, serie := range series {
 		transformed := &out[i]
 		transformed.Target = fmt.Sprintf("integral(%s)", serie.Target)
-		transformed.QueryPatt = fmt.Sprintf("integral(%s)", serie.QueryPatt)
-		transformed.Tags = make(map[string]string, len(serie.Tags)+1)
+		transformed.Tags = serie.CopyTagsWith("integral", "1")
 		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
+		transformed.QueryPatt = fmt.Sprintf("integral(%s)", serie.QueryPatt)
 		transformed.Interval = serie.Interval
 		transformed.Consolidator = serie.Consolidator
 		transformed.QueryCons = serie.QueryCons
-
-		for k, v := range serie.Tags {
-			transformed.Tags[k] = v
-		}
-		transformed.Tags["integral"] = "1"
+		transformed.Meta = serie.Meta
 
 		current := 0.0
 		for _, p := range serie.Datapoints {

--- a/expr/func_isnonnull.go
+++ b/expr/func_isnonnull.go
@@ -31,17 +31,11 @@ func (s *FuncIsNonNull) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		return nil, err
 	}
 
-	out := make([]models.Series, len(series))
 	for i, serie := range series {
-		transformed := &out[i]
-		transformed.Target = fmt.Sprintf("isNonNull(%s)", serie.Target)
-		transformed.QueryPatt = fmt.Sprintf("isNonNull(%s)", serie.QueryPatt)
-		transformed.Tags = serie.CopyTagsWith("isNonNull", "1")
-		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
-		transformed.Interval = serie.Interval
-		transformed.Consolidator = serie.Consolidator
-		transformed.QueryCons = serie.QueryCons
-		transformed.Meta = serie.Meta.Copy()
+		series[i].Target = fmt.Sprintf("isNonNull(%s)", serie.Target)
+		series[i].QueryPatt = fmt.Sprintf("isNonNull(%s)", serie.QueryPatt)
+		series[i].Tags = serie.CopyTagsWith("isNonNull", "1")
+		series[i].Datapoints = pointSlicePool.Get().([]schema.Point)
 
 		for _, p := range serie.Datapoints {
 			if math.IsNaN(p.Val) {
@@ -49,10 +43,9 @@ func (s *FuncIsNonNull) Exec(cache map[Req][]models.Series) ([]models.Series, er
 			} else {
 				p.Val = 1
 			}
-			transformed.Datapoints = append(transformed.Datapoints, p)
+			series[i].Datapoints = append(series[i].Datapoints, p)
 		}
-		cache[Req{}] = append(cache[Req{}], *transformed)
 	}
-
-	return out, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/func_isnonnull.go
+++ b/expr/func_isnonnull.go
@@ -36,16 +36,13 @@ func (s *FuncIsNonNull) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		transformed := &out[i]
 		transformed.Target = fmt.Sprintf("isNonNull(%s)", serie.Target)
 		transformed.QueryPatt = fmt.Sprintf("isNonNull(%s)", serie.QueryPatt)
-		transformed.Tags = make(map[string]string, len(serie.Tags)+1)
+		transformed.Tags = serie.CopyTagsWith("isNonNull", "1")
 		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
 		transformed.Interval = serie.Interval
 		transformed.Consolidator = serie.Consolidator
 		transformed.QueryCons = serie.QueryCons
+		transformed.Meta = serie.Meta.Copy()
 
-		for k, v := range serie.Tags {
-			transformed.Tags[k] = v
-		}
-		transformed.Tags["isNonNull"] = "1"
 		for _, p := range serie.Datapoints {
 			if math.IsNaN(p.Val) {
 				p.Val = 0

--- a/expr/func_keeplastvalue.go
+++ b/expr/func_keeplastvalue.go
@@ -45,13 +45,9 @@ func (s *FuncKeepLastValue) Exec(cache map[Req][]models.Series) ([]models.Series
 		return nil, err
 	}
 	limit := int(s.limit)
-	outSeries := make([]models.Series, len(series))
-	for i, in := range series {
-		serie := in.CopyBare()
-		serie.Target = fmt.Sprintf("keepLastValue(%s)", in.Target)
-		serie.QueryPatt = serie.Target
-		serie.Tags = in.Tags
-		serie.Meta = in.Meta
+	for i, serie := range series {
+		series[i].Target = fmt.Sprintf("keepLastValue(%s)", serie.Target)
+		series[i].QueryPatt = series[i].Target
 		out := pointSlicePool.Get().([]schema.Point)
 
 		var consecutiveNaNs int
@@ -78,9 +74,8 @@ func (s *FuncKeepLastValue) Exec(cache map[Req][]models.Series) ([]models.Series
 			}
 		}
 
-		serie.Datapoints = out
-		outSeries[i] = serie
+		series[i].Datapoints = out
 	}
-	cache[Req{}] = append(cache[Req{}], outSeries...)
-	return outSeries, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/func_keeplastvalue.go
+++ b/expr/func_keeplastvalue.go
@@ -46,10 +46,12 @@ func (s *FuncKeepLastValue) Exec(cache map[Req][]models.Series) ([]models.Series
 	}
 	limit := int(s.limit)
 	outSeries := make([]models.Series, len(series))
-	for i, serie := range series {
-		serie.Target = fmt.Sprintf("keepLastValue(%s)", serie.Target)
+	for i, in := range series {
+		serie := in.CopyBare()
+		serie.Target = fmt.Sprintf("keepLastValue(%s)", in.Target)
 		serie.QueryPatt = serie.Target
-
+		serie.Tags = in.Tags
+		serie.Meta = in.Meta
 		out := pointSlicePool.Get().([]schema.Point)
 
 		var consecutiveNaNs int

--- a/expr/func_movingaverage.go
+++ b/expr/func_movingaverage.go
@@ -37,6 +37,5 @@ func (s *FuncMovingAverage) Exec(cache map[Req][]models.Series) ([]models.Series
 	if err != nil {
 		return nil, err
 	}
-	//cache[Req{}] = append(cache[Req{}], out)
 	return series, nil
 }

--- a/expr/func_nonnegativederivative.go
+++ b/expr/func_nonnegativederivative.go
@@ -36,13 +36,10 @@ func (s *FuncNonNegativeDerivative) Exec(cache map[Req][]models.Series) ([]model
 		return nil, err
 	}
 
-	outSeries := make([]models.Series, len(series))
-	for i, in := range series {
-		serie := in.CopyBare()
-		serie.Target = fmt.Sprintf("nonNegativeDerivative(%s)", in.Target)
-		serie.QueryPatt = fmt.Sprintf("nonNegativeDerivative(%s)", in.QueryPatt)
-		serie.Tags = serie.CopyTagsWith("nonNegativeDerivative", "1")
-		serie.Meta = in.Meta
+	for i, serie := range series {
+		series[i].Target = fmt.Sprintf("nonNegativeDerivative(%s)", serie.Target)
+		series[i].QueryPatt = fmt.Sprintf("nonNegativeDerivative(%s)", serie.QueryPatt)
+		series[i].Tags = serie.CopyTagsWith("nonNegativeDerivative", "1")
 		out := pointSlicePool.Get().([]schema.Point)
 
 		prev := math.NaN()
@@ -52,11 +49,10 @@ func (s *FuncNonNegativeDerivative) Exec(cache map[Req][]models.Series) ([]model
 			p.Val = delta
 			out = append(out, p)
 		}
-		serie.Datapoints = out
-		outSeries[i] = serie
+		series[i].Datapoints = out
 	}
-	cache[Req{}] = append(cache[Req{}], outSeries...)
-	return outSeries, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }
 
 func nonNegativeDelta(val, prev, maxValue float64) (float64, float64) {

--- a/expr/func_nonnegativederivative.go
+++ b/expr/func_nonnegativederivative.go
@@ -37,17 +37,13 @@ func (s *FuncNonNegativeDerivative) Exec(cache map[Req][]models.Series) ([]model
 	}
 
 	outSeries := make([]models.Series, len(series))
-	for i, serie := range series {
-		serie.Target = fmt.Sprintf("nonNegativeDerivative(%s)", serie.Target)
-		serie.QueryPatt = fmt.Sprintf("nonNegativeDerivative(%s)", serie.QueryPatt)
+	for i, in := range series {
+		serie := in.CopyBare()
+		serie.Target = fmt.Sprintf("nonNegativeDerivative(%s)", in.Target)
+		serie.QueryPatt = fmt.Sprintf("nonNegativeDerivative(%s)", in.QueryPatt)
+		serie.Tags = serie.CopyTagsWith("nonNegativeDerivative", "1")
+		serie.Meta = in.Meta
 		out := pointSlicePool.Get().([]schema.Point)
-
-		newTags := make(map[string]string, len(serie.Tags)+1)
-		for k, v := range serie.Tags {
-			newTags[k] = v
-		}
-		newTags["nonNegativeDerivative"] = "1"
-		serie.Tags = newTags
 
 		prev := math.NaN()
 		for _, p := range serie.Datapoints {

--- a/expr/func_nonnegativederivative.go
+++ b/expr/func_nonnegativederivative.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/schema"
 )
 
@@ -40,6 +41,8 @@ func (s *FuncNonNegativeDerivative) Exec(cache map[Req][]models.Series) ([]model
 		series[i].Target = fmt.Sprintf("nonNegativeDerivative(%s)", serie.Target)
 		series[i].QueryPatt = fmt.Sprintf("nonNegativeDerivative(%s)", serie.QueryPatt)
 		series[i].Tags = serie.CopyTagsWith("nonNegativeDerivative", "1")
+		series[i].Consolidator = consolidation.None
+		series[i].QueryCons = consolidation.None
 		out := pointSlicePool.Get().([]schema.Point)
 
 		prev := math.NaN()

--- a/expr/func_persecond.go
+++ b/expr/func_persecond.go
@@ -64,6 +64,7 @@ func (s *FuncPerSecond) Exec(cache map[Req][]models.Series) ([]models.Series, er
 			Tags:       serie.Tags,
 			Datapoints: out,
 			Interval:   serie.Interval,
+			Meta:       serie.Meta,
 		}
 		outputs = append(outputs, s)
 		cache[Req{}] = append(cache[Req{}], s)

--- a/expr/func_removeabovebelowpercentile.go
+++ b/expr/func_removeabovebelowpercentile.go
@@ -55,13 +55,7 @@ func (s *FuncRemoveAboveBelowPercentile) Exec(cache map[Req][]models.Series) ([]
 			serie.Target = fmt.Sprintf("removeBelowPercentile(%s, %g)", serie.Target, s.n)
 		}
 		serie.QueryPatt = serie.Target
-
-		newTags := make(map[string]string, len(serie.Tags)+1)
-		for k, v := range serie.Tags {
-			newTags[k] = v
-		}
-		newTags["nPercentile"] = fmt.Sprintf("%g", s.n)
-		serie.Tags = newTags
+		serie.Tags = serie.CopyTagsWith("nPercentile", fmt.Sprintf("%g", s.n))
 
 		percentile := getPercentileValue(serie.Datapoints, s.n, sortedDatapointVals)
 

--- a/expr/func_scale.go
+++ b/expr/func_scale.go
@@ -48,6 +48,7 @@ func (s *FuncScale) Exec(cache map[Req][]models.Series) ([]models.Series, error)
 			Interval:     serie.Interval,
 			Consolidator: serie.Consolidator,
 			QueryCons:    serie.QueryCons,
+			Meta:         serie.Meta,
 		}
 		outputs = append(outputs, s)
 		cache[Req{}] = append(cache[Req{}], s)

--- a/expr/func_scale.go
+++ b/expr/func_scale.go
@@ -34,24 +34,15 @@ func (s *FuncScale) Exec(cache map[Req][]models.Series) ([]models.Series, error)
 	if err != nil {
 		return nil, err
 	}
-	var outputs []models.Series
-	for _, serie := range series {
+	for i, serie := range series {
 		out := pointSlicePool.Get().([]schema.Point)
 		for _, v := range serie.Datapoints {
 			out = append(out, schema.Point{Val: v.Val * s.factor, Ts: v.Ts})
 		}
-		s := models.Series{
-			Target:       fmt.Sprintf("scale(%s,%f)", serie.Target, s.factor),
-			QueryPatt:    fmt.Sprintf("scale(%s,%f)", serie.QueryPatt, s.factor),
-			Tags:         serie.Tags,
-			Datapoints:   out,
-			Interval:     serie.Interval,
-			Consolidator: serie.Consolidator,
-			QueryCons:    serie.QueryCons,
-			Meta:         serie.Meta,
-		}
-		outputs = append(outputs, s)
-		cache[Req{}] = append(cache[Req{}], s)
+		series[i].Target = fmt.Sprintf("scale(%s,%f)", serie.Target, s.factor)
+		series[i].QueryPatt = fmt.Sprintf("scale(%s,%f)", serie.QueryPatt, s.factor)
+		series[i].Datapoints = out
 	}
-	return outputs, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/func_scaletoseconds.go
+++ b/expr/func_scaletoseconds.go
@@ -40,16 +40,12 @@ func (s *FuncScaleToSeconds) Exec(cache map[Req][]models.Series) ([]models.Serie
 		transformed := &out[i]
 		transformed.Target = fmt.Sprintf("scaleToSeconds(%s,%d)", serie.Target, int64(s.seconds))
 		transformed.QueryPatt = transformed.Target
-		transformed.Tags = make(map[string]string, len(serie.Tags)+1)
+		transformed.Tags = serie.CopyTagsWith("scaleToSeconds", strconv.FormatFloat(s.seconds, 'g', -1, 64))
 		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
 		transformed.Interval = serie.Interval
 		transformed.Consolidator = serie.Consolidator
 		transformed.QueryCons = serie.QueryCons
-
-		for k, v := range serie.Tags {
-			transformed.Tags[k] = v
-		}
-		transformed.Tags["scaleToSeconds"] = strconv.FormatFloat(s.seconds, 'g', -1, 64)
+		transformed.Meta = serie.Meta
 
 		factor := float64(s.seconds) / float64(serie.Interval)
 		for _, p := range serie.Datapoints {

--- a/expr/func_scaletoseconds.go
+++ b/expr/func_scaletoseconds.go
@@ -35,17 +35,11 @@ func (s *FuncScaleToSeconds) Exec(cache map[Req][]models.Series) ([]models.Serie
 		return nil, err
 	}
 
-	out := make([]models.Series, len(series))
 	for i, serie := range series {
-		transformed := &out[i]
-		transformed.Target = fmt.Sprintf("scaleToSeconds(%s,%d)", serie.Target, int64(s.seconds))
-		transformed.QueryPatt = transformed.Target
-		transformed.Tags = serie.CopyTagsWith("scaleToSeconds", strconv.FormatFloat(s.seconds, 'g', -1, 64))
-		transformed.Datapoints = pointSlicePool.Get().([]schema.Point)
-		transformed.Interval = serie.Interval
-		transformed.Consolidator = serie.Consolidator
-		transformed.QueryCons = serie.QueryCons
-		transformed.Meta = serie.Meta
+		series[i].Target = fmt.Sprintf("scaleToSeconds(%s,%d)", serie.Target, int64(s.seconds))
+		series[i].QueryPatt = series[i].Target
+		series[i].Tags = serie.CopyTagsWith("scaleToSeconds", strconv.FormatFloat(s.seconds, 'g', -1, 64))
+		series[i].Datapoints = pointSlicePool.Get().([]schema.Point)
 
 		factor := float64(s.seconds) / float64(serie.Interval)
 		for _, p := range serie.Datapoints {
@@ -54,9 +48,9 @@ func (s *FuncScaleToSeconds) Exec(cache map[Req][]models.Series) ([]models.Serie
 				roundingFactor := math.Pow(10, 6)
 				p.Val = math.Round(p.Val*factor*roundingFactor) / roundingFactor
 			}
-			transformed.Datapoints = append(transformed.Datapoints, p)
+			series[i].Datapoints = append(series[i].Datapoints, p)
 		}
 	}
-	cache[Req{}] = append(cache[Req{}], out...)
-	return out, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/func_summarize.go
+++ b/expr/func_summarize.go
@@ -70,11 +70,11 @@ func (s *FuncSummarize) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		output := models.Series{
 			Target:     newName(serie.Target),
 			QueryPatt:  newName(serie.QueryPatt),
-			Tags:       serie.Tags,
+			Tags:       serie.CopyTagsWith("summarize", s.intervalString),
 			Datapoints: out,
 			Interval:   interval,
+			Meta:       serie.Meta,
 		}
-		output.Tags["summarize"] = s.intervalString
 		output.Tags["summarizeFunction"] = s.fn
 
 		outputs = append(outputs, output)

--- a/expr/func_summarize.go
+++ b/expr/func_summarize.go
@@ -70,6 +70,8 @@ func (s *FuncSummarize) Exec(cache map[Req][]models.Series) ([]models.Series, er
 		output := models.Series{
 			Target:     newName(serie.Target),
 			QueryPatt:  newName(serie.QueryPatt),
+			QueryFrom:  serie.QueryFrom,
+			QueryTo:    serie.QueryTo,
 			Tags:       serie.CopyTagsWith("summarize", s.intervalString),
 			Datapoints: out,
 			Interval:   interval,

--- a/expr/func_transformnull.go
+++ b/expr/func_transformnull.go
@@ -55,6 +55,7 @@ func (s *FuncTransformNull) Exec(cache map[Req][]models.Series) ([]models.Series
 			Interval:     serie.Interval,
 			Consolidator: serie.Consolidator,
 			QueryCons:    serie.QueryCons,
+			Meta:         serie.Meta,
 		}
 		for _, p := range serie.Datapoints {
 			if math.IsNaN(p.Val) {

--- a/expr/func_transformnull.go
+++ b/expr/func_transformnull.go
@@ -39,32 +39,23 @@ func (s *FuncTransformNull) Exec(cache map[Req][]models.Series) ([]models.Series
 		custom = false
 	}
 
-	var out []models.Series
-	for _, serie := range series {
+	for i, serie := range series {
 		var target string
 		if custom {
 			target = fmt.Sprintf("transFormNull(%s,%f)", serie.Target, s.def)
 		} else {
 			target = fmt.Sprintf("transFormNull(%s)", serie.Target)
 		}
-		transformed := models.Series{
-			Target:       target,
-			QueryPatt:    target,
-			Tags:         serie.Tags,
-			Datapoints:   pointSlicePool.Get().([]schema.Point),
-			Interval:     serie.Interval,
-			Consolidator: serie.Consolidator,
-			QueryCons:    serie.QueryCons,
-			Meta:         serie.Meta,
-		}
+		series[i].Target = target
+		series[i].QueryPatt = target
+		series[i].Datapoints = pointSlicePool.Get().([]schema.Point)
 		for _, p := range serie.Datapoints {
 			if math.IsNaN(p.Val) {
 				p.Val = s.def
 			}
-			transformed.Datapoints = append(transformed.Datapoints, p)
+			series[i].Datapoints = append(series[i].Datapoints, p)
 		}
-		out = append(out, transformed)
-		cache[Req{}] = append(cache[Req{}], transformed)
 	}
-	return out, nil
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
 }

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -33,6 +33,7 @@ type GraphiteFunc interface {
 	// * not modify slices of points that they get from their inputs
 	// * use the pool to get new slices in which to store any new/modified dat
 	// * add the newly created slices into the cache so they can be reclaimed after the output is consumed
+	// * not modify other properties on its input series, such as Tags map or Meta
 	Exec(map[Req][]models.Series) ([]models.Series, error)
 }
 

--- a/expr/plan.go
+++ b/expr/plan.go
@@ -220,7 +220,6 @@ func (p Plan) Run(input map[Req][]models.Series) ([]models.Series, error) {
 	var out []models.Series
 	p.data = input
 	for _, fn := range p.funcs {
-		// TODO track in all function execs
 		series, err := fn.Exec(p.data)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
fix #1091 

Here's my vision:
for every series, there's a SeriesSource. The SeriesSource describes how the data was generated through the concept of SeriesSourceProperties (which describe which storage-schemas rules applied to our data, which archive we read from, what kind of normalization and runtime consolidation was applied) along with a count of series for those properties.

In the most simple case (fetching 1 timeseries, and not running a function like sumSeries() or no merging together because of an interval change), the source is only one set of properties with a count of 1.

When things get interesting (mergeSeries, sumSeries(), etc) is when we need to combine multiple series to create one new output series. in all these cases we merge the SeriesSources together, adding up the counts based on their SeriesSourceProperties.

Ultimately then, for any series returned in the http response body, we know if it was composed out of just 1 source timeseries or multiple, and how they were generated.

Conceptually I think it's fairly simple. the main challenge is updating all processing functions accordingly (for now i've only done a few to showcase the idea) and making sure not to make any permanent changes to SeriesSource maps when we may reuse series in the processing pipeline

the output format for now looks like so:
(notice how we already had response-global metadata, and now we're adding per series metadata under "source")
note that instead of (or in addition to) schema-id i plan to return the actual schemas rule being used.
```
~ ❯❯❯ http  'http://localhost:6060/render?target=metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32&from=-5s&meta=true'
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Length: 399
Content-Type: application/json
Date: Wed, 25 Sep 2019 12:57:19 GMT
Vary: Accept-Encoding

{
    "meta": {
        "stats": {
            "executeplan.cache-hit-partial.count": 0,
            "executeplan.cache-hit.count": 0,
            "executeplan.cache-miss.count": 0,
            "executeplan.chunks-from-cache.count": 0,
            "executeplan.chunks-from-store.count": 0,
            "executeplan.chunks-from-tank.count": 1,
            "executeplan.get-targets.ms": 0,
            "executeplan.plan-run.ms": 0,
            "executeplan.points-fetch.count": 5,
            "executeplan.points-return.count": 5,
            "executeplan.prepare-series.ms": 0,
            "executeplan.resolve-series.ms": 0,
            "executeplan.series-fetch.count": 1
        }
    },
    "series": [
        {
            "datapoints": [
                [
                    8152,
                    1569416235
                ],
                [
                    8559,
                    1569416236
                ],
                [
                    8864,
                    1569416237
                ],
                [
                    9162,
                    1569416238
                ],
                [
                    9450,
                    1569416239
                ]
            ],
            "source": [
                {
                    "aggnum-norm": 1,
                    "aggnum-rc": 0,
                    "archive": 0,
                    "consolidate-normfetch": "AverageConsolidator",
                    "consolidate-rc": "NoneConsolidator",
                    "count": 1,
                    "schema-id": 0
                }
            ],
            "tags": {
                "name": "metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32"
            },
            "target": "metrictank.stats.docker-env.default.input.carbon.metricdata.received.counter32"
        }
    ],
    "version": "v0.1"
}

```
cc @torkelo 