### PR TITLE
Dockerfiles now actually build metrictank too instead of relying on a pre-existing local build

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,21 +1,32 @@
+FROM golang:1.11.4-alpine AS gobase
+RUN apk add --no-cache git bash
+
+# Compile metrictank
+ENV MT_SRC_DIR $GOPATH/src/github.com/grafana/metrictank
+RUN mkdir -p $MT_SRC_DIR
+ADD . $MT_SRC_DIR
+RUN $MT_SRC_DIR/scripts/build.sh
+RUN cp -r $MT_SRC_DIR/build /tmp/build
+
+
 FROM alpine:3.10.0
 MAINTAINER Dieter Plaetinck dieter@grafana.com
 
 RUN apk add -U tzdata
 
 RUN mkdir -p /etc/metrictank /usr/share/metrictank/examples
-COPY config/metrictank-docker.ini /etc/metrictank/metrictank.ini
-COPY config/index-rules.conf /etc/metrictank/index-rules.conf
-COPY config/storage-schemas.conf /etc/metrictank/storage-schemas.conf
-COPY config/storage-aggregation.conf /etc/metrictank/storage-aggregation.conf
-COPY config/schema-store-cassandra.toml /etc/metrictank/schema-store-cassandra.toml
-COPY config/schema-idx-cassandra.toml /etc/metrictank/schema-idx-cassandra.toml
-COPY config/schema-store-scylladb.toml /usr/share/metrictank/examples/schema-store-scylladb.toml
-COPY config/schema-idx-scylladb.toml /usr/share/metrictank/examples/schema-idx-scylladb.toml
+COPY scripts/config/metrictank-docker.ini /etc/metrictank/metrictank.ini
+COPY scripts/config/index-rules.conf /etc/metrictank/index-rules.conf
+COPY scripts/config/storage-schemas.conf /etc/metrictank/storage-schemas.conf
+COPY scripts/config/storage-aggregation.conf /etc/metrictank/storage-aggregation.conf
+COPY scripts/config/schema-store-cassandra.toml /etc/metrictank/schema-store-cassandra.toml
+COPY scripts/config/schema-idx-cassandra.toml /etc/metrictank/schema-idx-cassandra.toml
+COPY scripts/config/schema-store-scylladb.toml /usr/share/metrictank/examples/schema-store-scylladb.toml
+COPY scripts/config/schema-idx-scylladb.toml /usr/share/metrictank/examples/schema-idx-scylladb.toml
 
-COPY build/* /usr/bin/
+COPY --from=gobase /tmp/build/* /usr/bin/
 
-COPY util/wait_for_endpoint.sh /usr/bin/wait_for_endpoint.sh
+COPY scripts/util/wait_for_endpoint.sh /usr/bin/wait_for_endpoint.sh
 
 EXPOSE 6060
 

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -4,17 +4,13 @@ set -x
 set -e
 # Find the directory we exist within
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-cd ${DIR}
-source version-tag.sh
+cd ${DIR}/..
+source ${DIR}/version-tag.sh
 
 # regular image
-rm -rf build/*
-mkdir -p build
-cp ../build/* build/
-
 if [ -z "$1" ]
 then
-    docker build -t grafana/metrictank .
+    docker build -t grafana/metrictank -f ${DIR}/Dockerfile .
     docker tag grafana/metrictank grafana/metrictank:$tag
     docker tag grafana/metrictank grafana/metrictank:$version
 

--- a/scripts/dlv/Dockerfile
+++ b/scripts/dlv/Dockerfile
@@ -1,9 +1,17 @@
 FROM golang:1.11.4-alpine AS gobase
-ENV CGO_ENABLED 0
+RUN apk add --no-cache git bash
+
+# Compile metrictank
+ENV MT_SRC_DIR $GOPATH/src/github.com/grafana/metrictank
+RUN mkdir -p $MT_SRC_DIR
+ADD . $MT_SRC_DIR
+RUN $MT_SRC_DIR/scripts/build.sh -debug
+RUN cp -r $MT_SRC_DIR/build /tmp/build
 
 # Compile Delve
-RUN apk add --no-cache git
+ENV CGO_ENABLED 0
 RUN go get github.com/derekparker/delve/cmd/dlv
+
 
 FROM alpine:3.10.0
 MAINTAINER Dieter Plaetinck dieter@grafana.com
@@ -11,18 +19,18 @@ MAINTAINER Dieter Plaetinck dieter@grafana.com
 RUN apk add -U tzdata
 
 RUN mkdir -p /etc/metrictank /usr/share/metrictank/examples
-COPY config/metrictank-docker.ini /etc/metrictank/metrictank.ini
-COPY config/index-rules.conf /etc/metrictank/index-rules.conf
-COPY config/storage-schemas.conf /etc/metrictank/storage-schemas.conf
-COPY config/storage-aggregation.conf /etc/metrictank/storage-aggregation.conf
-COPY config/schema-store-cassandra.toml /etc/metrictank/schema-store-cassandra.toml
-COPY config/schema-idx-cassandra.toml /etc/metrictank/schema-idx-cassandra.toml
-COPY config/schema-store-scylladb.toml /usr/share/metrictank/examples/schema-store-scylladb.toml
-COPY config/schema-idx-scylladb.toml /usr/share/metrictank/examples/schema-idx-scylladb.toml
+COPY scripts/config/metrictank-docker.ini /etc/metrictank/metrictank.ini
+COPY scripts/config/index-rules.conf /etc/metrictank/index-rules.conf
+COPY scripts/config/storage-schemas.conf /etc/metrictank/storage-schemas.conf
+COPY scripts/config/storage-aggregation.conf /etc/metrictank/storage-aggregation.conf
+COPY scripts/config/schema-store-cassandra.toml /etc/metrictank/schema-store-cassandra.toml
+COPY scripts/config/schema-idx-cassandra.toml /etc/metrictank/schema-idx-cassandra.toml
+COPY scripts/config/schema-store-scylladb.toml /usr/share/metrictank/examples/schema-store-scylladb.toml
+COPY scripts/config/schema-idx-scylladb.toml /usr/share/metrictank/examples/schema-idx-scylladb.toml
 
-COPY build/* /usr/bin/
+COPY --from=gobase /tmp/build/* /usr/bin/
 
-COPY util/wait_for_endpoint_debug.sh /usr/bin/wait_for_endpoint_debug.sh
+COPY scripts/util/wait_for_endpoint.sh /usr/bin/wait_for_endpoint.sh
 
 COPY --from=gobase /go/bin/dlv /usr/bin/dlv
 

--- a/scripts/dlv/Dockerfile
+++ b/scripts/dlv/Dockerfile
@@ -30,7 +30,7 @@ COPY scripts/config/schema-idx-scylladb.toml /usr/share/metrictank/examples/sche
 
 COPY --from=gobase /tmp/build/* /usr/bin/
 
-COPY scripts/util/wait_for_endpoint.sh /usr/bin/wait_for_endpoint.sh
+COPY scripts/util/wait_for_endpoint_debug.sh /usr/bin/wait_for_endpoint_debug.sh
 
 COPY --from=gobase /go/bin/dlv /usr/bin/dlv
 


### PR DESCRIPTION
Dockerfiles now actually build metrictank too instead of relying on a pre-existing local build.

This prevents pollution of the build and makes it easier to customize what version of Golang is used to build metrictank.

Base image used for building metrictank is `golang:1.11.4-alpine`. Previously the Golang version was the one set in the CI: `circleci/golang:1.11.4` (see `.circleci/config.yml`).