### PR TITLE
Optimize autocomplete queries

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1077,11 +1077,11 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 
 	resMap := make(map[string]struct{})
 
-	var enricher *enricher
+	var enricher *enricherWithUniqueMetaTags
 	if MetaTagSupport {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
-			enricher = mtr.getEnricher(tags.idHasTag)
+			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaTags()
 		}
 	}
 
@@ -1203,11 +1203,11 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 
 	resMap := make(map[string]struct{})
 
-	var enricher *enricher
+	var enricher *enricherWithUniqueMetaTags
 	if MetaTagSupport && !isMetricTag {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
-			enricher = mtr.getEnricher(tags.idHasTag)
+			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaTags()
 		}
 	}
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1077,11 +1077,11 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 
 	resMap := make(map[string]struct{})
 
-	var enricher *enricherWithUniqueMetaTags
+	var enricher *enricherWithUniqueMetaRecords
 	if MetaTagSupport {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
-			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaTags()
+			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaRecords()
 		}
 	}
 
@@ -1203,11 +1203,11 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 
 	resMap := make(map[string]struct{})
 
-	var enricher *enricherWithUniqueMetaTags
+	var enricher *enricherWithUniqueMetaRecords
 	if MetaTagSupport && !isMetricTag {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
-			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaTags()
+			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaRecords()
 		}
 	}
 

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -199,32 +199,32 @@ func (e *enricher) enrich(id schema.MKey, name string, tags []string) tagquery.T
 	return res
 }
 
-func (e *enricher) uniqueMetaTags() *enricherWithUniqueMetaTags {
-	var res enricherWithUniqueMetaTags
+func (e *enricher) uniqueMetaRecords() *enricherWithUniqueMetaRecords {
+	var res enricherWithUniqueMetaRecords
 	res.enricher = *e
 	res.initialize()
 
 	return &res
 }
 
-// enricherWithUniqueMetaTags has the same purpose as the normal enricher, but it is
+// enricherWithUniqueMetaRecords has the same purpose as the normal enricher, but it is
 // different because it uses each meta record only once to enrich metrics. this can be
 // used as a performance optimization in cases where we only want to retrieve all unique
 // meta tags matching a set of ids, but we don't necessarily need to associate them with
 // every metric that matches a meta tag (f.e. autocomplete)
-type enricherWithUniqueMetaTags struct {
+type enricherWithUniqueMetaRecords struct {
 	enricher
 	metaRecordsToUse map[int]struct{}
 }
 
-func (e *enricherWithUniqueMetaTags) initialize() {
+func (e *enricherWithUniqueMetaRecords) initialize() {
 	e.metaRecordsToUse = make(map[int]struct{}, len(e.filters))
 	for i := range e.filters {
 		e.metaRecordsToUse[i] = struct{}{}
 	}
 }
 
-func (e *enricherWithUniqueMetaTags) enrich(id schema.MKey, name string, tags []string) tagquery.Tags {
+func (e *enricherWithUniqueMetaRecords) enrich(id schema.MKey, name string, tags []string) tagquery.Tags {
 	cachedRes, ok := e.enricher.cache.Get(id.Key)
 	if ok {
 		enrichmentCacheHits.Inc()

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -199,6 +199,50 @@ func (e *enricher) enrich(id schema.MKey, name string, tags []string) tagquery.T
 	return res
 }
 
+func (e *enricher) uniqueMetaTags() *enricherWithUniqueMetaTags {
+	var res enricherWithUniqueMetaTags
+	res.enricher = *e
+	res.initialize()
+
+	return &res
+}
+
+// enricherWithUniqueMetaTags has the same purpose as the normal enricher, but it is
+// different because it uses each meta record only once to enrich metrics. this can be
+// used as a performance optimization in cases where we only want to retrieve all unique
+// meta tags matching a set of ids, but we don't necessarily need to associate them with
+// every metric that matches a meta tag (f.e. autocomplete)
+type enricherWithUniqueMetaTags struct {
+	enricher
+	metaRecordsToUse map[int]struct{}
+}
+
+func (e *enricherWithUniqueMetaTags) initialize() {
+	e.metaRecordsToUse = make(map[int]struct{}, len(e.filters))
+	for i := range e.filters {
+		e.metaRecordsToUse[i] = struct{}{}
+	}
+}
+
+func (e *enricherWithUniqueMetaTags) enrich(id schema.MKey, name string, tags []string) tagquery.Tags {
+	cachedRes, ok := e.enricher.cache.Get(id.Key)
+	if ok {
+		enrichmentCacheHits.Inc()
+		return cachedRes.(tagquery.Tags)
+	}
+	enrichmentCacheMisses.Inc()
+
+	var res tagquery.Tags
+	for i := range e.metaRecordsToUse {
+		if e.enricher.filters[i](id, name, tags) == tagquery.Pass {
+			res = append(res, e.enricher.tags[i]...)
+			delete(e.metaRecordsToUse, i)
+		}
+	}
+
+	return res
+}
+
 // index structure keyed by tag -> value -> list of meta record IDs
 type metaTagValue map[string][]recordId
 type metaTagIndex map[string]metaTagValue

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -435,7 +435,7 @@ func TestEnricher(t *testing.T) {
 
 func TestEnricherWithUniqueMetaTags(t *testing.T) {
 	testMetrics, e := getEnricherWithTestData(t)
-	enricher := e.uniqueMetaTags()
+	enricher := e.uniqueMetaRecords()
 
 	tags := enricher.enrich(testMetrics[0].Id, testMetrics[0].Name, testMetrics[0].Tags)
 	expectedTags := tagquery.Tags{{Key: "meta1", Value: "tag1"}}
@@ -462,7 +462,7 @@ func TestEnricherWithUniqueMetaTags(t *testing.T) {
 
 	// when we re-initialize the enricher with unique meta tags and run the same query one more time
 	// then there should be results, but only once
-	enricher = e.uniqueMetaTags()
+	enricher = e.uniqueMetaRecords()
 
 	tags = enricher.enrich(testMetrics[2].Id, testMetrics[2].Name, testMetrics[2].Tags)
 	tags.Sort()


### PR DESCRIPTION
This adds an optimization to make autocomplete requests faster. 
It works like this:
For populating the auto complete value list we need to first execute the query specified, we then take the result set and enrich it with meta tags that match each of the metrics in the result set. From the set of the metric tags and enriched meta tags we then build the list of values to return to autocomplete requests. 
The optimization which this PR implements is that in the case of autocomplete requests its not necessary to enrich every metric in the result set with all meta tags which match it, every meta tag only needs to enrich one metric in the result set and that will be sufficient for it to be taken into account when building the list of values to return. That way we can skip a lot of redundant enriching of metrics in the result set.

It also adds and refactors some unit tests.