### PR TITLE
Evaluate expressions which involve meta tags at the end

### DIFF
--- a/expr/tagquery/expression_not_equal.go
+++ b/expr/tagquery/expression_not_equal.go
@@ -24,7 +24,7 @@ func (e *expressionNotEqual) GetOperator() ExpressionOperator {
 }
 
 func (e *expressionNotEqual) GetOperatorCost() uint32 {
-	return 1
+	return 2
 }
 
 func (e *expressionNotEqual) RequiresNonEmptyValue() bool {

--- a/expr/tagquery/expression_prefix.go
+++ b/expr/tagquery/expression_prefix.go
@@ -24,7 +24,7 @@ func (e *expressionPrefix) GetOperator() ExpressionOperator {
 }
 
 func (e *expressionPrefix) GetOperatorCost() uint32 {
-	return 2
+	return 3
 }
 
 func (e *expressionPrefix) RequiresNonEmptyValue() bool {


### PR DESCRIPTION
When evaluating a set of query expressions of which some involve the meta tag index and some do not, then we want to build the initial result set based on those expressions which do not involve it and use the ones that do involve it as filters.

In many cases this can lead to a significant improvement in query latency, because when we build the initial result set based on a meta tag in some cases it can grow to a really large size which then needs to be filtered down (f.e. `datacenter=XYZ`).

Fixes issue #1534 

