### PR TITLE
bring in sync with upstream fakemetrics

### DIFF
--- a/stacktest/fakemetrics/fakemetrics.go
+++ b/stacktest/fakemetrics/fakemetrics.go
@@ -59,9 +59,9 @@ func NewFakeMetrics(metrics []*schema.MetricData, o out.Out, stats met.Backend) 
 	return fm
 }
 
-func NewKafka(num int) *FakeMetrics {
+func NewKafka(num int, timeout time.Duration) *FakeMetrics {
 	stats, _ := helper.New(false, "", "standard", "", "")
-	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", stats, "lastNum")
+	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", timeout, stats, "lastNum")
 	if err != nil {
 		log.Fatalf("failed to create kafka-mdm output. %s", err.Error())
 	}

--- a/stacktest/fakemetrics/fakemetrics.go
+++ b/stacktest/fakemetrics/fakemetrics.go
@@ -59,9 +59,9 @@ func NewFakeMetrics(metrics []*schema.MetricData, o out.Out, stats met.Backend) 
 	return fm
 }
 
-func NewKafka(num int, timeout time.Duration) *FakeMetrics {
+func NewKafka(num int, timeout time.Duration, v2 bool) *FakeMetrics {
 	stats, _ := helper.New(false, "", "standard", "", "")
-	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", timeout, stats, "lastNum")
+	out, err := kafkamdm.New("mdm", []string{"localhost:9092"}, "none", timeout, stats, "lastNum", v2)
 	if err != nil {
 		log.Fatalf("failed to create kafka-mdm output. %s", err.Error())
 	}

--- a/stacktest/fakemetrics/out/kafkamdm/kafkamdm.go
+++ b/stacktest/fakemetrics/out/kafkamdm/kafkamdm.go
@@ -88,7 +88,7 @@ func New(topic string, brokers []string, codec string, timeout time.Duration, st
 	} else {
 		part, err = p.NewKafka(partitionScheme)
 		if err != nil {
-			return nil, fmt.Errorf("partitionScheme must be one of 'byOrg|bySeries|bySeriesWithTags|lastNum'. got %s", partitionScheme)
+			return nil, fmt.Errorf("partitionscheme must be one of 'byOrg|bySeries|bySeriesWithTags|bySeriesWithTagsFnv|lastNum'. got %s", partitionScheme)
 		}
 	}
 

--- a/stacktest/fakemetrics/out/kafkamdm/kafkamdm.go
+++ b/stacktest/fakemetrics/out/kafkamdm/kafkamdm.go
@@ -41,7 +41,7 @@ func (p *LastNumPartitioner) Partition(m schema.PartitionedMetric, numPartitions
 	return int32(part), nil
 }
 
-func New(topic string, brokers []string, codec string, stats met.Backend, partitionScheme string) (*KafkaMdm, error) {
+func New(topic string, brokers []string, codec string, timeout time.Duration, stats met.Backend, partitionScheme string) (*KafkaMdm, error) {
 	// We are looking for strong consistency semantics.
 	// Because we don't change the flush settings, sarama will try to produce messages
 	// as fast as possible to keep latency low.
@@ -52,12 +52,9 @@ func New(topic string, brokers []string, codec string, stats met.Backend, partit
 	config.Producer.Compression = out.GetCompression(codec)
 	config.Producer.Partitioner = sarama.NewManualPartitioner
 
-	// set all timeouts a bit more aggressive so we can bail out quicker.
-	// useful for our unit tests, which operate in the orders of seconds anyway
-	// the defaults of 30s is too long for many of our tests.
-	config.Net.DialTimeout = 5 * time.Second
-	config.Net.ReadTimeout = 5 * time.Second
-	config.Net.WriteTimeout = 5 * time.Second
+	config.Net.DialTimeout = timeout
+	config.Net.ReadTimeout = timeout
+	config.Net.WriteTimeout = timeout
 	err := config.Validate()
 	if err != nil {
 		return nil, err

--- a/stacktest/fakemetrics/out/kafkamdm/keycache/cache.go
+++ b/stacktest/fakemetrics/out/kafkamdm/keycache/cache.go
@@ -1,0 +1,51 @@
+package keycache
+
+import (
+	"time"
+
+	"github.com/grafana/metrictank/schema"
+)
+
+// Cache is a single-tenant keycache
+// it is sharded for 2 reasons:
+// * more granular GC (eg. less latency perceived by caller)
+// * mild space savings cause keys are 1 byte shorter
+// We shard on the first byte of the metric key, which we assume
+// is evenly distributed.
+type Cache struct {
+	shards [256]Shard
+}
+
+// NewCache creates a new cache
+func NewCache(ref Ref) *Cache {
+	c := Cache{}
+	for i := 0; i < 256; i++ {
+		c.shards[i] = NewShard(ref)
+	}
+	return &c
+}
+
+// Touch marks the key as seen and returns whether it was seen before
+// callers should assure that t >= ref and t-ref <= 42 hours
+func (c *Cache) Touch(key schema.Key, t time.Time) bool {
+	shard := int(key[0])
+	return c.shards[shard].Touch(key, t)
+}
+
+// Len returns the length of the cache
+func (c *Cache) Len() int {
+	var sum int
+	for i := 0; i < 256; i++ {
+		sum += c.shards[i].Len()
+	}
+	return sum
+}
+
+// Prune makes sure all shards are pruned
+func (c *Cache) Prune(now time.Time, staleThresh Duration) int {
+	var remaining int
+	for i := 0; i < 256; i++ {
+		remaining += c.shards[i].Prune(now, staleThresh)
+	}
+	return remaining
+}

--- a/stacktest/fakemetrics/out/kafkamdm/keycache/keycache.go
+++ b/stacktest/fakemetrics/out/kafkamdm/keycache/keycache.go
@@ -1,0 +1,103 @@
+package keycache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/grafana/metrictank/schema"
+)
+
+// KeyCache tracks for all orgs, which keys have been seen, and when was the last time
+type KeyCache struct {
+	staleThresh   Duration // number of 10-minutely periods
+	pruneInterval time.Duration
+
+	sync.RWMutex
+	caches map[uint32]*Cache
+}
+
+// NewKeyCache creates a new KeyCache
+func NewKeyCache(staleThresh, pruneInterval time.Duration) *KeyCache {
+	if staleThresh.Hours() > 42 {
+		panic("stale time may not exceed 42 hours due to resolution of internal bookkeeping")
+	}
+	if pruneInterval.Hours() > 42 {
+		panic("prune interval may not exceed 42 hours due to resolution of internal bookkeeping")
+	}
+	if pruneInterval.Minutes() < 10 {
+		panic("prune interval less than 10 minutes is useless due to resolution of internal bookkeeping")
+	}
+	k := &KeyCache{
+		pruneInterval: pruneInterval,
+		staleThresh:   Duration(int(staleThresh.Seconds()) / 600),
+		caches:        make(map[uint32]*Cache),
+	}
+	go k.prune()
+	return k
+}
+
+// Touch marks the key as seen and returns whether it was seen before
+// callers should assure that t >= ref and t-ref <= 42 hours
+func (k *KeyCache) Touch(key schema.MKey, t time.Time) bool {
+	k.RLock()
+	cache, ok := k.caches[key.Org]
+	k.RUnlock()
+	// most likely this branch won't execute
+	if !ok {
+		k.Lock()
+		// check again in case another routine has just added it
+		cache, ok = k.caches[key.Org]
+		if !ok {
+			cache = NewCache(NewRef(t))
+			k.caches[key.Org] = cache
+		}
+		k.Unlock()
+	}
+	return cache.Touch(key.Key, t)
+}
+
+// Len returns the size across all orgs
+func (k *KeyCache) Len() int {
+	var sum int
+	k.RLock()
+	caches := make([]*Cache, 0, len(k.caches))
+	for _, c := range k.caches {
+		caches = append(caches, c)
+	}
+	k.RUnlock()
+	for _, c := range caches {
+		sum += c.Len()
+	}
+	return sum
+}
+
+// prune makes sure each org's cache is pruned
+func (k *KeyCache) prune() {
+	tick := time.NewTicker(k.pruneInterval)
+	for now := range tick.C {
+
+		type target struct {
+			org   uint32
+			cache *Cache
+		}
+
+		k.RLock()
+		targets := make([]target, 0, len(k.caches))
+		for org, c := range k.caches {
+			targets = append(targets, target{
+				org,
+				c,
+			})
+		}
+		k.RUnlock()
+
+		for _, t := range targets {
+			size := t.cache.Prune(now, k.staleThresh)
+			if size == 0 {
+				k.Lock()
+				delete(k.caches, t.org)
+				k.Unlock()
+			}
+		}
+	}
+}

--- a/stacktest/fakemetrics/out/kafkamdm/keycache/shard.go
+++ b/stacktest/fakemetrics/out/kafkamdm/keycache/shard.go
@@ -1,0 +1,113 @@
+package keycache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/grafana/metrictank/schema"
+)
+
+// SubKey is the last 15 bytes of a 16 byte Key
+// We can track Key-identified metrics with a SubKey because
+// we shard by the first byte of the Key.
+type SubKey [15]byte
+
+// Shard tracks for each SubKey when it was last seen
+// we know the last seen timestamp with ~10 minute precision
+// because all SubKey's Duration's are relative to the ref
+type Shard struct {
+	sync.Mutex
+	ref  Ref
+	data map[SubKey]Duration
+}
+
+// NewShard creates a new shard
+func NewShard(ref Ref) Shard {
+	return Shard{
+		ref:  ref,
+		data: make(map[SubKey]Duration),
+	}
+}
+
+// Touch marks the key as seen and returns whether it was seen before
+// callers should assure that t >= ref and t-ref <= 42 hours
+func (s *Shard) Touch(key schema.Key, t time.Time) bool {
+	var sub SubKey
+	copy(sub[:], key[1:])
+	s.Lock()
+	_, ok := s.data[sub]
+	s.data[sub] = NewDuration(s.ref, t)
+	s.Unlock()
+	return ok
+}
+
+// Len returns the length of the shard
+func (s *Shard) Len() int {
+	s.Lock()
+	l := len(s.data)
+	s.Unlock()
+	return l
+}
+
+// Prune removes stale entries from the shard.
+// for this to work effectively,
+// call this with a frequency > 10 min and < 42 hours
+func (s *Shard) Prune(now time.Time, cutoff Duration) int {
+
+	s.Lock()
+	defer s.Unlock()
+
+	// establish the new reference.
+	// any values older will be pruned
+	// any values newer or equal will have their duration adjusted relative to newRef
+	newref := NewRef(now) - Ref(cutoff)
+
+	// in this case, nothing we can do.
+	// this happens when:
+	// caller prunes too often (more frequently than every 10 minutes)
+	// clock was adjusted and we went back in time
+	// the cutoff has increased from one call to the next
+	if newref <= s.ref {
+		return len(s.data)
+	}
+
+	// if we went further ahead in time than our bookkeeping resolution
+	// prune everything
+	// this happens when:
+	// clock jumps ahead
+	// missed ticker reads
+	// poorly configured prune interval
+	if newref > s.ref+255 {
+		s.data = make(map[SubKey]Duration)
+		return 0
+	}
+
+	// now that we know for sure that s.ref < newref <= s.ref+255
+	// or 0 < newref - s.ref <= 255                                                     (1)
+	// we can do precise pruning
+
+	// the amount to subtract of a duration for it to be based on the new reference
+	subtract := Duration(newref - s.ref)
+
+	for subkey, duration := range s.data {
+		// remove entry if it is too old, e.g. if:
+		// newref > "timestamp of the entry in 10minutely buckets"
+		// newref > s.ref + duration                                                (2)
+		if newref > s.ref+Ref(duration) {
+			delete(s.data, subkey)
+			continue
+		}
+
+		// adjust the duration to be based on the new reference
+		// for this to be correct we must assert that there is no underflow,
+		// ie. that: duration - subtract >= 0
+		// because of (2) we know that:
+		// newref <= s.ref+duration
+		// iow duration >= newref - s.ref
+		// iow duration >= subtract
+		// iow duration - bustract >=0 (QED)
+		s.data[subkey] = duration - subtract
+	}
+	s.ref = newref
+	return len(s.data)
+}

--- a/stacktest/fakemetrics/out/kafkamdm/keycache/shard_test.go
+++ b/stacktest/fakemetrics/out/kafkamdm/keycache/shard_test.go
@@ -1,0 +1,131 @@
+package keycache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/metrictank/schema"
+)
+
+func GetKey(suffix int) schema.Key {
+	s := uint32(suffix)
+	return schema.Key{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, byte(s >> 24), byte(s >> 16), byte(s >> 8), byte(s)}
+}
+
+func TestPrune(t *testing.T) {
+	base := 1234567890
+	now := time.Unix(int64(base), 0)
+
+	shard := NewShard(NewRef(now))
+	maxOffset := 255 * 600
+
+	// add a bunch of keys, with a key named after their timestamp for convenience
+	// starting at the base timestamp, all the way to base+(255*600)-1, they are bucketed as follows:
+	// ref     range                 count
+	// 2057613 base       - 1234568399 510
+	// 2057614 1234568400 - 1234569000 600
+	// ....
+	// 2057867 1234720200 - 1234720799 600
+	// 2057868 1234720800 - 1234720889 90
+	for offset := 0; offset < maxOffset; offset++ {
+		ok := shard.Touch(GetKey(offset), time.Unix(int64(base+offset), 0))
+		if ok {
+			t.Fatalf("offset=%d, Touch ok expected false, got true", offset)
+		}
+		l := shard.Len()
+		if l != offset+1 {
+			t.Fatalf("offset=%d, expected len %d, got %d", offset, offset+1, l)
+		}
+	}
+	// assert behavior when we prune very quickly after last prune or after shard creation
+	l := shard.Prune(now, 0)
+	exp := maxOffset
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+	// also try a few different cutoffs
+	l = shard.Prune(now, 1)
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+	l = shard.Prune(now, 2)
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+	l = shard.Prune(now, 3)
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+
+	// now start progressing through time and assert that stale entries get pruned
+	l = shard.Prune(now.Add(10*time.Minute), 1)
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+	l = shard.Prune(now.Add(20*time.Minute), 1)
+	exp = maxOffset - 510
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+	l = shard.Prune(now.Add(30*time.Minute), 1)
+	exp -= 600
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+
+	// re-prune with same settings and also with more cutoff allowance, should remain where we are
+	l = shard.Prune(now.Add(30*time.Minute), 1)
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+	l = shard.Prune(now.Add(30*time.Minute), 2)
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+
+	// continue again
+	l = shard.Prune(now.Add(40*time.Minute), 1)
+	exp -= 600
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+
+	// jump forward more significantly
+	l = shard.Prune(now.Add(70*time.Minute), 1)
+	exp -= 3 * 600
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+
+	// jump forward more significantly but with more cutoff allowance
+	l = shard.Prune(now.Add(100*time.Minute), 3)
+	exp -= 600
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+}
+
+// TestPruneAdjustRef creates a shard with arbitrary ref, adds a point to it with arbitrary timestamp
+// prunes it in the future, and asserts that the ref of the entry has been updated for the new reference
+func TestPruneAdjustRef(t *testing.T) {
+	base := 1234567890 // ref 2057613
+	now := time.Unix(int64(base), 0)
+	pointTs := 2057687*600 + 1337
+	key := GetKey(42)
+
+	shard := NewShard(NewRef(now))
+	shard.Touch(key, time.Unix(int64(pointTs), 0))
+	newNow := time.Unix(2057689*600, 10)
+	l := shard.Prune(newNow, 2)
+	exp := 1
+	if l != exp {
+		t.Fatalf("after prune, expected len %d, got %d", exp, l)
+	}
+
+	expDuration := Duration((pointTs / 600) - (2057689 - 2))
+	var sub SubKey
+	copy(sub[:], key[1:])
+	if shard.data[sub] != expDuration {
+		t.Fatalf("after prune, expected duration to have been adjusted to %d, but got %d", expDuration, shard.data[sub])
+	}
+}

--- a/stacktest/fakemetrics/out/kafkamdm/keycache/time.go
+++ b/stacktest/fakemetrics/out/kafkamdm/keycache/time.go
@@ -1,0 +1,26 @@
+package keycache
+
+import "time"
+
+// Ref represents a unix timestamp bucketed in 10m buckets
+type Ref uint32
+
+func NewRef(t time.Time) Ref {
+	unix := t.Unix()
+	return Ref(unix / 600)
+}
+
+// Duration is a compact way to represent a duration
+// bucketed in 10 minutely buckets.
+// which allows us to cover a timeframe of 42 hours
+// (just over a day and a half)
+// because:
+// 6 (10m periods per hour) *42 (hours) = 252 (10m periods)
+type Duration uint8
+
+// NewDuration creates a new Duration representing the
+// duration between Ref and t.
+// callers responsibility that t >= ref and t-ref <= 42 hours
+func NewDuration(ref Ref, t time.Time) Duration {
+	return Duration(NewRef(t) - ref)
+}

--- a/stacktest/fakemetrics/out/out.go
+++ b/stacktest/fakemetrics/out/out.go
@@ -10,6 +10,7 @@ import (
 // Out submits metricdata to a destination
 type Out interface {
 	Close() error
+	//output completely handles the data so that caller can reuse
 	Flush(metrics []*schema.MetricData) error
 }
 

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -120,7 +120,7 @@ func TestClusterBaseIngestWorkload(t *testing.T) {
 
 	// generate exactly numPartitions metrics, numbered 0..numPartitions where each metric goes to the partition of the same number
 	// each partition is consumed by 2 instances, and each instance consumes 4 partitions thus 4 metrics/s on average.
-	fm = fakemetrics.NewKafka(numPartitions)
+	fm = fakemetrics.NewKafka(numPartitions, 5*time.Second)
 
 	req := graphite.RequestForLocalTestingGraphite("perSecond(metrictank.stats.docker-cluster.*.input.kafka-mdm.metricdata.received.counter32)", "-8s")
 

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -120,7 +120,7 @@ func TestClusterBaseIngestWorkload(t *testing.T) {
 
 	// generate exactly numPartitions metrics, numbered 0..numPartitions where each metric goes to the partition of the same number
 	// each partition is consumed by 2 instances, and each instance consumes 4 partitions thus 4 metrics/s on average.
-	fm = fakemetrics.NewKafka(numPartitions, 5*time.Second)
+	fm = fakemetrics.NewKafka(numPartitions, 5*time.Second, false)
 
 	req := graphite.RequestForLocalTestingGraphite("perSecond(metrictank.stats.docker-cluster.*.input.kafka-mdm.metricdata.received.counter32)", "-8s")
 


### PR DESCRIPTION
pull in changes / best practices from upstream fakemetrics.in particular v2 aka MetricPoint support.
corresponding PR for fakemetrics: https://github.com/raintank/fakemetrics/pull/19
These 2 PR's makes the 2 codebases identical again, such that they can be merged.