### PR TITLE
skip meta tag enrichment when we can

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1197,10 +1197,14 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 		return nil
 	}
 
+	// check whether the tag of which we're looking up values is a metric tag
+	// if so we can skip the meta tag enrichment
+	_, isMetricTag := tags[tag]
+
 	resMap := make(map[string]struct{})
 
 	var enricher *enricher
-	if MetaTagSupport {
+	if MetaTagSupport && !isMetricTag {
 		mtr, ok := m.metaTagRecords[orgId]
 		if ok {
 			enricher = mtr.getEnricher(tags.idHasTag)


### PR DESCRIPTION
when we lookup values of  a tag to reply to an auto complete call, we can skip the meta tag enrichment if the given tag we're looking up the values for is a metric tag.

this slightly breaches the rules, because i'm of the opinion that we should inter-mix metric and meta tag values in this case, we only don't inter-mix them for a single metric, but let's do this for the sake of speed.