### PR TITLE
monitor efficiency of enrichment cache

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -202,6 +202,8 @@ a counter of findCache misses
 the duration of a get of one metric in the memory idx
 * `idx.memory.list`:  
 the duration of memory idx listings
+* `idx.memory.meta-tags.enrichment-cache.entries`:  
+a the number of entries in the enrichment cache
 * `idx.memory.meta-tags.enrichment-cache.ops.hit`:  
 a counter of enrichment cache hits
 * `idx.memory.meta-tags.enrichment-cache.ops.miss`:  

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -202,6 +202,10 @@ a counter of findCache misses
 the duration of a get of one metric in the memory idx
 * `idx.memory.list`:  
 the duration of memory idx listings
+* `idx.memory.meta-tags.enrichment-cache.ops.hit`:  
+a counter of enrichment cache hits
+* `idx.memory.meta-tags.enrichment-cache.ops.miss`:  
+a counter of enrichment cache misses
 * `idx.memory.ops.add`:  
 the number of additions to the memory idx
 * `idx.memory.ops.update`:  

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -871,6 +871,10 @@ func (m *UnpartitionedMemoryIdx) FindByTag(orgId uint32, query tagquery.Query) [
 		}
 	}
 
+	if enricher != nil {
+		enricher.reportStats()
+	}
+
 	results := make([]idx.Node, len(byPath))
 
 	i := 0
@@ -1114,6 +1118,10 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 		}
 	}
 
+	if enricher != nil {
+		enricher.reportStats()
+	}
+
 	// handle special case of the name tag
 	if len(prefix) == 0 || strings.HasPrefix("name", prefix) {
 		resMap["name"] = struct{}{}
@@ -1240,6 +1248,10 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 				}
 			}
 		}
+	}
+
+	if enricher != nil {
+		enricher.reportStats()
 	}
 
 	res := make([]string, len(resMap))

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	"github.com/grafana/metrictank/stats"
 	"github.com/grafana/metrictank/util"
 
 	"github.com/grafana/metrictank/errors"
@@ -13,9 +14,16 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 )
 
-// the collision avoidance window defines how many times we try to find a higher
-// slot that's free if two record hashes collide
-var collisionAvoidanceWindow = uint32(1024)
+var (
+	// the collision avoidance window defines how many times we try to find a higher
+	// slot that's free if two record hashes collide
+	collisionAvoidanceWindow = uint32(1024)
+
+	// metric idx.memory.meta-tags.enrichment-cache.ops.hit is a counter of enrichment cache hits
+	enrichmentCacheHits = stats.NewCounter32("idx.memory.meta-tags.enrichment-cache.ops.hit")
+	// metric idx.memory.meta-tags.enrichment-cache.ops.miss is a counter of enrichment cache misses
+	enrichmentCacheMisses = stats.NewCounter32("idx.memory.meta-tags.enrichment-cache.ops.miss")
+)
 
 type recordId uint32
 
@@ -172,8 +180,10 @@ func (e *enricher) enrich(id schema.MKey, name string, tags []string) tagquery.T
 
 	cachedRes, ok := e.cache.Get(sum)
 	if ok {
+		enrichmentCacheHits.Inc()
 		return cachedRes.(tagquery.Tags)
 	}
+	enrichmentCacheMisses.Inc()
 
 	var res tagquery.Tags
 	var matches []int

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -23,6 +23,8 @@ var (
 	enrichmentCacheHits = stats.NewCounter32("idx.memory.meta-tags.enrichment-cache.ops.hit")
 	// metric idx.memory.meta-tags.enrichment-cache.ops.miss is a counter of enrichment cache misses
 	enrichmentCacheMisses = stats.NewCounter32("idx.memory.meta-tags.enrichment-cache.ops.miss")
+	// metric idx.memory.meta-tags.enrichment-cache.entries is a the number of entries in the enrichment cache
+	enrichmentCacheEntries = stats.NewGauge32("idx.memory.meta-tags.enrichment-cache.entries")
 )
 
 type recordId uint32
@@ -167,6 +169,10 @@ type enricher struct {
 	filters []tagquery.MetricDefinitionFilter
 	tags    []tagquery.Tags
 	cache   *lru.Cache
+}
+
+func (e *enricher) reportStats() {
+	enrichmentCacheEntries.Set(e.cache.Len())
 }
 
 func (e *enricher) enrich(id schema.MKey, name string, tags []string) tagquery.Tags {


### PR DESCRIPTION
the enrichment cache is critical for the performance of certain queries when meta tags are in use. this metric is necessary to tune its size.