### PR TITLE
disable staticcheck

### DIFF
--- a/scripts/qa/unused.sh
+++ b/scripts/qa/unused.sh
@@ -2,12 +2,14 @@
 
 # runs the tools staticcheck, varcheck, structcheck and deadcode
 # see their websites for more info.
+# staticcheck is temporarily commented because of a recent commit which makes it segfault
+# as soon as it is fixed, please uncomment again
 
 # find the dir we exist within...
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # and cd into root project dir
 cd ${DIR}/../..
-go get -u honnef.co/go/tools/cmd/staticcheck
+#go get -u honnef.co/go/tools/cmd/staticcheck
 go get -u github.com/opennota/check/cmd/varcheck
 go get -u github.com/opennota/check/cmd/structcheck
 # for https://github.com/remyoudompheng/go-misc/pull/14
@@ -15,10 +17,10 @@ go get -u github.com/Dieterbe/go-misc/deadcode
 
 ret=0
 
-echo "## running staticcheck"
-staticcheck -checks U1000 ./...
-r=$?
-[ $r -gt $ret ] && ret=$r
+#echo "## running staticcheck"
+#staticcheck -checks U1000 ./...
+#r=$?
+#[ $r -gt $ret ] && ret=$r
 
 echo "## running varcheck"
 varcheck ./...


### PR DESCRIPTION
staticcheck is segfaulting since a very recent commit. this temporarily comments the staticcheck utility, once it is fixed we can uncomment it again.

that's the issue:
```
## running staticcheck
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x6da988]
```