### PR TITLE
Rewrite enricher to use map lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## breaking changes
 
+* as of v0.13.0-160-gd2703083 the default setting for `memory-idx.tag-query-workers` is `5` instead of `50`.
+  If a user still has the value `50` in their config file we recommend decreasing that, because due to how
+  meta tag queries get processed MT may now create multiple pools of workers concurrently to process a single
+  query, where each pool consists of `tag-query-workers` threads.
 * as of v0.13.0-75-geaac736a Metrictank requires two new Cassandra tables if the meta tag feature is enabled and the Cassandra index is used. It only creates them automatically if `cassandra-idx-create-keyspace` is set to true.
 * as of v0.12.0-404-gc7715cb2 we clean up poorly formatted graphite metrics better. To the extent that they have previously worked, queries may need some adjusting
   #1435

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -452,8 +452,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -452,8 +452,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -452,8 +452,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -452,8 +452,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -452,8 +452,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -452,8 +452,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -452,8 +452,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -452,8 +452,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docs/config.md
+++ b/docs/config.md
@@ -526,8 +526,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docs/config.md
+++ b/docs/config.md
@@ -526,8 +526,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -202,6 +202,14 @@ a counter of findCache misses
 the duration of a get of one metric in the memory idx
 * `idx.memory.list`:  
 the duration of memory idx listings
+* `idx.memory.meta-tags.enricher.ops.known-meta-records`:  
+a counter of meta records known to the enricher
+* `idx.memory.meta-tags.enricher.ops.metrics-filtered-by-meta-record.accepted`:  
+a counter of metrics getting accepted by meta record filters
+* `idx.memory.meta-tags.enricher.ops.metrics-filtered-by-meta-record.rejected`:  
+a counter of metrics getting rejected by meta record filters
+* `idx.memory.meta-tags.enricher.ops.metrics-with-meta-records`:  
+a counter of metrics with at least one associated meta record
 * `idx.memory.ops.add`:  
 the number of additions to the memory idx
 * `idx.memory.ops.update`:  

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -202,12 +202,6 @@ a counter of findCache misses
 the duration of a get of one metric in the memory idx
 * `idx.memory.list`:  
 the duration of memory idx listings
-* `idx.memory.meta-tags.enrichment-cache.entries`:  
-a the number of entries in the enrichment cache
-* `idx.memory.meta-tags.enrichment-cache.ops.hit`:  
-a counter of enrichment cache hits
-* `idx.memory.meta-tags.enrichment-cache.ops.miss`:  
-a counter of enrichment cache misses
 * `idx.memory.ops.add`:  
 the number of additions to the memory idx
 * `idx.memory.ops.update`:  

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -204,10 +204,6 @@ the duration of a get of one metric in the memory idx
 the duration of memory idx listings
 * `idx.memory.meta-tags.enricher.ops.known-meta-records`:  
 a counter of meta records known to the enricher
-* `idx.memory.meta-tags.enricher.ops.metrics-filtered-by-meta-record.accepted`:  
-a counter of metrics getting accepted by meta record filters
-* `idx.memory.meta-tags.enricher.ops.metrics-filtered-by-meta-record.rejected`:  
-a counter of metrics getting rejected by meta record filters
 * `idx.memory.meta-tags.enricher.ops.metrics-with-meta-records`:  
 a counter of metrics with at least one associated meta record
 * `idx.memory.ops.add`:  

--- a/expr/tagquery/expression.go
+++ b/expr/tagquery/expression.go
@@ -59,6 +59,20 @@ func (e Expressions) Sort() {
 	})
 }
 
