### PR TITLE
Add optimizations for meta records of which the underlying expressions use equal operator

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -925,6 +925,8 @@ func (m *UnpartitionedMemoryIdx) add(archive *idx.Archive) {
 	path := def.NameWithTags()
 
 	if TagSupport {
+		sort.Strings(def.Tags)
+
 		// Even if there are no tags, index at least "name". It's important to use the definition
 		// in the archive pointer that we add to defById, because the pointers must reference the
 		// same underlying object in m.defById and m.defByTagSet

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -51,6 +51,43 @@ func filterAndCompareResults(t *testing.T, expressions tagquery.Expressions, met
 	}
 }
 
+func TestSliceContainsElements(t *testing.T) {
+	slice := []string{"a", "c", "e", "g", "i"}
+	if sliceContainsElements([]string{"a", "b", "c"}, slice) {
+		t.Fatalf("Failed at TC 1")
+	}
+	if sliceContainsElements([]string{"b", "c", "e"}, slice) {
+		t.Fatalf("Failed at TC 2")
+	}
+	if sliceContainsElements([]string{"a", "c", "e", "f"}, slice) {
+		t.Fatalf("Failed at TC 3")
+	}
+	if !sliceContainsElements([]string{"a", "c", "e"}, slice) {
+		t.Fatalf("Failed at TC 4")
+	}
+	if !sliceContainsElements([]string{"c", "e", "g"}, slice) {
+		t.Fatalf("Failed at TC 5")
+	}
+	if !sliceContainsElements([]string{"e", "g", "i"}, slice) {
+		t.Fatalf("Failed at TC 6")
+	}
+	if !sliceContainsElements(slice, slice) {
+		t.Fatalf("Failed at TC 7")
+	}
+	if !sliceContainsElements(nil, slice) {
+		t.Fatalf("Failed at TC 8")
+	}
+	if !sliceContainsElements(nil, nil) {
+		t.Fatalf("Failed at TC 9")
+	}
+	if !sliceContainsElements([]string{"i"}, slice) {
+		t.Fatalf("Failed at TC 10")
+	}
+	if !sliceContainsElements([]string{"a"}, slice) {
+		t.Fatalf("Failed at TC 11")
+	}
+}
+
 func TestFilterByMetricTag(t *testing.T) {
 	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetricTag))(t)
 }

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -210,6 +210,80 @@ func testFilterByMetaTagWithEqualAndWithHasTag(t *testing.T) {
 	filterAndCompareResults(t, tagquery.Expressions{notEqualExpr}, metaRecords, expectedMatch, expectedFail)
 }
 
+func TestFilterByMetaTagWithSingleUnderlyingEqualExpression(t *testing.T) {
+	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithSingleUnderlyingEqualExpression))(t)
+}
+
+func testFilterByMetaTagWithSingleUnderlyingEqualExpression(t *testing.T) {
+	metaRecord, err := tagquery.ParseMetaTagRecord([]string{"meta1=value1"}, []string{"tag1=value4"})
+	if err != nil {
+		t.Fatalf("Unexpected error when parsing meta record: %s", err)
+	}
+
+	_, mds := getTestArchives(10)
+
+	notEqualExpr, err := tagquery.ParseExpression("meta1=value1")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %s", err)
+	}
+
+	notHasTagExpr, err := tagquery.ParseExpression("meta1!=")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %s", err)
+	}
+
+	var expectedMatch []schema.MetricDefinition
+	var expectedFail []schema.MetricDefinition
+
+	if MetaTagSupport {
+		expectedMatch = []schema.MetricDefinition{mds[4]}
+		expectedFail = append(mds[:4], mds[5:]...)
+	} else {
+		expectedMatch = nil
+		expectedFail = mds
+	}
+
+	filterAndCompareResults(t, tagquery.Expressions{notHasTagExpr}, []tagquery.MetaTagRecord{metaRecord}, expectedMatch, expectedFail)
+	filterAndCompareResults(t, tagquery.Expressions{notEqualExpr}, []tagquery.MetaTagRecord{metaRecord}, expectedMatch, expectedFail)
+}
+
+func TestFilterByMetaTagWithMultipleUnderlyingEqualExpression(t *testing.T) {
+	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithMultipleUnderlyingEqualExpression))(t)
+}
+
+func testFilterByMetaTagWithMultipleUnderlyingEqualExpression(t *testing.T) {
+	metaRecord, err := tagquery.ParseMetaTagRecord([]string{"meta1=value1"}, []string{"tag1=value2", "tag2=other"})
+	if err != nil {
+		t.Fatalf("Unexpected error when parsing meta record: %s", err)
+	}
+
+	_, mds := getTestArchives(10)
+
+	notEqualExpr, err := tagquery.ParseExpression("meta1=value1")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %s", err)
+	}
+
+	notHasTagExpr, err := tagquery.ParseExpression("meta1!=")
+	if err != nil {
+		t.Fatalf("Failed to parse expression: %s", err)
+	}
+
+	var expectedMatch []schema.MetricDefinition
+	var expectedFail []schema.MetricDefinition
+
+	if MetaTagSupport {
+		expectedMatch = []schema.MetricDefinition{mds[2]}
+		expectedFail = append(mds[:2], mds[3:]...)
+	} else {
+		expectedMatch = nil
+		expectedFail = mds
+	}
+
+	filterAndCompareResults(t, tagquery.Expressions{notHasTagExpr}, []tagquery.MetaTagRecord{metaRecord}, expectedMatch, expectedFail)
+	filterAndCompareResults(t, tagquery.Expressions{notEqualExpr}, []tagquery.MetaTagRecord{metaRecord}, expectedMatch, expectedFail)
+}
+
 func TestFilterByMetaTagWithPatternMatching(t *testing.T) {
 	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithPatternMatching))(t)
 }


### PR DESCRIPTION
This PR is based on #1541, it does not make sense to review it before that one is merged.

When we filter by meta records of which the underlying expressions all use the equal operator we can save a lot of tag index lookup by building a set of acceptable tags based on the meta record expressions and then simple filtering by them, instead of having to evaluate each of them by doing the tag lookup on the tag index. 

These 3 benchmarks are testing cases where we filter by meta tags which have a large number of underlying expressions which all use equal operators. For example a datacenter mapping to a list of `host=X` tag/value pairs.

```
benchmark                                                                                  old ns/op        new ns/op       delta
BenchmarkFilter100kByMetaTagWithIndexSize1mAnd50kMetaRecords-12                            95441374800      285884142       -99.70%
BenchmarkFilter10kByMetaTagWithIndexSize1mAnd10kMetaRecords-12                             2008162900       30703885        -98.47%
BenchmarkFilter100kByMetaTagWithIndexSize1mAnd50kMetaRecordsWithMultipleExpressions-12     115969750200     12734048100     -89.02%
```

grafana/metrictank-ops/issues/524