### PR TITLE
correct for delayed lastUpdate updates

### DIFF
--- a/idx/bigtable/bigtable.go
+++ b/idx/bigtable/bigtable.go
@@ -308,6 +308,17 @@ func (b *BigtableIdx) updateBigtable(now uint32, inMemory bool, archive idx.Arch
 	return archive
 }
 
+func (b *BigtableIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, error) {
+	// The lastUpdate timestamp does not get updated in the bigtable index every time when
+	// a data point is received, there can be a delay of up to b.cfg.updateInterval32. To
+	// avoid falsely excluding a metric based on its lastUpdate timestamp we offset the
+	// from time by updateInterval32, this way we err on the "too inclusive" side
+	if from > int64(b.cfg.updateInterval32) {
+		from -= int64(b.cfg.updateInterval32)
+	}
+	return b.MemoryIndex.Find(orgId, pattern, from)
+}
+
 func (b *BigtableIdx) rebuildIndex() {
 	log.Info("bigtable-idx: Rebuilding Memory Index from metricDefinitions in bigtable")
 	pre := time.Now()


### PR DESCRIPTION
We don't always update the `lastUpdate` property in the cassandra index when a metric receives a data point. There can be a delay of up to `cassandra-idx.update-interval`. To prevent that we falsely exclude a metric based on its delayed `lastUpdate` time stamp, we offset the `from` parameter by the value of `cassandra-idx.update-interval` at the time when `CasIdx.Find()` is called.

Fixes: https://github.com/grafana/metrictank-ops/issues/520