### PR TITLE
report readiness per kafka partition

### DIFF
--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -360,6 +360,7 @@ func (k *KafkaMdm) trackStats(topic string, partition int32) {
 			kafkaStats.Lag.Set(lag)
 			k.lagMonitor.StoreOffsets(partition, currentOffset, newest, ts)
 			kafkaStats.Priority.Set(k.lagMonitor.GetPartitionPriority(partition))
+			kafkaStats.Ready.Set(cluster.Manager.IsReady())
 		}
 	}
 }

--- a/stats/kafka.go
+++ b/stats/kafka.go
@@ -19,6 +19,7 @@ type KafkaPartition struct {
 	LogSize  Gauge64
 	Lag      Gauge64
 	Priority Gauge64
+	Ready    Bool
 }
 
 func NewKafkaPartition(prefix string) *KafkaPartition {
@@ -27,5 +28,6 @@ func NewKafkaPartition(prefix string) *KafkaPartition {
 	registry.getOrAdd(prefix+".log_size", &k.LogSize)
 	registry.getOrAdd(prefix+".lag", &k.Lag)
 	registry.getOrAdd(prefix+".priority", &k.Priority)
+	registry.getOrAdd(prefix+".ready", &k.Ready)
 	return &k
 }


### PR DESCRIPTION
this is necessary for us so we can create an alert to monitor if a partition's data is not served by any instance of Metrictank.

#1492 