### PR TITLE
MemoryReporter: make call to runtime.ReadMemStats time bound to avoid lost metrics

### DIFF
--- a/stats/memory_reporter.go
+++ b/stats/memory_reporter.go
@@ -23,7 +23,7 @@ func NewMemoryReporter() *MemoryReporter {
 		mem := &runtime.MemStats{}
 		runtime.ReadMemStats(mem)
 		return mem
-	}, 500*time.Millisecond, 1*time.Minute)
+	}, 5*time.Second, 1*time.Minute)
 	return reporter
 }
 

--- a/stats/memory_reporter.go
+++ b/stats/memory_reporter.go
@@ -20,8 +20,8 @@ type MemoryReporter struct {
 func NewMemoryReporter() *MemoryReporter {
 	reporter := registry.getOrAdd("memory", &MemoryReporter{}).(*MemoryReporter)
 	reporter.timeBoundGetMemStats = util.TimeBoundWithCacheFunc(func() interface{} {
-		mem := &runtime.MemStats{}
-		runtime.ReadMemStats(mem)
+		mem := runtime.MemStats{}
+		runtime.ReadMemStats(&mem)
 		return mem
 	}, 5*time.Second, 1*time.Minute)
 	return reporter
@@ -46,7 +46,7 @@ func getGcPercent() int {
 }
 
 func (m *MemoryReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
-	m.mem = *m.timeBoundGetMemStats().(*runtime.MemStats)
+	m.mem = m.timeBoundGetMemStats().(runtime.MemStats)
 	gcPercent := getGcPercent()
 
 	// metric memory.total_bytes_allocated is a counter of total number of bytes allocated during process lifetime

--- a/util/timeout.go
+++ b/util/timeout.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"time"
+)
+
+// TimeBoundWithCacheFunc decorates a function that has a return value in order to bound its execution time.
+// When the decorated function is called, if the original function takes more than 'timeout' to execute,
+// the returned value will be the value returned by a previous call. If no previous call was performed,
+// the call will block until the original function returns.
+func TimeBoundWithCacheFunc(fn func() interface{}, timeout, maxAge time.Duration) func() interface{} {
+	var previousResult interface{}
+	var previousTimestamp time.Time
+
+	return func() interface{} {
+		done := make(chan interface{}, 1)
+		timer := time.NewTimer(timeout)
+
+		go func() {
+			result := fn()
+			done <- result
+			close(done)
+		}()
+
+		var result interface{}
+
+		select {
+		case result = <-done:
+			// call succeeded in time, use its result
+			// avoid timers from staying alive
+			// see https://medium.com/@oboturov/golang-time-after-is-not-garbage-collected-4cbc94740082
+			timer.Stop()
+		case <-timer.C:
+			// call took too long, use cached result if not too old
+			if time.Since(previousTimestamp) < maxAge && previousResult != nil {
+				return previousResult
+			}
+		}
+		if result == nil { // in case the result did not arrive in time but the previous result was too old
+			result = <-done
+		}
+		previousTimestamp = time.Now()
+		previousResult = result
+		return result
+	}
+}

--- a/util/timeout.go
+++ b/util/timeout.go
@@ -34,11 +34,12 @@ func TimeBoundWithCacheFunc(fn func() interface{}, timeout, maxAge time.Duration
 			// call took too long, use cached result if not too old
 			if time.Since(previousTimestamp) < maxAge && previousResult != nil {
 				return previousResult
+			} else {
+				// in case the result did not arrive in time but the previous result was too old
+				result = <-done
 			}
 		}
-		if result == nil { // in case the result did not arrive in time but the previous result was too old
-			result = <-done
-		}
+
 		previousTimestamp = time.Now()
 		previousResult = result
 		return result

--- a/util/timeout_test.go
+++ b/util/timeout_test.go
@@ -145,8 +145,7 @@ func TestTimeBoundWithCacheFunc(t *testing.T) {
 
 			for i := range tt.executionDurations {
 				// compute end time for all function executions of the test
-				tolerance := 1 * time.Millisecond
-				finishesAt := time.Now().Add(tt.executionDurations[i] + tolerance)
+				finishesAt := time.Now().Add(tt.executionDurations[i])
 				if finishesAt.After(endTime) {
 					endTime = finishesAt
 				}
@@ -165,6 +164,7 @@ func TestTimeBoundWithCacheFunc(t *testing.T) {
 				// check that function execution took around tt.timeout
 				// if the function does not have a cached result or the cache is stale due to maxAge, the timeout is not enforced
 				cacheIsStale := time.Now().After(cacheTimestamp.Add(tt.maxAge))
+				tolerance := 1 * time.Millisecond
 				if !cacheIsStale && executionDuration > tt.timeout+tolerance {
 					t.Errorf("iteration %v: decoratedFunc() took too long to execute %v which is greater than timeout (%v)", i, executionDuration, tt.timeout)
 				}
@@ -175,7 +175,8 @@ func TestTimeBoundWithCacheFunc(t *testing.T) {
 			}
 
 			// detects if any goroutine is leaked after all processing is supposed to be complete
-			time.Sleep(time.Until(endTime))
+			tolerance := 100 * time.Millisecond
+			time.Sleep(time.Until(endTime.Add(tolerance)))
 			extraGoRoutines := runtime.NumGoroutine() - numGoRoutineAtRest
 			if extraGoRoutines > 0 {
 				t.Errorf("too many goroutines left after processing: %d", extraGoRoutines)

--- a/util/timeout_test.go
+++ b/util/timeout_test.go
@@ -1,0 +1,175 @@
+package util
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestTimeBoundWithCacheFunc(t *testing.T) {
+	tests := []struct {
+		name               string
+		functionReturns    []int
+		executionDurations []time.Duration
+		expectedResults    []int
+		timeout            time.Duration
+		maxAge             time.Duration
+	}{
+		{
+			name:               "immediate",
+			functionReturns:    []int{42},
+			executionDurations: []time.Duration{0},
+			expectedResults:    []int{42},
+			timeout:            50 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "immediate_zero_timeout",
+			functionReturns:    []int{42},
+			executionDurations: []time.Duration{0},
+			expectedResults:    []int{42},
+			timeout:            0 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "immediate_zero_maxage",
+			functionReturns:    []int{42},
+			executionDurations: []time.Duration{0},
+			expectedResults:    []int{42},
+			timeout:            50 * time.Millisecond,
+			maxAge:             0 * time.Minute,
+		},
+		{
+			name:               "slow_notimeout",
+			functionReturns:    []int{42},
+			executionDurations: []time.Duration{100 * time.Millisecond},
+			expectedResults:    []int{42},
+			timeout:            500 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "slow_timeout",
+			functionReturns:    []int{42},
+			executionDurations: []time.Duration{100 * time.Millisecond},
+			expectedResults:    []int{42},
+			timeout:            50 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "fast_then_slow_timeout",
+			functionReturns:    []int{42, 88},
+			executionDurations: []time.Duration{10 * time.Millisecond, 100 * time.Millisecond},
+			expectedResults:    []int{42, 42},
+			timeout:            50 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "fast_then_fast",
+			functionReturns:    []int{42, 88},
+			executionDurations: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			expectedResults:    []int{42, 88},
+			timeout:            50 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "slow_timeout_then_slow_timeout",
+			functionReturns:    []int{42, 88},
+			executionDurations: []time.Duration{100 * time.Millisecond, 100 * time.Millisecond},
+			expectedResults:    []int{42, 42},
+			timeout:            50 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "fast_then_slow_then_fast_never_timeout",
+			functionReturns:    []int{42, 88, 1},
+			executionDurations: []time.Duration{1 * time.Millisecond, 100 * time.Millisecond, 2 * time.Millisecond},
+			expectedResults:    []int{42, 88, 1},
+			timeout:            500 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "fast_then_slow_timeout_then_fast",
+			functionReturns:    []int{42, 88, 1},
+			executionDurations: []time.Duration{1 * time.Millisecond, 100 * time.Millisecond, 2 * time.Millisecond},
+			expectedResults:    []int{42, 42, 1},
+			timeout:            50 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
+			name:               "stale_cache_fast_then_slow_timeout",
+			functionReturns:    []int{42, 88},
+			executionDurations: []time.Duration{10 * time.Millisecond, 100 * time.Millisecond},
+			expectedResults:    []int{42, 88},
+			timeout:            50 * time.Millisecond,
+			maxAge:             30 * time.Millisecond,
+		},
+		{
+			name:               "stale_cache_slow_timeout_then_slow_timeout",
+			functionReturns:    []int{42, 88},
+			executionDurations: []time.Duration{100 * time.Millisecond, 100 * time.Millisecond},
+			expectedResults:    []int{42, 88},
+			timeout:            50 * time.Millisecond,
+			maxAge:             30 * time.Millisecond,
+		},
+		{
+			name:               "stale_cache_fast_then_slow_timeout_then_fast_then_slow",
+			functionReturns:    []int{42, 88, 1, 33},
+			executionDurations: []time.Duration{1 * time.Millisecond, 100 * time.Millisecond, 2 * time.Millisecond, 100 * time.Millisecond},
+			expectedResults:    []int{42, 88, 1, 33},
+			timeout:            50 * time.Millisecond,
+			maxAge:             30 * time.Millisecond,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			numGoRoutineAtRest := runtime.NumGoroutine()
+			endTime := time.Now()
+
+			var i int
+			fn := func() interface{} {
+				result := tt.functionReturns[i]
+				time.Sleep(tt.executionDurations[i])
+				return result
+			}
+			decoratedFunc := TimeBoundWithCacheFunc(fn, tt.timeout, tt.maxAge)
+			var cacheTimestamp time.Time
+
+			for i = range tt.executionDurations {
+				// compute end time for all function executions of the test
+				tolerance := 1 * time.Millisecond
+				finishesAt := time.Now().Add(tt.executionDurations[i] + tolerance)
+				if finishesAt.After(endTime) {
+					endTime = finishesAt
+				}
+
+				beforeExecution := time.Now()
+				result := decoratedFunc()
+				executionDuration := time.Now().Sub(beforeExecution)
+
+				// save last time a result was cached
+				if tt.executionDurations[i] <= tt.timeout {
+					cacheTimestamp = time.Now()
+				}
+
+				// check that function execution took around tt.timeout
+				// if the function does not have a cached result or the cache is stale due to maxAge, the timeout is not enforced
+				cacheIsStale := time.Now().After(cacheTimestamp.Add(tt.maxAge))
+				if !cacheIsStale && executionDuration > tt.timeout+tolerance {
+					t.Errorf("iteration %v: decoratedFunc() took too long to execute %v which is greater than timeout (%v)", i, executionDuration, tt.timeout)
+				}
+
+				if !reflect.DeepEqual(result, tt.expectedResults[i]) {
+					t.Errorf("iteration %v: decoratedFunc() = %v, want %v", i, result, tt.expectedResults[i])
+				}
+			}
+
+			// detects if any goroutine is leaked after all processing is supposed to be complete
+			time.Sleep(time.Until(endTime))
+			extraGoRoutines := runtime.NumGoroutine() - numGoRoutineAtRest
+			if extraGoRoutines > 0 {
+				t.Errorf("too many goroutines left after processing: %d", extraGoRoutines)
+			}
+		})
+	}
+}

--- a/util/timeout_test.go
+++ b/util/timeout_test.go
@@ -81,6 +81,14 @@ func TestTimeBoundWithCacheFunc(t *testing.T) {
 			maxAge:             5 * time.Minute,
 		},
 		{
+			name:               "fast_then_fast_then_slow_timeout",
+			functionReturns:    []int{42, 88, 1},
+			executionDurations: []time.Duration{10 * time.Millisecond, 1 * time.Millisecond, 100 * time.Millisecond},
+			expectedResults:    []int{42, 88, 88},
+			timeout:            50 * time.Millisecond,
+			maxAge:             5 * time.Minute,
+		},
+		{
 			name:               "fast_then_slow_then_fast_never_timeout",
 			functionReturns:    []int{42, 88, 1},
 			executionDurations: []time.Duration{1 * time.Millisecond, 100 * time.Millisecond, 2 * time.Millisecond},

--- a/util/timeout_test.go
+++ b/util/timeout_test.go
@@ -156,21 +156,21 @@ func TestTimeBoundWithCacheFunc(t *testing.T) {
 				result := decoratedFunc()
 				executionDuration := time.Now().Sub(beforeExecution)
 
-				// save last time a result was cached
-				if tt.executionDurations[i] <= tt.timeout {
-					cacheTimestamp = time.Now()
-				}
-
 				// check that function execution took around tt.timeout
 				// if the function does not have a cached result or the cache is stale due to maxAge, the timeout is not enforced
 				cacheIsStale := time.Now().After(cacheTimestamp.Add(tt.maxAge))
-				tolerance := 1 * time.Millisecond
+				tolerance := 20 * time.Millisecond
 				if !cacheIsStale && executionDuration > tt.timeout+tolerance {
 					t.Errorf("iteration %v: decoratedFunc() took too long to execute %v which is greater than timeout (%v)", i, executionDuration, tt.timeout)
 				}
 
 				if !reflect.DeepEqual(result, tt.expectedResults[i]) {
 					t.Errorf("iteration %v: decoratedFunc() = %v, want %v", i, result, tt.expectedResults[i])
+				}
+
+				// save last time a result was cached
+				if tt.executionDurations[i] <= tt.timeout {
+					cacheTimestamp = time.Now()
 				}
 			}
 

--- a/util/timeout_test.go
+++ b/util/timeout_test.go
@@ -101,7 +101,7 @@ func TestTimeBoundWithCacheFunc(t *testing.T) {
 			functionReturns:    []int{42, 88, 1},
 			executionDurations: []time.Duration{veryShortDuration, longDuration, veryShortDuration},
 			expectedResults:    []int{42, 88, 1},
-			timeout:            veryLongDuration, //FIXME: only use?
+			timeout:            veryLongDuration,
 			maxAge:             veryLongDuration,
 		},
 		{


### PR DESCRIPTION
MemoryReporter: make call to runtime.ReadMemStats time bound to avoid lost metrics. If the timeout is reached, use the previous result of the function.
Added a generic decorator to limit function execution time.

Inspired by https://github.com/prometheus/client_golang/pull/568

Fixes #1207