+func (e Expressions) Equal(other Expressions) bool {
+	if len(e) != len(other) {
+		return false
+	}
+
+	for i, expression := range e {
+		if !expression.Equals(other[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MarshalJSON satisfies the json.Marshaler interface
 // it is used by the api endpoint /metaTags to list the meta tag records
 func (e Expressions) MarshalJSON() ([]byte, error) {

--- a/expr/tagquery/meta_tag_record.go
+++ b/expr/tagquery/meta_tag_record.go
@@ -54,7 +54,7 @@ func (m *MetaTagRecord) Equals(other *MetaTagRecord) bool {
 		}
 	}
 
-	return m.EqualExpressions(other)
+	return m.Expressions.Equal(other.Expressions)
 }
 
 // HashExpressions returns a hash of all expressions in this meta tag record
@@ -90,24 +90,6 @@ func (m *MetaTagRecord) HashRecord() uint64 {
 	metaTagHash := m.HashMetaTags()
 
 	return uint64(expressionsHash) | uint64(metaTagHash)<<32
-}
-
-// EqualExpressions compares another meta tag record's expressions to
-// this one's expressions
-// Returns true if they are equal, otherwise false
-// It is assumed that all the expressions are already sorted
-func (m *MetaTagRecord) EqualExpressions(other *MetaTagRecord) bool {
-	if len(m.Expressions) != len(other.Expressions) {
-		return false
-	}
-
-	for i, expression := range m.Expressions {
-		if !expression.Equals(other.Expressions[i]) {
-			return false
-		}
-	}
-
-	return true
 }
 
 // HasMetaTags returns true if the meta tag record has one or more

--- a/expr/tagquery/tag.go
+++ b/expr/tagquery/tag.go
@@ -81,6 +81,20 @@ func (t Tags) Sort() {
 	})
 }
 
+func (t Tags) Equal(other Tags) bool {
+	if len(t) != len(other) {
+		return false
+	}
+
+	for i := range t {
+		if t[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MarshalJSON satisfies the json.Marshaler interface
 // it is used by the api endpoint /metaTags to list the meta tag records
 func (t Tags) MarshalJSON() ([]byte, error) {

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -387,19 +387,14 @@ func (c *CasIdx) rebuildIndex() {
 		}(partition)
 	}
 
-	if memory.MetaTagSupport {
-		wg.Add(1)
-		go func() {
-			gate <- struct{}{}
+	wg.Wait()
 
-			c.loadMetaRecords()
-
-			wg.Done()
-			<-gate
-		}()
+	if memory.TagSupport && memory.MetaTagSupport {
+		// should only get called after the metric index has been initialized
+		// if metrics get added first and meta records second then startup is faster
+		c.loadMetaRecords()
 	}
 
-	wg.Wait()
 	log.Infof("cassandra-idx: Rebuilding Memory Index Complete. Imported %d. Took %s", num, time.Since(pre))
 }
 

--- a/idx/cassandra/meta_records.go
+++ b/idx/cassandra/meta_records.go
@@ -129,6 +129,7 @@ func (c *CasIdx) loadMetaRecords() {
 	}
 
 	for orgId, batchId := range toLoad {
+		log.Infof("cassandra-idx: Loading meta record batch %s of org %d", batchId.String(), orgId)
 		var expressions, metatags string
 		q = fmt.Sprintf("SELECT expressions, metatags FROM %s WHERE batchid=? AND orgid=?", c.Config.MetaRecordTable)
 		iter = c.Session.Query(q, batchId, orgId).RetryPolicy(&metaRecordRetryPolicy).Iter()

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -823,18 +823,7 @@ func (m *UnpartitionedMemoryIdx) indexTags(def *schema.MetricDefinition) {
 	m.defByTagSet.add(def)
 
 	if MetaTagSupport {
-		enricher := m.getMetaTagEnricher(def.OrgId, true)
-		// need to temporarily release the write lock when calling into enricher's
-		// addMetric. even though the addMetric operation gets executed async via
-		// a queue, the queue size is limited, if that queue is full and blocking
-		// on insert then the consumer needs to be able to consume it, otherwise
-		// we end up in a dead lock situation where the queue consumer is waiting
-		// for the index lock while this thread holds the write lock and is waiting
-		// for the queue consumer to consume the queue because otherwise it cannot
-		// push into it.
-		m.Unlock()
-		enricher.addMetric(*def)
-		m.Lock()
+		m.getMetaTagEnricher(def.OrgId, true).addMetric(*def)
 	}
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1411,7 +1411,7 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 
 	var enricher *metaTagEnricher
 	var mtr *metaTagRecords
-	if MetaTagSupport {
+	if MetaTagSupport && !isMetricTag {
 		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
 		if enricher.countMetricsWithMetaTags() == 0 {
 			// if the enricher is empty we set it back to nil so it doesn't even get called
@@ -1451,7 +1451,7 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 				resMap[tagValue[1]] = struct{}{}
 			}
 
-			if enricher != nil && mtr != nil && !isMetricTag {
+			if enricher != nil && mtr != nil {
 				metaTags := mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
 				for _, metaTag := range metaTags {
 					if metaTag.Key == tag && strings.HasPrefix(metaTag.Value, prefix) {

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -585,7 +585,7 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, newRecords []ta
 
 	metaRecordSwapExecuting.Inc()
 
-	log.Infof("memory-idx: Initiaing Swap with %d records for org %d", len(newRecords), orgId)
+	log.Infof("memory-idx: Initiating Swap with %d records for org %d", len(newRecords), orgId)
 	m.RLock()
 	mtr, mti, enricher := m.getMetaTagDataStructures(orgId, false)
 	tags := m.tags[orgId]

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -53,6 +53,9 @@ var (
 	maxPruneLockTimeStr          string
 	TagSupport                   bool
 	TagQueryWorkers              int // number of workers to spin up when evaluation tag expressions
+	metaTagEnricherQueueSize     = 100
+	metaTagEnricherBufferSize    = 10000
+	metaTagEnricherBufferTime    = 5 * time.Second
 	indexRulesFile               string
 	IndexRules                   conf.IndexRules
 	Partitioned                  bool
@@ -65,7 +68,6 @@ var (
 	writeQueueDelay              = 30 * time.Second
 	writeMaxBatchSize            = 5000
 	matchCacheSize               = 1000
-	enricherQueueSize            = 10000
 	MetaTagSupport               = false
 )
 
@@ -75,6 +77,9 @@ func ConfigSetup() *flag.FlagSet {
 	memoryIdx.BoolVar(&TagSupport, "tag-support", false, "enables/disables querying based on tags")
 	memoryIdx.BoolVar(&Partitioned, "partitioned", false, "use separate indexes per partition. experimental feature")
 	memoryIdx.IntVar(&TagQueryWorkers, "tag-query-workers", 5, "number of workers to spin up to evaluate tag queries")
+	memoryIdx.IntVar(&metaTagEnricherQueueSize, "meta-tag-enricher-queue-size", 100, "size of event queue in the meta tag enricher")
+	memoryIdx.IntVar(&metaTagEnricherBufferSize, "meta-tag-enricher-buffer-size", 10000, "size of add metric event buffer in enricher")
+	memoryIdx.DurationVar(&metaTagEnricherBufferTime, "meta-tag-enricher-buffer-time", time.Second*5, "how long to buffer enricher events before they must be processed")
 	memoryIdx.IntVar(&findCacheSize, "find-cache-size", 1000, "number of find expressions to cache (per org). 0 disables cache")
 	memoryIdx.IntVar(&findCacheInvalidateQueueSize, "find-cache-invalidate-queue-size", 200, "size of queue for invalidating findCache entries")
 	memoryIdx.IntVar(&findCacheInvalidateMaxSize, "find-cache-invalidate-max-size", 100, "max amount of invalidations to queue up in one batch")
@@ -86,7 +91,6 @@ func ConfigSetup() *flag.FlagSet {
 	memoryIdx.StringVar(&indexRulesFile, "rules-file", "/etc/metrictank/index-rules.conf", "path to index-rules.conf file")
 	memoryIdx.StringVar(&maxPruneLockTimeStr, "max-prune-lock-time", "100ms", "Maximum duration each second a prune job can lock the index.")
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
-	memoryIdx.IntVar(&enricherQueueSize, "enricher-queue-size", 10000, "queue size for jobs that modify enricher state")
 	memoryIdx.BoolVar(&MetaTagSupport, "meta-tag-support", false, "enables/disables querying based on meta tags which get defined via meta tag rules")
 	globalconf.Register("memory-idx", memoryIdx, flag.ExitOnError)
 	return memoryIdx

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -624,8 +624,8 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, newRecords []ta
 		// check for each record whether it exists, those which exist and have
 		// the same meta tags get added to recordIdsToKeep because we don't
 		// want to modify them
-		existingRecordId, exists, sameMetaTags := mtr.recordExists(newRecords[i])
-		if exists && sameMetaTags {
+		existingRecordId, exists, equal := mtr.recordExistsAndIsEqual(newRecords[i])
+		if exists && equal {
 			recordIdsToKeep[existingRecordId] = struct{}{}
 			continue
 		}
@@ -654,8 +654,8 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, newRecords []ta
 
 		// verify that nothing has changed between releasing the read lock
 		// and acquiring the write lock
-		existingRecordId, exists, sameMetaTags := mtr.recordExists(record)
-		if exists && sameMetaTags {
+		existingRecordId, exists, equal := mtr.recordExistsAndIsEqual(record)
+		if exists && equal {
 			// something changed since we released the read lock, no need
 			// to update this record anymore
 			recordIdsToKeep[existingRecordId] = struct{}{}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -267,10 +267,11 @@ type UnpartitionedMemoryIdx struct {
 	tree map[uint32]*Tree // by orgId
 
 	// used by tag index
-	defByTagSet    defByTagSet
-	tags           map[uint32]TagIndex        // by orgId
-	metaTagIndex   map[uint32]metaTagIndex    // by orgId
-	metaTagRecords map[uint32]*metaTagRecords // by orgId
+	defByTagSet     defByTagSet
+	tags            map[uint32]TagIndex         // by orgId
+	metaTagIndex    map[uint32]metaTagIndex     // by orgId
+	metaTagRecords  map[uint32]*metaTagRecords  // by orgId
+	metaTagEnricher map[uint32]*metaTagEnricher // by orgId
 
 	findCache *FindCache
 
@@ -279,12 +280,13 @@ type UnpartitionedMemoryIdx struct {
 
 func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
 	m := &UnpartitionedMemoryIdx{
-		defById:        make(map[schema.MKey]*idx.Archive),
-		defByTagSet:    make(defByTagSet),
-		tree:           make(map[uint32]*Tree),
-		tags:           make(map[uint32]TagIndex),
-		metaTagIndex:   make(map[uint32]metaTagIndex),
-		metaTagRecords: make(map[uint32]*metaTagRecords),
+		defById:         make(map[schema.MKey]*idx.Archive),
+		defByTagSet:     make(defByTagSet),
+		tree:            make(map[uint32]*Tree),
+		tags:            make(map[uint32]TagIndex),
+		metaTagIndex:    make(map[uint32]metaTagIndex),
+		metaTagRecords:  make(map[uint32]*metaTagRecords),
+		metaTagEnricher: make(map[uint32]*metaTagEnricher),
 	}
 	return m
 }
@@ -308,6 +310,15 @@ func (m *UnpartitionedMemoryIdx) Stop() {
 	if m.writeQueue != nil {
 		m.writeQueue.Stop()
 		m.writeQueue = nil
+	}
+
+	if MetaTagSupport {
+		m.Lock()
+		for orgId := range m.metaTagEnricher {
+			m.metaTagEnricher[orgId].stop()
+			delete(m.metaTagEnricher, orgId)
+		}
+		m.Unlock()
 	}
 	return
 }
@@ -450,8 +461,8 @@ func (m *UnpartitionedMemoryIdx) UpdateArchiveLastSave(id schema.MKey, partition
 	}
 }
 
-func (m *UnpartitionedMemoryIdx) getMetaTagDataStructures(orgId uint32, create bool) (*metaTagRecords, metaTagIndex) {
-	return m.getMetaTagRecords(orgId, create), m.getMetaTagIndex(orgId, create)
+func (m *UnpartitionedMemoryIdx) getMetaTagDataStructures(orgId uint32, create bool) (*metaTagRecords, metaTagIndex, *metaTagEnricher) {
+	return m.getMetaTagRecords(orgId, create), m.getMetaTagIndex(orgId, create), m.getMetaTagEnricher(orgId, create)
 }
 
 func (m *UnpartitionedMemoryIdx) getMetaTagRecords(orgId uint32, create bool) *metaTagRecords {
@@ -476,6 +487,17 @@ func (m *UnpartitionedMemoryIdx) getMetaTagIndex(orgId uint32, create bool) meta
 	return nil
 }
 
+func (m *UnpartitionedMemoryIdx) getMetaTagEnricher(orgId uint32, create bool) *metaTagEnricher {
+	if enricher, ok := m.metaTagEnricher[orgId]; ok {
+		return enricher
+	} else if create {
+		enricher = newEnricher()
+		m.metaTagEnricher[orgId] = enricher
+		return enricher
+	}
+	return nil
+}
+
 // MetaTagRecordUpsert inserts or updates a meta record, depending on whether
 // it already exists or is new. The identity of a record is determined by its
 // queries, if the set of queries in the given record already exists in another
@@ -489,35 +511,61 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 
 	var mtr *metaTagRecords
 	var mti metaTagIndex
+	var enricher *metaTagEnricher
 
 	// expressions need to be sorted because the unique ID of a meta record is
 	// its sorted set of expressions
 	upsertRecord.Expressions.Sort()
 
+	// initialize query in preparation to execute it once we have the look
+	// doing struct instantiations before acquiring lock to keep lock time short
+	query, err := tagquery.NewQuery(upsertRecord.Expressions, 0)
+	if err != nil {
+		return fmt.Errorf("Invalid record with expressions/meta tags: %q/%q", upsertRecord.Expressions, upsertRecord.MetaTags)
+	}
+	queryCtx := NewTagQueryContext(query)
+
 	m.Lock()
 	defer m.Unlock()
 
-	mtr, mti = m.getMetaTagDataStructures(orgId, true)
+	// need to acquire write lock before getting the meta tag data structures
+	// because if they have not yet been initialized then this call will do so
+	mtr, mti, enricher = m.getMetaTagDataStructures(orgId, true)
+	tags := m.tags[orgId]
+	if tags == nil {
+		tags = make(TagIndex)
+		m.tags[orgId] = tags
+	}
+
+	// acquiring meta record lock because we're going to modify
+	// meta records and the meta tag index
+	mtr.metaRecordLock.Lock()
+	defer mtr.metaRecordLock.Unlock()
 
 	id, record, oldId, oldRecord, err := mtr.upsert(upsertRecord)
 	if err != nil {
 		return err
 	}
 
-	// if this upsert has updated a previously existing record, then we remove its entries
-	// from the metaTagIndex before inserting the new ones
-	if oldRecord != nil {
+	var metricKeys []schema.Key
+	idCh := m.idsByTagQuery(orgId, queryCtx)
+	for metricId := range idCh {
+		metricKeys = append(metricKeys, metricId.Key)
+	}
+
+	// check if the upsert has replaced a previously existing record
+	if oldId > 0 && oldRecord != nil {
+		// if so we remove all references to it from the enricher
+		// and from the meta tag index
+		enricher.delMetaRecord(oldId, metricKeys)
 		for _, keyValue := range oldRecord.MetaTags {
 			mti.deleteRecord(keyValue, oldId)
 		}
-
-		for _, keyValue := range record.MetaTags {
-			mti.insertRecord(keyValue, id)
-		}
-
-		return nil
 	}
 
+	// add the newly inserted meta record into the enricher and the
+	// meta tag index
+	enricher.addMetaRecord(id, record.GetMetricDefinitionFilter(tags.idHasTag), metricKeys)
 	for _, keyValue := range record.MetaTags {
 		mti.insertRecord(keyValue, id)
 	}
@@ -525,42 +573,180 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 	return nil
 }
 
-func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, records []tagquery.MetaTagRecord) error {
+func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaTagRecord) error {
 	if !TagSupport || !MetaTagSupport {
 		log.Warn("memory-idx: received a tag/meta-tag query, but that feature is disabled")
 		return errors.NewBadRequest("Tag/Meta-Tag support is disabled")
 	}
 
-	newMtr := newMetaTagRecords()
-	newMti := make(metaTagIndex)
+	m.RLock()
+	mtr, mti, enricher := m.getMetaTagDataStructures(orgId, false)
+	tags := m.tags[orgId]
+	m.RUnlock()
 
-	for _, record := range records {
-		recordId, _, _, _, err := newMtr.upsert(record)
-		if err != nil {
-			return err
-		}
-
-		for _, keyValue := range record.MetaTags {
-			newMti.insertRecord(keyValue, recordId)
-		}
+	if mtr == nil || mti == nil || enricher == nil {
+		// if one of the meta tag data structs has not been initialized yet we
+		// acquire the write lock and do so by calling with `true` as 2nd arg
+		m.Lock()
+		mtr, mti, enricher = m.getMetaTagDataStructures(orgId, true)
+		m.Unlock()
 	}
 
+	if tags == nil {
+		m.Lock()
+		tags = make(TagIndex)
+		m.tags[orgId] = tags
+		m.Unlock()
+	}
+
+	// recordIdsToKeep contains the records that should not be modified
+	recordIdsToKeep := make(map[recordId]struct{}, len(newRecords))
+
+	// recordsToUpsert contains the records which we're either going to
+	// either insert or update
+	var recordsToUpsert []tagquery.MetaTagRecord
+
+	// acquiring meta record lock because we're going to modify the meta tag
+	// index and the meta records
+	mtr.metaRecordLock.Lock()
+	defer mtr.metaRecordLock.Unlock()
+
+	// iterate over each of the new records to build a list of those that need to
+	// either be updated or inserted by comparing them to the currently existing
+	// records.
+	// all the existing ones that should not be modified get added to the set
+	// recordIdsToKeep.
 	m.RLock()
-	oldMtr := m.getMetaTagRecords(orgId, false)
-	if oldMtr != nil {
-		if oldMtr.hashRecords() == newMtr.hashRecords() {
-			// the old and the new records are the same, so there is no need to change anyting
-			m.RUnlock()
-			return nil
+	for i := range newRecords {
+		newRecords[i].Expressions.Sort()
+		newRecords[i].MetaTags.Sort()
+
+		// check for each record whether it exists, those which exist and have
+		// the same meta tags get added to recordIdsToKeep because we don't
+		// want to modify them
+		existingRecordId, exists, sameMetaTags := mtr.recordExists(newRecords[i])
+		if exists && sameMetaTags {
+			recordIdsToKeep[existingRecordId] = struct{}{}
+			continue
 		}
+
+		// the ones which either don't exist or do not have the same meta tags
+		// get added to recordsToUpsert
+		recordsToUpsert = append(recordsToUpsert, newRecords[i])
 	}
 	m.RUnlock()
 
-	m.Lock()
-	defer m.Unlock()
+	var query tagquery.Query
+	var queryCtx TagQueryContext
+	var err error
+	for _, record := range recordsToUpsert {
+		query, err = tagquery.NewQuery(record.Expressions, 0)
+		if err != nil {
+			log.Errorf("Invalid record with expressions/meta tags: %q/%q", record.Expressions.Strings(), record.MetaTags.Strings())
+			continue
+		}
+		queryCtx = NewTagQueryContext(query)
 
-	m.metaTagRecords[orgId] = newMtr
-	m.metaTagIndex[orgId] = newMti
+		// acquiring the write lock once per iteration, instead of acquiring it
+		// for the whole loop, because the speed of swap operations is not as
+		// important as keeping the query response times low
+		m.Lock()
+
+		// verify that nothing has changed between releasing the read lock
+		// and acquiring the write lock
+		existingRecordId, exists, sameMetaTags := mtr.recordExists(record)
+		if exists && sameMetaTags {
+			// something changed since we released the read lock, no need
+			// to update this record anymore
+			recordIdsToKeep[existingRecordId] = struct{}{}
+			m.Unlock()
+			continue
+		}
+
+		idCh := m.idsByTagQuery(orgId, queryCtx)
+		// not reusing metricKeys because it will be passed into the enricher
+		// which processes it asynchronously
+		var metricKeys []schema.Key
+		for metricId := range idCh {
+			metricKeys = append(metricKeys, metricId.Key)
+		}
+
+		if exists {
+			// the record already exists, but it has different meta tags
+			// associated, so we need to delete the references to the old
+			// recordId from the enricher and the mti because the id may
+			// change when we update it
+
+			enricher.delMetaRecord(existingRecordId, metricKeys)
+			for _, tag := range record.MetaTags {
+				mti.deleteRecord(tag, existingRecordId)
+			}
+		}
+
+		newRecordId, newRecord, _, _, err := mtr.upsert(record)
+		if err != nil {
+			log.Errorf("Error when upserting meta record with expressions/meta tags (%q/%q): %s", record.Expressions.Strings(), record.MetaTags.Strings(), err.Error())
+			m.Unlock()
+			continue
+		}
+
+		enricher.addMetaRecord(newRecordId, newRecord.GetMetricDefinitionFilter(tags.idHasTag), metricKeys)
+		for _, tag := range newRecord.MetaTags {
+			mti.insertRecord(tag, newRecordId)
+		}
+
+		m.Unlock()
+
+		// adding the new record id to recordIdsToKeep to prevent that
+		// it gets pruned further down
+		recordIdsToKeep[newRecordId] = struct{}{}
+	}
+
+	m.RLock()
+
+	// if the number of meta tag records is equal to the number of record
+	// ids to keep, and we've already ensured that the meta tag records are
+	// all up2date, then there's nothing to prune
+	if mtr.length() != len(recordIdsToKeep) {
+		m.RUnlock()
+		var pruned map[recordId]tagquery.MetaTagRecord
+		toPrune := mtr.getPrunable(recordIdsToKeep)
+		if len(toPrune) > 0 {
+			m.Lock()
+			// we can assume that the toPrune list is still correct because we're
+			// holding the metaRecordLock
+			pruned = make(map[recordId]tagquery.MetaTagRecord, len(toPrune))
+			mtr.prune(toPrune, pruned)
+			m.Unlock()
+		}
+
+		// remove all references to the pruned meta records from the meta
+		// tag index and the enricher
+		for recordId, record := range pruned {
+			query, err = tagquery.NewQuery(record.Expressions, 0)
+			if err != nil {
+				log.Errorf("Invalid meta record with id %d and expressions/meta tags: %q/%q", recordId, record.Expressions.Strings(), record.MetaTags.Strings())
+				continue
+			}
+			queryCtx = NewTagQueryContext(query)
+
+			// keeping the lock time as short as possible because pruning
+			// performance is not important compared to query response times
+			m.Lock()
+			for _, tag := range record.MetaTags {
+				mti.deleteRecord(tag, recordId)
+			}
+			idCh := m.idsByTagQuery(orgId, queryCtx)
+			var metricKeys []schema.Key
+			for metricId := range idCh {
+				metricKeys = append(metricKeys, metricId.Key)
+			}
+			enricher.delMetaRecord(recordId, metricKeys)
+			m.Unlock()
+		}
+	} else {
+		m.RUnlock()
+	}
 
 	return nil
 }
@@ -613,6 +799,21 @@ func (m *UnpartitionedMemoryIdx) indexTags(def *schema.MetricDefinition) {
 	tags.addTagId("name", def.NameSanitizedAsTagValue(), def.Id)
 
 	m.defByTagSet.add(def)
+
+	if MetaTagSupport {
+		enricher := m.getMetaTagEnricher(def.OrgId, true)
+		// need to temporarily release the write lock when calling into enricher's
+		// addMetric. even though the addMetric operation gets executed async via
+		// a queue, the queue size is limited, if that queue is full and blocking
+		// on insert then the consumer needs to be able to consume it, otherwise
+		// we end up in a dead lock situation where the queue consumer is waiting
+		// for the index lock while this thread holds the write lock and is waiting
+		// for the queue consumer to consume the queue because otherwise it cannot
+		// push into it.
+		m.Unlock()
+		enricher.addMetric(def, &m.RWMutex)
+		m.Lock()
+	}
 }
 
 // deindexTags takes a given metric definition and removes all references
@@ -639,6 +840,10 @@ func (m *UnpartitionedMemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDe
 	tags.delTagId("name", def.NameSanitizedAsTagValue(), def.Id)
 
 	m.defByTagSet.del(def)
+
+	if MetaTagSupport {
+		m.getMetaTagEnricher(def.OrgId, true).delMetric(def)
+	}
 
 	return true
 }
@@ -846,17 +1051,13 @@ func (m *UnpartitionedMemoryIdx) FindByTag(orgId uint32, query tagquery.Query) [
 	m.RLock()
 	defer m.RUnlock()
 
-	tagIndex, ok := m.tags[orgId]
-	if !ok {
-		// if there is no tag index, we don't need to run the tag query
-		return nil
-	}
-
-	var enricher *enricher
+	var enricher *metaTagEnricher
+	var mtr *metaTagRecords
 	if MetaTagSupport {
-		mtr := m.getMetaTagRecords(orgId, false)
-		if mtr != nil {
-			enricher = mtr.getEnricher(tagIndex.idHasTag)
+		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
+		if enricher.countMetricsWithMetaTags() == 0 {
+			// if the enricher is empty we set it back to nil so it doesn't even get called
+			enricher = nil
 		}
 	}
 
@@ -880,16 +1081,12 @@ func (m *UnpartitionedMemoryIdx) FindByTag(orgId uint32, query tagquery.Query) [
 				HasChildren: false,
 				Defs:        []idx.Archive{CloneArchive(def)},
 			}
-			if enricher != nil {
-				byPath[nameWithTags].MetaTags = enricher.enrich(def.Id, def.Name, def.Tags)
+			if enricher != nil && mtr != nil {
+				byPath[nameWithTags].MetaTags = mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
 			}
 		} else {
 			existing.Defs = append(existing.Defs, CloneArchive(def))
 		}
-	}
-
-	if enricher != nil {
-		enricher.reportStats()
 	}
 
 	results := make([]idx.Node, len(byPath))
@@ -983,7 +1180,7 @@ func (m *UnpartitionedMemoryIdx) TagDetails(orgId uint32, key string, filter *re
 		return res
 	}
 
-	mtr, mti := m.getMetaTagDataStructures(orgId, false)
+	mtr, mti, _ := m.getMetaTagDataStructures(orgId, false)
 
 	for value, recordIds := range mti[key] {
 		if filter != nil && !filter.MatchString(value) {
@@ -1075,18 +1272,15 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 	m.RLock()
 	defer m.RUnlock()
 
-	tags, ok := m.tags[orgId]
-	if !ok {
-		return nil
-	}
-
 	resMap := make(map[string]struct{})
 
-	var enricher *enricherWithUniqueMetaRecords
+	var enricher *metaTagEnricher
+	var mtr *metaTagRecords
 	if MetaTagSupport {
-		mtr := m.getMetaTagRecords(orgId, false)
-		if mtr != nil {
-			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaRecords()
+		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
+		if enricher.countMetricsWithMetaTags() == 0 {
+			// if the enricher is empty we set it back to nil so it doesn't even get called
+			enricher = nil
 		}
 	}
 
@@ -1113,18 +1307,14 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 			}
 		}
 
-		if enricher != nil {
-			metaTags := enricher.enrich(def.Id, def.Name, def.Tags)
+		if enricher != nil && mtr != nil {
+			metaTags := mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
 			for _, tag := range metaTags {
 				if len(prefix) == 0 || strings.HasPrefix(tag.Key, prefix) {
 					resMap[tag.Key] = struct{}{}
 				}
 			}
 		}
-	}
-
-	if enricher != nil {
-		enricher.reportStats()
 	}
 
 	// handle special case of the name tag
@@ -1208,11 +1398,13 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 
 	resMap := make(map[string]struct{})
 
-	var enricher *enricherWithUniqueMetaRecords
-	if MetaTagSupport && !isMetricTag {
-		mtr := m.getMetaTagRecords(orgId, false)
-		if mtr != nil {
-			enricher = mtr.getEnricher(tags.idHasTag).uniqueMetaRecords()
+	var enricher *metaTagEnricher
+	var mtr *metaTagRecords
+	if MetaTagSupport {
+		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
+		if enricher.countMetricsWithMetaTags() == 0 {
+			// if the enricher is empty we set it back to nil so it doesn't even get called
+			enricher = nil
 		}
 	}
 
@@ -1248,8 +1440,8 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 				resMap[tagValue[1]] = struct{}{}
 			}
 
-			if enricher != nil {
-				metaTags := enricher.enrich(def.Id, def.Name, def.Tags)
+			if enricher != nil && mtr != nil && !isMetricTag {
+				metaTags := mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
 				for _, metaTag := range metaTags {
 					if metaTag.Key == tag && strings.HasPrefix(metaTag.Value, prefix) {
 						resMap[metaTag.Value] = struct{}{}
@@ -1257,10 +1449,6 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 				}
 			}
 		}
-	}
-
-	if enricher != nil {
-		enricher.reportStats()
 	}
 
 	res := make([]string, len(resMap))

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -65,7 +65,7 @@ var (
 	writeQueueDelay              = 30 * time.Second
 	writeMaxBatchSize            = 5000
 	matchCacheSize               = 1000
-	enrichmentCacheSize          = 10000
+	enricherQueueSize            = 10000
 	MetaTagSupport               = false
 )
 
@@ -86,7 +86,7 @@ func ConfigSetup() *flag.FlagSet {
 	memoryIdx.StringVar(&indexRulesFile, "rules-file", "/etc/metrictank/index-rules.conf", "path to index-rules.conf file")
 	memoryIdx.StringVar(&maxPruneLockTimeStr, "max-prune-lock-time", "100ms", "Maximum duration each second a prune job can lock the index.")
 	memoryIdx.IntVar(&matchCacheSize, "match-cache-size", 1000, "size of regular expression cache in tag query evaluation")
-	memoryIdx.IntVar(&enrichmentCacheSize, "enrichment-cache-size", 10000, "size of the meta tag enrichment cache")
+	memoryIdx.IntVar(&enricherQueueSize, "enricher-queue-size", 10000, "queue size for jobs that modify enricher state")
 	memoryIdx.BoolVar(&MetaTagSupport, "meta-tag-support", false, "enables/disables querying based on meta tags which get defined via meta tag rules")
 	globalconf.Register("memory-idx", memoryIdx, flag.ExitOnError)
 	return memoryIdx

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -1057,6 +1057,8 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 		t.Fatalf("Unexpected error when upserting meta tag record: %q", err)
 	}
 
+	waitForMetaTagEnrichers(t, ix)
+
 	metaTagRecords := ix.MetaTagRecordList(1)
 	if len(metaTagRecords) != 2 {
 		t.Fatalf("Expected MetaTagRecordList to return 2 records for org 1, but it has:\n%+v\n", metaTagRecords)
@@ -1098,6 +1100,8 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when upserting meta tag record: %q", err)
 	}
+
+	waitForMetaTagEnrichers(t, ix)
 
 	metaTagRecords = ix.MetaTagRecordList(1)
 	if len(metaTagRecords) != 2 {

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -187,16 +187,16 @@ type metaTagEnricher struct {
 	wg sync.WaitGroup
 	// mapping from metric key to list of meta record ids, used to do the enrichment
 	recordsByMetric map[schema.Key]map[recordId]struct{}
+	// mapping from record ids to tag queries associated with given record
+	queriesByRecord map[recordId]tagquery.Query
 	// the event queue, all state changing operations get pushed through this queue
 	eventQueue chan enricherEvent
-
-	queriesByRecord map[recordId]tagquery.Query
+	// buffer that's used to buffer addMetric events, because executing them in bunches
+	// is more efficient (faster) than executing them one-by-one
 	addMetricBuffer []schema.MetricDefinition
-	archivePool     sync.Pool
+	// pool of idx.Archive structs that we use when processing add metric events
+	archivePool sync.Pool
 }
-
-const enricherAddMetricBufferSize = 1000
-const enricherAddMetricBufferTimeout = time.Second * 5
 
 type enricherEventType uint8
 
@@ -229,19 +229,19 @@ func newEnricher() *metaTagEnricher {
 
 // start creates the go routine which consumes the event queue and processes received events
 func (e *metaTagEnricher) start() {
-	e.eventQueue = make(chan enricherEvent, 1000)
+	e.eventQueue = make(chan enricherEvent, metaTagEnricherQueueSize)
 
 	e.wg.Add(1)
 	go func() {
 		defer e.wg.Done()
 
 		var event enricherEvent
-		timer := time.NewTimer(enricherAddMetricBufferTimeout)
+		timer := time.NewTimer(metaTagEnricherBufferTime)
 
 		for {
 			select {
 			case <-timer.C:
-				timer.Reset(enricherAddMetricBufferTimeout)
+				timer.Reset(metaTagEnricherBufferTime)
 				e._flushAddMetricBuffer()
 			case event = <-e.eventQueue:
 				if event.eventType != addMetric && len(e.addMetricBuffer) > 0 {
@@ -252,7 +252,7 @@ func (e *metaTagEnricher) start() {
 				case addMetric:
 					e._bufferAddMetric(event.payload)
 
-					if len(e.addMetricBuffer) >= enricherAddMetricBufferSize {
+					if len(e.addMetricBuffer) >= metaTagEnricherBufferSize {
 						e._flushAddMetricBuffer()
 					}
 
@@ -262,7 +262,7 @@ func (e *metaTagEnricher) start() {
 					if !timer.Stop() {
 						<-timer.C
 					}
-					timer.Reset(enricherAddMetricBufferTimeout)
+					timer.Reset(metaTagEnricherBufferTime)
 				case delMetric:
 					e._delMetric(event.payload)
 				case addMetaRecord:
@@ -279,6 +279,7 @@ func (e *metaTagEnricher) start() {
 
 func (e *metaTagEnricher) _flushAddMetricBuffer() {
 	if len(e.addMetricBuffer) == 0 {
+		// buffer is empty, nothing to do
 		return
 	}
 
@@ -292,6 +293,8 @@ func (e *metaTagEnricher) _flushAddMetricBuffer() {
 		e.addMetricBuffer = e.addMetricBuffer[:0]
 	}()
 
+	// build a small tag index with all the metrics in the buffer
+	// we later use that index to run the meta record queries on it
 	for _, md := range e.addMetricBuffer {
 		for _, tag := range md.Tags {
 			tagSplits := strings.SplitN(tag, "=", 2)
@@ -317,6 +320,10 @@ func (e *metaTagEnricher) _flushAddMetricBuffer() {
 		keys   []schema.Key
 	}, len(e.queriesByRecord))
 	group, _ := errgroup.WithContext(context.Background())
+
+	// execute all the meta record queries on the small index we built above
+	// and collect their results in the resultCh
+	// the queries run concurrently in a group of workers
 	for i := 0; i < TagQueryWorkers; i++ {
 		group.Go(func() error {
 			var queryCtx TagQueryContext
@@ -344,11 +351,16 @@ func (e *metaTagEnricher) _flushAddMetricBuffer() {
 		close(resultCh)
 	}()
 
+	// feed all records ids for which we have a query into recordCh
+	// to make the query workers execute them
 	for record := range e.queriesByRecord {
 		recordCh <- record
 	}
 	close(recordCh)
 
+	// collect all results before applying them to the enricher to
+	// keep the time during which we need to hold the write lock as
+	// short as possible
 	results := make(map[recordId][]schema.Key)
 	for result := range resultCh {
 		results[result.record] = result.keys

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -349,15 +349,20 @@ func (e *metaTagEnricher) _flushAddMetricBuffer() {
 	}
 	close(recordCh)
 
+	results := make(map[recordId][]schema.Key)
+	for result := range resultCh {
+		results[result.record] = result.keys
+	}
+
 	e.Lock()
 	defer e.Unlock()
 
-	for result := range resultCh {
-		for _, key := range result.keys {
+	for record, keys := range results {
+		for _, key := range keys {
 			if _, ok := e.recordsByMetric[key]; !ok {
 				e.recordsByMetric[key] = make(map[recordId]struct{})
 			}
-			e.recordsByMetric[key][result.record] = struct{}{}
+			e.recordsByMetric[key][record] = struct{}{}
 		}
 	}
 

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -514,6 +514,7 @@ func benchmarkAddingMetricToEnricher(b *testing.B, metaRecordCount int) {
 	}
 
 	enricher := index.getMetaTagEnricher(1, true)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		index.AddOrUpdate(mkeys[i], &mds[i], 0)

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -435,8 +435,6 @@ func benchmarkFindByMetaTag(b *testing.B, indexSize, metaRecordCount int) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	enricherQueueSize = indexSize
-
 	metaTagSets := [][]string{
 		{"dc=datacenter1", "operatingSystem=ubuntu", "stage=prod"},
 		{"dc=datacenter2", "operatingSystem=ubuntu", "stage=prod"},

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -435,10 +435,7 @@ func benchmarkFindByMetaTag(b *testing.B, indexSize, metaRecordCount int) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	// reset enrichmentCacheSize back to original value when we're done
-	_enrichmentCacheSize := enrichmentCacheSize
-	defer func() { enrichmentCacheSize = _enrichmentCacheSize }()
-	enrichmentCacheSize = indexSize
+	enricherQueueSize = indexSize
 
 	metaTagSets := [][]string{
 		{"dc=datacenter1", "operatingSystem=ubuntu", "stage=prod"},

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -37,9 +37,9 @@ func getTestIndexWithMetaTags(t testing.TB, metaTags []tagquery.MetaTagRecord, c
 		mkeys[i] = mkey
 	}
 
-	for i := range metaTags {
-		idx.MetaTagRecordUpsert(1, metaTags[i])
-	}
+	idx.MetaTagRecordSwap(1, metaTags)
+
+	waitForMetaTagEnrichers(t, idx)
 
 	return idx, mkeys
 }
@@ -326,19 +326,6 @@ func BenchmarkMetaTagEnricher(b *testing.B) {
 		}
 	}
 
-	queries := make([]tagquery.Query, 1000)
-	for i := 0; i < 1000; i++ {
-		expression, err := tagquery.ParseExpression(fmt.Sprintf("metatag=value%d", i))
-		if err != nil {
-			b.Fatalf("Error when parsing expressions: %s", err)
-		}
-
-		queries[i], err = tagquery.NewQuery(tagquery.Expressions{expression}, 0)
-		if err != nil {
-			b.Fatalf("Unexpected error when instantiating query from expression %q: %s", expression, err)
-		}
-	}
-
 	allMetaTagRecords := make([]tagquery.MetaTagRecord, len(metaTagRecords1)+len(metaTagRecords2)+len(metaTagRecords3))
 	cursor := 0
 	for i := 0; i < len(metaTagRecords1); i++ {
@@ -365,12 +352,13 @@ func BenchmarkMetaTagEnricher(b *testing.B) {
 
 	var def *idx.Archive
 	resToCompare := make(map[tagquery.Tag]struct{})
+	mtr, _, enricher := memoryIdx.getMetaTagDataStructures(1, true)
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		def = &defs[i%1000]
-		metaTags := memoryIdx.metaTagRecords[1].getEnricher(memoryIdx.tags[1].idHasTag).enrich(def.Id, def.Name, def.Tags)
+		metaTags := mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
 		if len(metaTags) != 3 {
 			b.Fatalf("Expected result to have length 3, but it had %d", len(metaTags))
 		}

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -1,12 +1,9 @@
 package memory
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/grafana/metrictank/expr/tagquery"
-	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/util"
 )
 
@@ -315,57 +312,7 @@ func TestDeletingMetaRecord(t *testing.T) {
 	}
 }
 
-func TestComparingMetaTagRecords(t *testing.T) {
-	reset := enableMetaTagSupport()
-	defer reset()
-
-	records := generateMetaRecords(t,
-		[][]string{{"meta1=tag1"}, {"meta2=tag2"}},
-		[][]string{{"expr1=value1"}, {"expr2=value2"}},
-	)
-
-	mtr1 := newMetaTagRecords()
-	mtr2 := newMetaTagRecords()
-
-	if mtr1.hashRecords() != mtr2.hashRecords() {
-		t.Fatalf("TC1: Expected meta tag records to be the same")
-	}
-
-	mtr1.upsert(records[0])
-
-	if mtr1.hashRecords() == mtr2.hashRecords() {
-		t.Fatalf("TC2: Expected meta tag records to be the different")
-	}
-
-	mtr2.upsert(records[0])
-
-	if mtr1.hashRecords() != mtr2.hashRecords() {
-		t.Fatalf("TC3: Expected meta tag records to be the same")
-	}
-
-	mtr1.upsert(records[1])
-
-	if mtr1.hashRecords() == mtr2.hashRecords() {
-		t.Fatalf("TC4: Expected meta tag records to be the different")
-	}
-
-	mtr2.upsert(records[1])
-
-	if mtr1.hashRecords() != mtr2.hashRecords() {
-		t.Fatalf("TC5: Expected meta tag records to be the same")
-	}
-
-	// create another instance of metaTagRecords and populate it in reverse order
-	mtr3 := newMetaTagRecords()
-	mtr3.upsert(records[1])
-	mtr3.upsert(records[0])
-
-	if mtr1.hashRecords() != mtr3.hashRecords() {
-		t.Fatalf("TC6: Expected meta tag records to be the same")
-	}
-}
-
-func getEnricherWithTestData(t *testing.T) ([]schema.MetricDefinition, *enricher) {
+/*func getEnricherWithTestData(t *testing.T) ([]schema.MetricDefinition, *enricher) {
 	mtr := newMetaTagRecords()
 
 	records := generateMetaRecords(t,
@@ -407,9 +354,9 @@ func getEnricherWithTestData(t *testing.T) ([]schema.MetricDefinition, *enricher
 	})
 
 	return testMetrics, enricher
-}
+}*/
 
-func TestEnricher(t *testing.T) {
+/*func TestEnricher(t *testing.T) {
 	testMetrics, enricher := getEnricherWithTestData(t)
 
 	tags := enricher.enrich(testMetrics[0].Id, testMetrics[0].Name, testMetrics[0].Tags)
@@ -482,22 +429,4 @@ func TestEnricherWithUniqueMetaTags(t *testing.T) {
 		t.Fatalf("Returned result set was not as expected. Expected: %q Got: %q", expectedTags, tags)
 	}
 }
-
-func BenchmarkMetaTagRecordsHashing(b *testing.B) {
-	mtrCount := 10000
-	mtr := newMetaTagRecords()
-	for i := 0; i < mtrCount; i++ {
-		record, err := tagquery.ParseMetaTagRecord([]string{fmt.Sprintf("meta%d=tag%d", i, i)}, []string{fmt.Sprintf("expr%d=value%d", i, i)})
-		if err != nil {
-			b.Fatalf("Unexpected error when parsing meta tag record: %s", err)
-		}
-		mtr.upsert(record)
-	}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		mtr.hashRecords()
-	}
-}
+*/

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -1,9 +1,11 @@
 package memory
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/grafana/metrictank/expr/tagquery"
+	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/util"
 )
 
@@ -312,121 +314,162 @@ func TestDeletingMetaRecord(t *testing.T) {
 	}
 }
 
-/*func getEnricherWithTestData(t *testing.T) ([]schema.MetricDefinition, *enricher) {
-	mtr := newMetaTagRecords()
+func TestAddingMetricsToEmptyEnricher(t *testing.T) {
+	enricher := newEnricher()
 
-	records := generateMetaRecords(t,
-		[][]string{{"meta1=tag1"}, {"meta2=tag2"}},
-		[][]string{{"expr1=value1"}, {"expr2=value2"}},
-	)
-	for _, record := range records {
-		mtr.upsert(record)
-	}
-
-	testMetrics := []schema.MetricDefinition{
+	mds := []schema.MetricDefinition{
 		{
-			Name: "metric1",
-			Tags: []string{"expr1=value1"},
+			Name: "one",
+			Tags: []string{"a=b", "c=d"},
 		}, {
-			Name: "metric2",
-			Tags: []string{"expr2=value2"},
+			Name: "two",
 		}, {
-			Name: "metric3",
-			Tags: []string{"expr1=value1", "expr2=value2"},
+			Name: "three",
+			Tags: []string{},
+		}, {
+			Name: "four",
+			Tags: []string{"c=d", "e=f"},
 		},
 	}
+	for i := range mds {
+		mds[i].SetId()
+		enricher.addMetric(&mds[i], nil)
+	}
+
+	// stop waits for the queue to be consumed
+	enricher.stop()
+	enricher.start()
+
+	if enricher.countMetricsWithMetaTags() != 0 {
+		t.Fatalf("Expected that there are no metrics with meta tags, but there were %d", enricher.countMetricsWithMetaTags())
+	}
+}
+
+func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
+	enricher := newEnricher()
+	i := 0
+	acceptEverySecond := func(schema.MKey, string, []string) tagquery.FilterDecision {
+		res := tagquery.Fail
+		if i%2 == 0 {
+			res = tagquery.Pass
+		}
+		i++
+		return res
+	}
+	acceptAll := func(schema.MKey, string, []string) tagquery.FilterDecision { return tagquery.Pass }
+	acceptNone := func(schema.MKey, string, []string) tagquery.FilterDecision { return tagquery.Fail }
+	enricher.addMetaRecord(recordId(1), acceptEverySecond, nil)
+	enricher.addMetaRecord(recordId(2), acceptAll, nil)
+	enricher.addMetaRecord(recordId(3), acceptNone, nil)
+
+	testMetrics := []schema.MetricDefinition{
+		{Name: "1"},
+		{Name: "2"},
+		{Name: "3"},
+		{Name: "4"},
+		{Name: "5"},
+	}
+
+	allKeys := make([]schema.Key, len(testMetrics))
 	for i := range testMetrics {
 		testMetrics[i].SetId()
+		allKeys[i] = testMetrics[i].Id.Key
+		enricher.addMetric(&testMetrics[i], nil)
 	}
 
-	enricher := mtr.getEnricher(func(id schema.MKey, tag, value string) bool {
-		for _, metric := range testMetrics {
-			if metric.Id == id {
-				searchTag := tag + "=" + value
-				for _, haveTag := range metric.Tags {
-					if searchTag == haveTag {
-						return true
-					}
-				}
+	flushEnricherQueue := func() {
+		// stop and start to process the event queue
+		enricher.stop()
+		enricher.start()
+	}
+
+	// helper to verify returned result
+	compareResultToExpected := func(expected []map[recordId]struct{}) {
+		flushEnricherQueue()
+
+		for i, metric := range testMetrics {
+			records := enricher.enrich(metric.Id.Key)
+			if !reflect.DeepEqual(records, expected[i]) {
+				t.Fatalf("Unexpected result returned from enrich:\nExpected: %+v\nGot: %+v\n", expected[i], records)
 			}
 		}
-		return false
+	}
+
+	compareExpectedMetricCount := func(expected int) {
+		flushEnricherQueue()
+
+		result := enricher.countMetricsWithMetaTags()
+		if result != expected {
+			t.Fatalf("Unexpected count of metrics with meta tags. Expected %d, got %d", expected, result)
+		}
+	}
+
+	compareResultToExpected([]map[recordId]struct{}{
+		{recordId(1): {}, recordId(2): {}},
+		{recordId(2): {}},
+		{recordId(1): {}, recordId(2): {}},
+		{recordId(2): {}},
+		{recordId(1): {}, recordId(2): {}},
 	})
+	compareExpectedMetricCount(5)
 
-	return testMetrics, enricher
-}*/
+	record4Keys := []schema.Key{testMetrics[1].Id.Key, testMetrics[3].Id.Key}
+	enricher.addMetaRecord(recordId(4), acceptAll, record4Keys)
 
-/*func TestEnricher(t *testing.T) {
-	testMetrics, enricher := getEnricherWithTestData(t)
+	compareResultToExpected([]map[recordId]struct{}{
+		{recordId(1): {}, recordId(2): {}},
+		{recordId(2): {}, recordId(4): {}},
+		{recordId(1): {}, recordId(2): {}},
+		{recordId(2): {}, recordId(4): {}},
+		{recordId(1): {}, recordId(2): {}},
+	})
+	compareExpectedMetricCount(5)
 
-	tags := enricher.enrich(testMetrics[0].Id, testMetrics[0].Name, testMetrics[0].Tags)
-	expectedTags := tagquery.Tags{{Key: "meta1", Value: "tag1"}}
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set was not as expected. Expected: %q Got: %q", expectedTags, tags)
+	enricher.delMetaRecord(recordId(2), allKeys)
+	enricher.delMetaRecord(recordId(4), record4Keys)
+
+	compareResultToExpected([]map[recordId]struct{}{
+		{recordId(1): {}},
+		nil,
+		{recordId(1): {}},
+		nil,
+		{recordId(1): {}},
+	})
+	compareExpectedMetricCount(3)
+
+	enricher.delMetric(&testMetrics[4])
+
+	compareResultToExpected([]map[recordId]struct{}{
+		{recordId(1): {}},
+		nil,
+		{recordId(1): {}},
+		nil,
+		nil,
+	})
+	compareExpectedMetricCount(2)
+
+	enricher.delMetaRecord(recordId(1), []schema.Key{testMetrics[0].Id.Key, testMetrics[2].Id.Key, testMetrics[4].Id.Key})
+	enricher.delMetaRecord(recordId(3), nil)
+
+	compareResultToExpected([]map[recordId]struct{}{
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	})
+	compareExpectedMetricCount(0)
+
+	for i := range testMetrics {
+		enricher.delMetric(&testMetrics[i])
 	}
 
-	tags = enricher.enrich(testMetrics[1].Id, testMetrics[1].Name, testMetrics[1].Tags)
-	expectedTags = tagquery.Tags{{Key: "meta2", Value: "tag2"}}
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set was not as expected. Expected: %q Got: %q", expectedTags, tags)
-	}
-
-	tags = enricher.enrich(testMetrics[2].Id, testMetrics[2].Name, testMetrics[2].Tags)
-	tags.Sort()
-	expectedTags = tagquery.Tags{{Key: "meta1", Value: "tag1"}, {Key: "meta2", Value: "tag2"}}
-	expectedTags.Sort()
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set was not as expected. Expected: %q Got: %q", expectedTags, tags)
-	}
+	compareResultToExpected([]map[recordId]struct{}{
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	})
+	compareExpectedMetricCount(0)
 }
-
-func TestEnricherWithUniqueMetaTags(t *testing.T) {
-	testMetrics, e := getEnricherWithTestData(t)
-	enricher := e.uniqueMetaRecords()
-
-	tags := enricher.enrich(testMetrics[0].Id, testMetrics[0].Name, testMetrics[0].Tags)
-	expectedTags := tagquery.Tags{{Key: "meta1", Value: "tag1"}}
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set did not contain expected tag. Expected: %q Got: %q", expectedTags, tags)
-	}
-
-	tags = enricher.enrich(testMetrics[1].Id, testMetrics[1].Name, testMetrics[1].Tags)
-	expectedTags = tagquery.Tags{{Key: "meta2", Value: "tag2"}}
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set did not contain expected tag. Expected: %q Got: %q", expectedTags, tags)
-	}
-
-	// we expect no tags to be enriched, because both present meta records have already been used once
-	tags = enricher.enrich(testMetrics[2].Id, testMetrics[2].Name, testMetrics[2].Tags)
-	if len(tags) == 0 {
-		tags = nil
-	}
-
-	expectedTags = nil
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set was not as expected. Expected: %q Got: %q", expectedTags, tags)
-	}
-
-	// when we re-initialize the enricher with unique meta tags and run the same query one more time
-	// then there should be results, but only once
-	enricher = e.uniqueMetaRecords()
-
-	tags = enricher.enrich(testMetrics[2].Id, testMetrics[2].Name, testMetrics[2].Tags)
-	tags.Sort()
-	expectedTags = tagquery.Tags{{Key: "meta1", Value: "tag1"}, {Key: "meta2", Value: "tag2"}}
-	expectedTags.Sort()
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set was not as expected. Expected: %q Got: %q", expectedTags, tags)
-	}
-
-	tags = enricher.enrich(testMetrics[2].Id, testMetrics[2].Name, testMetrics[2].Tags)
-	if len(tags) == 0 {
-		tags = nil
-	}
-
-	expectedTags = nil
-	if !reflect.DeepEqual(tags, expectedTags) {
-		t.Fatalf("Returned result set was not as expected. Expected: %q Got: %q", expectedTags, tags)
-	}
-}
-*/

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -15,13 +15,19 @@ func filterAndCompareResults(t *testing.T, expressions tagquery.Expressions, met
 	index.Init()
 
 	archives, _ := getTestArchives(10)
+	index.Lock()
 	for i := range archives {
 		index.add(archives[i])
 	}
+	index.Unlock()
 
 	for i := range metaRecords {
 		index.MetaTagRecordUpsert(1, metaRecords[i])
 	}
+
+	enricher := index.getMetaTagEnricher(1, true)
+	enricher.stop()
+	enricher.start()
 
 	ctx := &TagQueryContext{
 		index:          index.tags[1],

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -37,13 +37,19 @@ func selectAndCompareResults(t *testing.T, expression tagquery.Expression, metaR
 	index.Init()
 
 	archives, _ := getTestArchives(10)
+	index.Lock()
 	for i := range archives {
 		index.add(archives[i])
 	}
+	index.Unlock()
 
 	for i := range metaRecords {
 		index.MetaTagRecordUpsert(1, metaRecords[i])
 	}
+
+	enricher := index.getMetaTagEnricher(1, true)
+	enricher.stop()
+	enricher.start()
 
 	ctx := &TagQueryContext{
 		index:          index.tags[1],

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -455,8 +455,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -455,8 +455,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -452,8 +452,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -452,8 +452,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -452,8 +452,12 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# queue size for jobs that modify enricher state
-enricher-queue-size = 10000
+# size of event queue in the meta tag enricher
+meta-tag-enricher-queue-size = 100
+# size of add metric event buffer in enricher
+meta-tag-enricher-buffer-size = 10000
+# how long to buffer enricher events before they must be processed
+meta-tag-enricher-buffer-time = 5s
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -452,8 +452,8 @@ meta-tag-support = false
 tag-query-workers = 5
 # size of regular expression cache in tag query evaluation
 match-cache-size = 1000
-# size of the meta tag enrichment cache
-enrichment-cache-size = 10000
+# queue size for jobs that modify enricher state
+enricher-queue-size = 10000
 # path to index-rules.conf file
 rules-file = /etc/metrictank/index-rules.conf
 # maximum duration each second a prune job can lock the index.


### PR DESCRIPTION
This replaces the enricher implementation to make enrichment faster. There are mainly two important changes:

* When enriching a metric the enricher now simply needs to lookup the metric keys from a map, which is much cheaper than running it through a filter for each present meta record. This map needs to be kept up2date, which means enrichment must happen whenever metrics or meta records get added.
* All events which change the state of the enricher (add metric, del metric, add meta record, del meta record) get processed asynchronously via a queue. Furthermore, all events to add metrics get buffered and executed in batches because this allows us to further decrease the amount of time it takes to enrich each of them. This means that when a new metric gets added to the index it can take a few seconds until its meta tags show up as well, but it is necessary to do it this way because otherwise the enrichment would slow down the ingest speed too much.

I will create a diagram to illustrate how it all works and post it here.