### PR TITLE
index refactor for more granular locks

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -279,7 +279,7 @@ type UnpartitionedMemoryIdx struct {
 	// used by tag index
 	defByTagSet     defByTagSet
 	tags            map[uint32]TagIndex         // by orgId
-	metaTagIndex    map[uint32]metaTagIndex     // by orgId
+	metaTagIndex    map[uint32]metaTagHierarchy // by orgId
 	metaTagRecords  map[uint32]*metaTagRecords  // by orgId
 	metaTagEnricher map[uint32]*metaTagEnricher // by orgId
 
@@ -294,7 +294,7 @@ func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
 		defByTagSet:     make(defByTagSet),
 		tree:            make(map[uint32]*Tree),
 		tags:            make(map[uint32]TagIndex),
-		metaTagIndex:    make(map[uint32]metaTagIndex),
+		metaTagIndex:    make(map[uint32]metaTagHierarchy),
 		metaTagRecords:  make(map[uint32]*metaTagRecords),
 		metaTagEnricher: make(map[uint32]*metaTagEnricher),
 	}
@@ -467,7 +467,7 @@ func (m *UnpartitionedMemoryIdx) UpdateArchiveLastSave(id schema.MKey, partition
 	}
 }
 
-func (m *UnpartitionedMemoryIdx) getMetaTagDataStructures(orgId uint32, create bool) (*metaTagRecords, metaTagIndex, *metaTagEnricher) {
+func (m *UnpartitionedMemoryIdx) getMetaTagDataStructures(orgId uint32, create bool) (*metaTagRecords, metaTagHierarchy, *metaTagEnricher) {
 	return m.getMetaTagRecords(orgId, create), m.getMetaTagIndex(orgId, create), m.getMetaTagEnricher(orgId, create)
 }
 
@@ -482,11 +482,11 @@ func (m *UnpartitionedMemoryIdx) getMetaTagRecords(orgId uint32, create bool) *m
 	return nil
 }
 
-func (m *UnpartitionedMemoryIdx) getMetaTagIndex(orgId uint32, create bool) metaTagIndex {
+func (m *UnpartitionedMemoryIdx) getMetaTagIndex(orgId uint32, create bool) metaTagHierarchy {
 	if mti, ok := m.metaTagIndex[orgId]; ok {
 		return mti
 	} else if create {
-		mti = make(metaTagIndex)
+		mti = make(metaTagHierarchy)
 		m.metaTagIndex[orgId] = mti
 		return mti
 	}
@@ -516,7 +516,7 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord 
 	}
 
 	var mtr *metaTagRecords
-	var mti metaTagIndex
+	var mti metaTagHierarchy
 	var enricher *metaTagEnricher
 
 	// expressions need to be sorted because the unique ID of a meta record is

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -268,6 +268,7 @@ func (n *Node) String() string {
 
 type UnpartitionedMemoryIdx struct {
 	sync.RWMutex
+	*metaTagIdx
 
 	// used for both hierarchy and tag index, so includes all MDs, with
 	// and without tags. It also mixes all orgs into one flat map.
@@ -277,11 +278,8 @@ type UnpartitionedMemoryIdx struct {
 	tree map[uint32]*Tree // by orgId
 
 	// used by tag index
-	defByTagSet     defByTagSet
-	tags            map[uint32]TagIndex         // by orgId
-	metaTagIndex    map[uint32]metaTagHierarchy // by orgId
-	metaTagRecords  map[uint32]*metaTagRecords  // by orgId
-	metaTagEnricher map[uint32]*metaTagEnricher // by orgId
+	defByTagSet defByTagSet
+	tags        map[uint32]TagIndex // by orgId
 
 	findCache *FindCache
 
@@ -290,14 +288,16 @@ type UnpartitionedMemoryIdx struct {
 
 func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
 	m := &UnpartitionedMemoryIdx{
-		defById:         make(map[schema.MKey]*idx.Archive),
-		defByTagSet:     make(defByTagSet),
-		tree:            make(map[uint32]*Tree),
-		tags:            make(map[uint32]TagIndex),
-		metaTagIndex:    make(map[uint32]metaTagHierarchy),
-		metaTagRecords:  make(map[uint32]*metaTagRecords),
-		metaTagEnricher: make(map[uint32]*metaTagEnricher),
+		defById:     make(map[schema.MKey]*idx.Archive),
+		defByTagSet: make(defByTagSet),
+		tree:        make(map[uint32]*Tree),
+		tags:        make(map[uint32]TagIndex),
 	}
+
+	if MetaTagSupport {
+		m.metaTagIdx = newMetaTagIndex(m.IdsByTagQuery)
+	}
+
 	return m
 }
 
@@ -322,12 +322,10 @@ func (m *UnpartitionedMemoryIdx) Stop() {
 		m.writeQueue = nil
 	}
 
-	if MetaTagSupport {
+	if MetaTagSupport && m.metaTagIdx != nil {
 		m.Lock()
-		for orgId := range m.metaTagEnricher {
-			m.metaTagEnricher[orgId].stop()
-			delete(m.metaTagEnricher, orgId)
-		}
+		m.metaTagIdx.stop()
+		m.metaTagIdx = nil
 		m.Unlock()
 	}
 	return
@@ -467,338 +465,6 @@ func (m *UnpartitionedMemoryIdx) UpdateArchiveLastSave(id schema.MKey, partition
 	}
 }
 
-func (m *UnpartitionedMemoryIdx) getMetaTagDataStructures(orgId uint32, create bool) (*metaTagRecords, metaTagHierarchy, *metaTagEnricher) {
-	return m.getMetaTagRecords(orgId, create), m.getMetaTagIndex(orgId, create), m.getMetaTagEnricher(orgId, create)
-}
-
-func (m *UnpartitionedMemoryIdx) getMetaTagRecords(orgId uint32, create bool) *metaTagRecords {
-	if mtr, ok := m.metaTagRecords[orgId]; ok {
-		return mtr
-	} else if create {
-		mtr = newMetaTagRecords()
-		m.metaTagRecords[orgId] = mtr
-		return mtr
-	}
-	return nil
-}
-
-func (m *UnpartitionedMemoryIdx) getMetaTagIndex(orgId uint32, create bool) metaTagHierarchy {
-	if mti, ok := m.metaTagIndex[orgId]; ok {
-		return mti
-	} else if create {
-		mti = make(metaTagHierarchy)
-		m.metaTagIndex[orgId] = mti
-		return mti
-	}
-	return nil
-}
-
-func (m *UnpartitionedMemoryIdx) getMetaTagEnricher(orgId uint32, create bool) *metaTagEnricher {
-	if enricher, ok := m.metaTagEnricher[orgId]; ok {
-		return enricher
-	} else if create {
-		enricher = newEnricher()
-		m.metaTagEnricher[orgId] = enricher
-		return enricher
-	}
-	return nil
-}
-
-// MetaTagRecordUpsert inserts or updates a meta record, depending on whether
-// it already exists or is new. The identity of a record is determined by its
-// queries, if the set of queries in the given record already exists in another
-// record, then the existing record will be updated, otherwise a new one gets
-// created.
-func (m *UnpartitionedMemoryIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord) error {
-	if !TagSupport || !MetaTagSupport {
-		log.Warn("memory-idx: received tag/meta-tag query, but that feature is disabled")
-		return errors.NewBadRequest("Tag/Meta-Tag support is disabled")
-	}
-
-	var mtr *metaTagRecords
-	var mti metaTagHierarchy
-	var enricher *metaTagEnricher
-
-	// expressions need to be sorted because the unique ID of a meta record is
-	// its sorted set of expressions
-	upsertRecord.Expressions.Sort()
-
-	// initialize query in preparation to execute it once we have the look
-	// doing struct instantiations before acquiring lock to keep lock time short
-	query, err := tagquery.NewQuery(upsertRecord.Expressions, 0)
-	if err != nil {
-		return fmt.Errorf("Invalid record with expressions/meta tags: %q/%q", upsertRecord.Expressions, upsertRecord.MetaTags)
-	}
-	queryCtx := NewTagQueryContext(query)
-
-	m.Lock()
-	defer m.Unlock()
-
-	// need to acquire write lock before getting the meta tag data structures
-	// because if they have not yet been initialized then this call will do so
-	mtr, mti, enricher = m.getMetaTagDataStructures(orgId, true)
-	tags := m.tags[orgId]
-	if tags == nil {
-		tags = make(TagIndex)
-		m.tags[orgId] = tags
-	}
-
-	// acquiring meta record lock because we're going to modify
-	// meta records and the meta tag index
-	mtr.metaRecordLock.Lock()
-	defer mtr.metaRecordLock.Unlock()
-
-	id, record, oldId, oldRecord, err := mtr.upsert(upsertRecord)
-	if err != nil {
-		return err
-	}
-
-	var metricKeys []schema.Key
-	idCh := m.idsByTagQuery(orgId, queryCtx)
-	for metricId := range idCh {
-		metricKeys = append(metricKeys, metricId.Key)
-	}
-
-	// check if the upsert has replaced a previously existing record
-	if oldId > 0 && oldRecord != nil {
-		// if so we remove all references to it from the enricher
-		// and from the meta tag index
-		enricher.delMetaRecord(oldId, metricKeys)
-		for _, keyValue := range oldRecord.MetaTags {
-			mti.deleteRecord(keyValue, oldId)
-		}
-	}
-
-	// add the newly inserted meta record into the enricher and the
-	// meta tag index
-	enricher.addMetaRecord(id, query, metricKeys)
-	for _, keyValue := range record.MetaTags {
-		mti.insertRecord(keyValue, id)
-	}
-
-	return nil
-}
-
-func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaTagRecord) error {
-	if !TagSupport || !MetaTagSupport {
-		log.Warn("memory-idx: received a tag/meta-tag query, but that feature is disabled")
-		return errors.NewBadRequest("Tag/Meta-Tag support is disabled")
-	}
-
-	metaRecordSwapExecuting.Inc()
-
-	log.Infof("memory-idx: Initiating Swap with %d records for org %d", len(newRecords), orgId)
-	m.RLock()
-	mtr, mti, enricher := m.getMetaTagDataStructures(orgId, false)
-	tags := m.tags[orgId]
-	m.RUnlock()
-
-	if mtr == nil || mti == nil || enricher == nil {
-		// if one of the meta tag data structs has not been initialized yet we
-		// acquire the write lock and do so by calling with `true` as 2nd arg
-		m.Lock()
-		mtr, mti, enricher = m.getMetaTagDataStructures(orgId, true)
-		m.Unlock()
-	}
-
-	if tags == nil {
-		m.Lock()
-		tags = make(TagIndex)
-		m.tags[orgId] = tags
-		m.Unlock()
-	}
-
-	// recordIdsToKeep contains the records that should not be modified
-	recordIdsToKeep := make(map[recordId]struct{}, len(newRecords))
-
-	// recordsToUpsert contains the records which we're either going to
-	// either insert or update
-	var recordsToUpsert []tagquery.MetaTagRecord
-
-	// acquiring meta record lock because we're going to modify the meta tag
-	// index and the meta records
-	mtr.metaRecordLock.Lock()
-	defer mtr.metaRecordLock.Unlock()
-
-	// iterate over each of the new records to build a list of those that need to
-	// either be updated or inserted by comparing them to the currently existing
-	// records.
-	// all the existing ones that should not be modified get added to the set
-	// recordIdsToKeep.
-	m.RLock()
-	for i := range newRecords {
-		newRecords[i].Expressions.Sort()
-		newRecords[i].MetaTags.Sort()
-
-		// check for each record whether it exists, those which exist and have
-		// the same meta tags get added to recordIdsToKeep because we don't
-		// want to modify them
-		existingRecordId, exists, equal := mtr.recordExistsAndIsEqual(newRecords[i])
-		if exists && equal {
-			recordIdsToKeep[existingRecordId] = struct{}{}
-			continue
-		}
-
-		// the ones which either don't exist or do not have the same meta tags
-		// get added to recordsToUpsert
-		recordsToUpsert = append(recordsToUpsert, newRecords[i])
-	}
-	m.RUnlock()
-	log.Infof("memory-idx: After diff against existing meta records for org %d, going to upsert %d, %d remain unchanged", orgId, len(recordsToUpsert), len(recordIdsToKeep))
-	recordsUnchanged := uint32(len(recordIdsToKeep))
-
-	var query tagquery.Query
-	var queryCtx TagQueryContext
-	var err error
-	var recordsModified, recordsAdded, recordsPruned uint32
-	for _, record := range recordsToUpsert {
-		query, err = tagquery.NewQuery(record.Expressions, 0)
-		if err != nil {
-			log.Errorf("Invalid record (%q/%q): %s", record.Expressions.Strings(), record.MetaTags.Strings(), err)
-			continue
-		}
-		queryCtx = NewTagQueryContext(query)
-
-		// acquiring the write lock once per iteration, instead of acquiring it
-		// for the whole loop, because the speed of swap operations is not as
-		// important as keeping the query response times low
-		m.Lock()
-
-		// verify that nothing has changed between releasing the read lock
-		// and acquiring the write lock
-		existingRecordId, exists, equal := mtr.recordExistsAndIsEqual(record)
-		if exists && equal {
-			// something changed since we released the read lock, no need
-			// to update this record anymore
-			recordsUnchanged++
-			recordIdsToKeep[existingRecordId] = struct{}{}
-			m.Unlock()
-			continue
-		}
-
-		idCh := m.idsByTagQuery(orgId, queryCtx)
-		// not reusing metricKeys because it will be passed into the enricher
-		// which processes it asynchronously
-		var metricKeys []schema.Key
-		for metricId := range idCh {
-			metricKeys = append(metricKeys, metricId.Key)
-		}
-
-		if exists {
-			// the record already exists, but it has different meta tags
-			// associated, so we need to delete the references to the old
-			// recordId from the enricher and the mti because the id may
-			// change when we update it
-			recordsModified++
-			enricher.delMetaRecord(existingRecordId, metricKeys)
-			for _, tag := range mtr.getMetaTagsByRecordId(existingRecordId) {
-				mti.deleteRecord(tag, existingRecordId)
-			}
-		} else {
-			// this record is new
-			recordsAdded++
-		}
-
-		newRecordId, newRecord, _, _, err := mtr.upsert(record)
-		if err != nil {
-			log.Errorf("Error when upserting meta record (%q/%q): %s", record.Expressions.Strings(), record.MetaTags.Strings(), err.Error())
-			m.Unlock()
-			continue
-		}
-
-		enricher.addMetaRecord(newRecordId, query, metricKeys)
-		for _, tag := range newRecord.MetaTags {
-			mti.insertRecord(tag, newRecordId)
-		}
-
-		m.Unlock()
-
-		// adding the new record id to recordIdsToKeep to prevent that
-		// it gets pruned further down
-		recordIdsToKeep[newRecordId] = struct{}{}
-	}
-
-	m.RLock()
-
-	// if the number of meta tag records is equal to the number of record
-	// ids to keep, and we've already ensured that the meta tag records are
-	// all up2date, then there's nothing to prune
-	if mtr.length() != len(recordIdsToKeep) {
-		m.RUnlock()
-		var pruned map[recordId]tagquery.MetaTagRecord
-		toPrune := mtr.getPrunable(recordIdsToKeep)
-		if len(toPrune) > 0 {
-			log.Infof("memory-idx: Going to prune %d meta records for org %d", len(toPrune), orgId)
-			recordsPruned = uint32(len(toPrune))
-
-			m.Lock()
-			// we can assume that the toPrune list is still correct because we're
-			// holding the metaRecordLock
-			pruned = make(map[recordId]tagquery.MetaTagRecord, len(toPrune))
-			mtr.prune(toPrune, pruned)
-			m.Unlock()
-		}
-
-		// remove all references to the pruned meta records from the meta
-		// tag index and the enricher
-		for recordId, record := range pruned {
-			// keeping the lock time as short as possible because pruning
-			// performance is not important compared to query response times
-			m.Lock()
-			for _, tag := range record.MetaTags {
-				mti.deleteRecord(tag, recordId)
-			}
-			m.Unlock()
-
-			query, err = tagquery.NewQuery(record.Expressions, 0)
-			if err != nil {
-				log.Errorf("Invalid meta record with id %d and expressions/meta tags: %q/%q", recordId, record.Expressions.Strings(), record.MetaTags.Strings())
-				continue
-			}
-			queryCtx = NewTagQueryContext(query)
-
-			m.Lock()
-			idCh := m.idsByTagQuery(orgId, queryCtx)
-			var metricKeys []schema.Key
-			for metricId := range idCh {
-				metricKeys = append(metricKeys, metricId.Key)
-			}
-			enricher.delMetaRecord(recordId, metricKeys)
-			m.Unlock()
-		}
-	} else {
-		m.RUnlock()
-	}
-
-	metaRecordSwapUnchanged.AddUint32(recordsUnchanged)
-	metaRecordSwapAdded.AddUint32(recordsAdded)
-	metaRecordSwapModified.AddUint32(recordsModified)
-	metaRecordSwapPruned.AddUint32(recordsPruned)
-
-	return nil
-}
-
-func (m *UnpartitionedMemoryIdx) MetaTagRecordList(orgId uint32) []tagquery.MetaTagRecord {
-	var res []tagquery.MetaTagRecord
-
-	m.RLock()
-	defer m.RUnlock()
-
-	mtr := m.getMetaTagRecords(orgId, false)
-	if mtr == nil {
-		return res
-	}
-
-	res = make([]tagquery.MetaTagRecord, len(mtr.records))
-	i := 0
-	for _, record := range mtr.records {
-		res[i] = record
-		i++
-	}
-
-	return res
-}
-
 // indexTags reads the tags of a given metric definition and creates the
 // corresponding tag index entries to refer to it. It assumes a lock is
 // already held.
@@ -828,7 +494,13 @@ func (m *UnpartitionedMemoryIdx) indexTags(def *schema.MetricDefinition) {
 	m.defByTagSet.add(def)
 
 	if MetaTagSupport {
-		m.getMetaTagEnricher(def.OrgId, true).addMetric(*def)
+		// it is important to release the lock for a short time, otherwise
+		// it's possible that the enricher can't process its queue because
+		// it could be blocked on waiting for the read lock on the index
+		// which would lead to deadlock.
+		m.Unlock()
+		m.getOrgMetaTagIndex(def.OrgId).enricher.addMetric(*def)
+		m.Lock()
 	}
 }
 
@@ -858,7 +530,13 @@ func (m *UnpartitionedMemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDe
 	m.defByTagSet.del(def)
 
 	if MetaTagSupport {
-		m.getMetaTagEnricher(def.OrgId, true).delMetric(def)
+		// it is important to release the lock for a short time, otherwise
+		// it's possible that the enricher can't process its queue because
+		// it could be blocked on waiting for the read lock on the index
+		// which would lead to deadlock.
+		m.Unlock()
+		m.getOrgMetaTagIndex(def.OrgId).enricher.delMetric(def)
+		m.Lock()
 	}
 
 	return true
@@ -1069,13 +747,11 @@ func (m *UnpartitionedMemoryIdx) FindByTag(orgId uint32, query tagquery.Query) [
 	m.RLock()
 	defer m.RUnlock()
 
-	var enricher *metaTagEnricher
-	var mtr *metaTagRecords
+	var metaTagIdx *orgMetaTagIdx
 	if MetaTagSupport {
-		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
-		if enricher != nil && enricher.countMetricsWithMetaTags() == 0 {
-			// if the enricher is empty we set it back to nil so it doesn't even get called
-			enricher = nil
+		metaTagIdx = m.getOrgMetaTagIndex(orgId)
+		if metaTagIdx.enricher.countMetricsWithMetaTags() == 0 {
+			metaTagIdx = nil
 		}
 	}
 
@@ -1099,8 +775,8 @@ func (m *UnpartitionedMemoryIdx) FindByTag(orgId uint32, query tagquery.Query) [
 				HasChildren: false,
 				Defs:        []idx.Archive{CloneArchive(def)},
 			}
-			if enricher != nil && mtr != nil {
-				byPath[nameWithTags].MetaTags = mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
+			if metaTagIdx != nil {
+				byPath[nameWithTags].MetaTags = metaTagIdx.getMetaTagsById(def.Id.Key)
 			}
 		} else {
 			existing.Defs = append(existing.Defs, CloneArchive(def))
@@ -1181,10 +857,10 @@ func (m *UnpartitionedMemoryIdx) Tags(orgId uint32, filter *regexp.Regexp) []str
 	}
 
 	m.RLock()
-	defer m.RUnlock()
 
 	tags, ok := m.tags[orgId]
 	if !ok {
+		m.RUnlock()
 		return nil
 	}
 
@@ -1201,27 +877,16 @@ func (m *UnpartitionedMemoryIdx) Tags(orgId uint32, filter *regexp.Regexp) []str
 		res = append(res, tag)
 	}
 
+	m.RUnlock()
+
 	if !MetaTagSupport {
 		sort.Strings(res)
 		return res
 	}
 
-	mti := m.getMetaTagIndex(orgId, false)
-	if mti == nil {
-		sort.Strings(res)
-		return res
-	}
-
-	for tag := range mti {
-		// filter by pattern if one was given
-		if filter != nil && !filter.MatchString(tag) {
-			continue
-		}
-
-		res = append(res, tag)
-	}
-
+	res = append(res, m.getOrgMetaTagIndex(orgId).tags.getTagsByFilter(filter)...)
 	sort.Strings(res)
+
 	return res
 }
 
@@ -1232,7 +897,6 @@ func (m *UnpartitionedMemoryIdx) TagDetails(orgId uint32, key string, filter *re
 	}
 
 	m.RLock()
-	defer m.RUnlock()
 
 	tags, ok := m.tags[orgId]
 	if !ok {
@@ -1248,34 +912,37 @@ func (m *UnpartitionedMemoryIdx) TagDetails(orgId uint32, key string, filter *re
 		res[value] += uint64(len(ids))
 	}
 
+	m.RUnlock()
+
 	if !MetaTagSupport {
 		return res
 	}
 
-	mtr, mti, _ := m.getMetaTagDataStructures(orgId, false)
+	metaTagIdx := m.getOrgMetaTagIndex(orgId)
 
-	for value, recordIds := range mti[key] {
-		if filter != nil && !filter.MatchString(value) {
-			continue
-		}
-
+	for value, recordIds := range metaTagIdx.tags.getTagValuesByRegex(key, filter) {
 		for _, recordId := range recordIds {
-			record, ok := mtr.records[recordId]
+			record, ok := metaTagIdx.records.getMetaRecordById(recordId)
 			if !ok {
-				corruptIndex.Inc()
-				log.Errorf("memory-idx: corrupt. record id %d is in meta tag index, but not in meta tag records", recordId)
 				continue
 			}
+
 			query, err := tagquery.NewQuery(record.Expressions, 0)
 			if err != nil {
 				corruptIndex.Inc()
 				log.Errorf("memory-idx: corrupt. record expressions cannot instantiate query: %+v results in %s", record.Expressions, err)
 				continue
 			}
-			resCh := m.idsByTagQuery(orgId, NewTagQueryContext(query))
+
+			queryCtx := NewTagQueryContext(query)
+			queryCtx.subQuery = true
+
+			m.RLock()
+			resCh := m.idsByTagQuery(orgId, queryCtx)
 			for range resCh {
 				res[value]++
 			}
+			m.RUnlock()
 		}
 	}
 
@@ -1294,10 +961,10 @@ func (m *UnpartitionedMemoryIdx) FindTags(orgId uint32, prefix string, limit uin
 	}
 
 	m.RLock()
-	defer m.RUnlock()
 
 	tags, ok := m.tags[orgId]
 	if !ok {
+		m.RUnlock()
 		return nil
 	}
 
@@ -1312,20 +979,17 @@ func (m *UnpartitionedMemoryIdx) FindTags(orgId uint32, prefix string, limit uin
 		}
 	}
 
+	m.RUnlock()
 	if !MetaTagSupport {
 		return m.finalizeResult(res, limit, false)
 	}
 
-	mti := m.getMetaTagIndex(orgId, false)
-	for tag := range mti {
-		// a tag gets appended to the result set if either the given prefix is
-		// empty or the tag has the given prefix
-		if len(prefix) == 0 || strings.HasPrefix(tag, prefix) {
-			res = append(res, tag)
-		}
+	metaTags := m.getOrgMetaTagIndex(orgId).tags.getTagsByPrefix(prefix)
+	if len(metaTags) == 0 {
+		return m.finalizeResult(res, limit, false)
 	}
 
-	return m.finalizeResult(res, limit, true)
+	return m.finalizeResult(append(res, metaTags...), limit, true)
 }
 
 // FindTagsWithQuery returns tags matching the specified conditions
@@ -1339,23 +1003,19 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 		return nil
 	}
 
-	queryCtx := NewTagQueryContext(query)
-
-	m.RLock()
-	defer m.RUnlock()
-
-	resMap := make(map[string]struct{})
-
-	var enricher *metaTagEnricher
-	var mtr *metaTagRecords
+	var metaTagIdx *orgMetaTagIdx
 	if MetaTagSupport {
-		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
-		if enricher != nil && enricher.countMetricsWithMetaTags() == 0 {
-			// if the enricher is empty we set it back to nil so it doesn't even get called
-			enricher = nil
+		metaTagIdx = m.getOrgMetaTagIndex(orgId)
+		if metaTagIdx.enricher.countMetricsWithMetaTags() == 0 {
+			// if the enricher is empty we set the index back to nil so it doesn't even get called
+			metaTagIdx = nil
 		}
 	}
 
+	queryCtx := NewTagQueryContext(query)
+	resMap := make(map[string]struct{})
+
+	m.RLock()
 	resCh := m.idsByTagQuery(orgId, queryCtx)
 	for id := range resCh {
 		def, ok := m.defById[id]
@@ -1379,8 +1039,8 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 			}
 		}
 
-		if enricher != nil && mtr != nil {
-			metaTags := mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
+		if metaTagIdx != nil {
+			metaTags := metaTagIdx.getMetaTagsById(def.Id.Key)
 			for _, tag := range metaTags {
 				if len(prefix) == 0 || strings.HasPrefix(tag.Key, prefix) {
 					resMap[tag.Key] = struct{}{}
@@ -1388,6 +1048,7 @@ func (m *UnpartitionedMemoryIdx) FindTagsWithQuery(orgId uint32, prefix string, 
 			}
 		}
 	}
+	m.RUnlock()
 
 	// handle special case of the name tag
 	if len(prefix) == 0 || strings.HasPrefix("name", prefix) {
@@ -1417,10 +1078,8 @@ func (m *UnpartitionedMemoryIdx) FindTagValues(orgId uint32, tag, prefix string,
 	}
 
 	m.RLock()
-	defer m.RUnlock()
 
 	values := m.tags[orgId][tag]
-
 	res := make([]string, 0, len(values))
 	for value := range values {
 		if len(prefix) == 0 || strings.HasPrefix(value, prefix) {
@@ -1428,24 +1087,23 @@ func (m *UnpartitionedMemoryIdx) FindTagValues(orgId uint32, tag, prefix string,
 		}
 	}
 
+	m.RUnlock()
+
 	if !MetaTagSupport {
 		return m.finalizeResult(res, limit, false)
 	}
 
-	metaTagValues := m.getMetaTagIndex(orgId, false)[tag]
+	metaTagIdx := m.getOrgMetaTagIndex(orgId)
+	if metaTagIdx.enricher.countMetricsWithMetaTags() == 0 {
+		return m.finalizeResult(res, limit, false)
+	}
+
+	metaTagValues := metaTagIdx.tags.getTagValuesByTagAndPrefix(tag, prefix)
 	if len(metaTagValues) == 0 {
 		return m.finalizeResult(res, limit, false)
 	}
 
-	for value := range metaTagValues {
-		// a tag value gets appended to the result set if either the given prefix is
-		// empty or the tag value has the given prefix
-		if len(prefix) == 0 || strings.HasPrefix(value, prefix) {
-			res = append(res, value)
-		}
-	}
-
-	return m.finalizeResult(res, limit, true)
+	return m.finalizeResult(append(res, metaTagValues...), limit, true)
 }
 
 func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefix string, query tagquery.Query, limit uint) []string {
@@ -1454,22 +1112,19 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 		return nil
 	}
 
-	queryCtx := NewTagQueryContext(query)
-
-	m.RLock()
-	defer m.RUnlock()
-
-	resMap := make(map[string]struct{})
-
-	var enricher *metaTagEnricher
-	var mtr *metaTagRecords
+	var metaTagIdx *orgMetaTagIdx
 	if MetaTagSupport {
-		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
-		if enricher != nil && enricher.countMetricsWithMetaTags() == 0 {
-			// if the enricher is empty we set it back to nil so it doesn't even get called
-			enricher = nil
+		metaTagIdx = m.getOrgMetaTagIndex(orgId)
+		if metaTagIdx.enricher.countMetricsWithMetaTags() == 0 {
+			// if the enricher is empty we set the index back to nil so it doesn't even get called
+			metaTagIdx = nil
 		}
 	}
+
+	queryCtx := NewTagQueryContext(query)
+	resMap := make(map[string]struct{})
+
+	m.RLock()
 
 	resCh := m.idsByTagQuery(orgId, queryCtx)
 	tagPrefix := tag + "=" + prefix
@@ -1503,8 +1158,8 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 				resMap[tagValue[1]] = struct{}{}
 			}
 
-			if enricher != nil && mtr != nil {
-				metaTags := mtr.getMetaTagsByRecordIds(enricher.enrich(def.Id.Key))
+			if metaTagIdx != nil {
+				metaTags := metaTagIdx.getMetaTagsById(def.Id.Key)
 				for _, metaTag := range metaTags {
 					if metaTag.Key == tag && strings.HasPrefix(metaTag.Value, prefix) {
 						resMap[metaTag.Value] = struct{}{}
@@ -1513,6 +1168,7 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 			}
 		}
 	}
+	m.RUnlock()
 
 	res := make([]string, len(resMap))
 	i := 0
@@ -1533,9 +1189,40 @@ func (m *UnpartitionedMemoryIdx) idsByTagQuery(orgId uint32, query TagQueryConte
 		return resCh
 	}
 
-	query.RunNonBlocking(tags, m.defById, m.getMetaTagIndex(orgId, false), m.getMetaTagRecords(orgId, false), resCh)
-
+	if MetaTagSupport {
+		metaTagIdx := m.getOrgMetaTagIndex(orgId)
+		query.RunNonBlocking(tags, m.defById, metaTagIdx.tags, metaTagIdx.records, resCh)
+	} else {
+		query.RunNonBlocking(tags, m.defById, nil, nil, resCh)
+	}
 	return resCh
+}
+
+func (m *UnpartitionedMemoryIdx) IdsByTagQuery(orgId uint32, query tagquery.Query, callback func(chan schema.MKey)) {
+	queryCtx := NewTagQueryContext(query)
+
+	m.RLock()
+
+	resCh := make(chan schema.MKey, 100)
+	callback(resCh)
+
+	tags, ok := m.tags[orgId]
+	if !ok {
+		m.RUnlock()
+		close(resCh)
+		return
+	}
+
+	go func() {
+		if MetaTagSupport {
+			metaTagIdx := m.getOrgMetaTagIndex(orgId)
+			queryCtx.RunBlocking(tags, m.defById, metaTagIdx.tags, metaTagIdx.records, resCh)
+		} else {
+			queryCtx.RunBlocking(tags, m.defById, nil, nil, resCh)
+		}
+		m.RUnlock()
+		close(resCh)
+	}()
 }
 
 // finalizeResult prepares a result to return it to the caller

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -881,7 +881,7 @@ func (m *UnpartitionedMemoryIdx) Tags(orgId uint32, filter *regexp.Regexp) []str
 		return res
 	}
 
-	res = append(res, m.getOrgMetaTagIndex(orgId).tags.getTagsByFilter(filter)...)
+	res = append(res, m.getOrgMetaTagIndex(orgId).hierarchy.getTagsByFilter(filter)...)
 	sort.Strings(res)
 
 	return res
@@ -917,7 +917,7 @@ func (m *UnpartitionedMemoryIdx) TagDetails(orgId uint32, key string, filter *re
 
 	metaTagIdx := m.getOrgMetaTagIndex(orgId)
 
-	for value, recordIds := range metaTagIdx.tags.getTagValuesByRegex(key, filter) {
+	for value, recordIds := range metaTagIdx.hierarchy.getTagValuesByRegex(key, filter) {
 		for _, recordId := range recordIds {
 			record, ok := metaTagIdx.records.getMetaRecordById(recordId)
 			if !ok {
@@ -977,7 +977,7 @@ func (m *UnpartitionedMemoryIdx) FindTags(orgId uint32, prefix string, limit uin
 		return m.finalizeResult(res, limit, false)
 	}
 
-	metaTags := m.getOrgMetaTagIndex(orgId).tags.getTagsByPrefix(prefix)
+	metaTags := m.getOrgMetaTagIndex(orgId).hierarchy.getTagsByPrefix(prefix)
 	if len(metaTags) == 0 {
 		return m.finalizeResult(res, limit, false)
 	}
@@ -1091,7 +1091,7 @@ func (m *UnpartitionedMemoryIdx) FindTagValues(orgId uint32, tag, prefix string,
 		return m.finalizeResult(res, limit, false)
 	}
 
-	metaTagValues := metaTagIdx.tags.getTagValuesByTagAndPrefix(tag, prefix)
+	metaTagValues := metaTagIdx.hierarchy.getTagValuesByTagAndPrefix(tag, prefix)
 	if len(metaTagValues) == 0 {
 		return m.finalizeResult(res, limit, false)
 	}
@@ -1188,7 +1188,7 @@ func (m *UnpartitionedMemoryIdx) idsByTagQuery(orgId uint32, query tagquery.Quer
 	go func() {
 		if useMeta && MetaTagSupport {
 			metaTagIdx := m.getOrgMetaTagIndex(orgId)
-			queryCtx.Run(tags, m.defById, metaTagIdx.tags, metaTagIdx.records, idCh)
+			queryCtx.Run(tags, m.defById, metaTagIdx.hierarchy, metaTagIdx.records, idCh)
 		} else {
 			queryCtx.Run(tags, m.defById, nil, nil, idCh)
 		}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -897,6 +897,7 @@ func (m *UnpartitionedMemoryIdx) TagDetails(orgId uint32, key string, filter *re
 
 	tags, ok := m.tags[orgId]
 	if !ok {
+		m.RUnlock()
 		return nil
 	}
 

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -302,13 +302,17 @@ func getMetaTagEnrichers(t testing.TB, ix MemoryIndex) map[uint32][]*metaTagEnri
 	switch concrete := ix.(type) {
 	case *PartitionedMemoryIdx:
 		for _, unpartitionedIdx := range concrete.Partition {
-			for orgId, enricher := range unpartitionedIdx.metaTagEnricher {
-				res[orgId] = append(res[orgId], enricher)
+			if unpartitionedIdx.metaTagIdx != nil {
+				for orgId, metaTagIdx := range unpartitionedIdx.metaTagIdx.byOrg {
+					res[orgId] = append(res[orgId], metaTagIdx.enricher)
+				}
 			}
 		}
 	case *UnpartitionedMemoryIdx:
-		for orgId, enricher := range concrete.metaTagEnricher {
-			res[orgId] = append(res[orgId], enricher)
+		if concrete.metaTagIdx != nil {
+			for orgId, metaTagIdx := range concrete.metaTagIdx.byOrg {
+				res[orgId] = append(res[orgId], metaTagIdx.enricher)
+			}
 		}
 	default:
 		t.Fatalf("Invalid index object")
@@ -317,9 +321,8 @@ func getMetaTagEnrichers(t testing.TB, ix MemoryIndex) map[uint32][]*metaTagEnri
 	return res
 }
 
-// waitForMetaTagEnrichers obtains all enrichers in existence, across all orgs, and uses
-// their .wait() function to wait for each of them. this function blocks until the whole
-// enricher queue has been processed up to the point when it was called
+// waitForMetaTagEnrichers obtains all enrichers in existence, across all orgs.
+// it stops and starts them to make sure their whole event queue is processed.
 func waitForMetaTagEnrichers(t testing.TB, ix MemoryIndex) {
 	enrichersByOrg := getMetaTagEnrichers(t, ix)
 	for _, enrichers := range enrichersByOrg {
@@ -561,11 +564,11 @@ func testTagKeysWithMetaTagSupportWithoutFilters(t *testing.T) {
 	queryAndCompareTagKeys(t, "", expected)
 }
 
-func TestTagSorting(t *testing.T) {
-	withAndWithoutPartitonedIndex(testTagSorting)(t)
+func TestTagSortingInFindByTag(t *testing.T) {
+	withAndWithoutPartitonedIndex(testTagSortingInFindByTag)(t)
 }
 
-func testTagSorting(t *testing.T) {
+func testTagSortingInFindByTag(t *testing.T) {
 	index := New()
 	defer index.Stop()
 	index.Init()

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -31,6 +31,22 @@ func init() {
 	partitionCount = 2
 }
 
+func parseExpressionsMustCompile(t testing.TB, expressions []string) tagquery.Expressions {
+	res, err := tagquery.ParseExpressions(expressions)
+	if err != nil {
+		t.Fatalf("Unexpected error when parsing expressions %+v: %s", expressions, err)
+	}
+	return res
+}
+
+func parseQueryMustCompile(t testing.TB, expressions []string) tagquery.Query {
+	query, err := tagquery.NewQueryFromStrings(expressions, 0)
+	if err != nil {
+		t.Fatalf("Unexpected error when parsing query expressions: %s", err)
+	}
+	return query
+}
+
 func getPartition(md *schema.MetricData) int32 {
 	return getPartitionFromName(md.Name)
 }
@@ -1053,26 +1069,18 @@ func testSingleNodeMetric(t *testing.T) {
 	}
 	ix.AddOrUpdate(mkey, data, getPartition(data))
 }
+
 func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
 	ix := NewUnpartitionedMemoryIdx()
 
-	record1, err := tagquery.ParseMetaTagRecord([]string{"a=b", "c=d"}, []string{"name=~a.+", "__tag^=a"})
-	if err != nil {
-		t.Fatalf("Unexpected error when parsing meta tag record: %q", err)
-	}
-	record2, err := tagquery.ParseMetaTagRecord([]string{"e=f", "g=h"}, []string{"other=queries", "some!=value"})
-	if err != nil {
-		t.Fatalf("Unexpected error when parsing meta tag record: %q", err)
-	}
-	record3, err := tagquery.ParseMetaTagRecord([]string{"i=j", "k=l"}, []string{"other=queries", "some!=value"})
-	if err != nil {
-		t.Fatalf("Unexpected error when parsing meta tag record: %q", err)
-	}
+	record1 := parseMetaTagRecordMustCompile(t, []string{"a=b", "c=d"}, []string{"name=~a.+", "__tag^=a"})
+	record2 := parseMetaTagRecordMustCompile(t, []string{"e=f", "g=h"}, []string{"other=queries", "some!=value"})
+	record3 := parseMetaTagRecordMustCompile(t, []string{"i=j", "k=l"}, []string{"other=queries", "some!=value"})
 
-	err = ix.MetaTagRecordUpsert(1, record1)
+	err := ix.MetaTagRecordUpsert(1, record1)
 	if err != nil {
 		t.Fatalf("Unexpected error when upserting meta tag record: %q", err)
 	}
@@ -1107,18 +1115,17 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 		t.Fatalf("Expected MetaTagRecordList to return no records for org 2, but it has:\n%+v\n", metaTagRecords)
 	}
 
-	if len(ix.metaTagIndex[1]["a"]["b"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag a=b, but there were %d", len(ix.metaTagIndex[1]["a"]["b"]))
+	compareRecordCount := func(expression string, expectedRecordCount int) {
+		recordCount := len(ix.metaTagIdx.getOrgMetaTagIndex(1).tags.getByTagValue(parseExpressionsMustCompile(t, []string{expression})[0], false))
+		if recordCount != expectedRecordCount {
+			t.Fatalf("Expected that there are %d record(s) associated with expression %s, but there were %d", expectedRecordCount, expression, recordCount)
+		}
 	}
-	if len(ix.metaTagIndex[1]["c"]["d"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag c=d, but there were %d", len(ix.metaTagIndex[1]["c"]["d"]))
-	}
-	if len(ix.metaTagIndex[1]["e"]["f"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag e=f, but there were %d", len(ix.metaTagIndex[1]["e"]["f"]))
-	}
-	if len(ix.metaTagIndex[1]["g"]["h"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag g=h, but there were %d", len(ix.metaTagIndex[1]["g"]["h"]))
-	}
+
+	compareRecordCount("a=b", 1)
+	compareRecordCount("c=d", 1)
+	compareRecordCount("e=f", 1)
+	compareRecordCount("g=h", 1)
 
 	// record3 has the same queries as record2, so it should completely replace it
 	err = ix.MetaTagRecordUpsert(1, record3)
@@ -1133,24 +1140,12 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 		t.Fatalf("Expected MetaTagRecordList to return 2 records for org 1, but it has:\n%+v\n", metaTagRecords)
 	}
 
-	if len(ix.metaTagIndex[1]["a"]["b"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag a=b, but there were %d", len(ix.metaTagIndex[1]["a"]["b"]))
-	}
-	if len(ix.metaTagIndex[1]["c"]["d"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag c=d, but there were %d", len(ix.metaTagIndex[1]["c"]["d"]))
-	}
-	if len(ix.metaTagIndex[1]["e"]["f"]) != 0 {
-		t.Fatalf("Expected that there is 0 record associated with tag e=f, but there were %d", len(ix.metaTagIndex[1]["e"]["f"]))
-	}
-	if len(ix.metaTagIndex[1]["g"]["h"]) != 0 {
-		t.Fatalf("Expected that there is 0 record associated with tag g=h, but there were %d", len(ix.metaTagIndex[1]["g"]["h"]))
-	}
-	if len(ix.metaTagIndex[1]["i"]["j"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag i=j, but there were %d", len(ix.metaTagIndex[1]["i"]["j"]))
-	}
-	if len(ix.metaTagIndex[1]["k"]["l"]) != 1 {
-		t.Fatalf("Expected that there is 1 record associated with tag k=l, but there were %d", len(ix.metaTagIndex[1]["k"]["l"]))
-	}
+	compareRecordCount("a=b", 1)
+	compareRecordCount("c=d", 1)
+	compareRecordCount("e=f", 0)
+	compareRecordCount("g=h", 0)
+	compareRecordCount("i=j", 1)
+	compareRecordCount("k=l", 1)
 }
 
 func TestMetricNameStartingWithTilde(t *testing.T) {

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -1116,7 +1116,7 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 	}
 
 	compareRecordCount := func(expression string, expectedRecordCount int) {
-		recordCount := len(ix.metaTagIdx.getOrgMetaTagIndex(1).tags.getByTagValue(parseExpressionsMustCompile(t, []string{expression})[0], false))
+		recordCount := len(ix.metaTagIdx.getOrgMetaTagIndex(1).hierarchy.getByTagValue(parseExpressionsMustCompile(t, []string{expression})[0], false))
 		if recordCount != expectedRecordCount {
 			t.Fatalf("Expected that there are %d record(s) associated with expression %s, but there were %d", expectedRecordCount, expression, recordCount)
 		}

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -510,9 +510,9 @@ func (e *metaTagEnricher) countMetricsWithMetaTags() int {
 
 // index structure keyed by tag -> value -> list of meta record IDs
 type metaTagValue map[string][]recordId
-type metaTagIndex map[string]metaTagValue
+type metaTagHierarchy map[string]metaTagValue
 
-func (m metaTagIndex) deleteRecord(keyValue tagquery.Tag, id recordId) {
+func (m metaTagHierarchy) deleteRecord(keyValue tagquery.Tag, id recordId) {
 	if ids, ok := m[keyValue.Key][keyValue.Value]; ok {
 		for i := 0; i < len(ids); i++ {
 			if ids[i] == id {
@@ -531,7 +531,7 @@ func (m metaTagIndex) deleteRecord(keyValue tagquery.Tag, id recordId) {
 	}
 }
 
-func (m metaTagIndex) insertRecord(keyValue tagquery.Tag, id recordId) {
+func (m metaTagHierarchy) insertRecord(keyValue tagquery.Tag, id recordId) {
 	var values metaTagValue
 	var ok bool
 
@@ -550,14 +550,14 @@ func (m metaTagIndex) insertRecord(keyValue tagquery.Tag, id recordId) {
 // because less meta records will need to be checked against a given MetricDefinition.
 // The caller, after receiving the result set, needs to be aware of whether the result set
 // is inverted and interpret it accordingly.
-func (m metaTagIndex) getMetaRecordIdsByExpression(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
+func (m metaTagHierarchy) getMetaRecordIdsByExpression(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
 	if expr.OperatesOnTag() {
 		return m.getByTag(expr, invertSetOfMetaRecords)
 	}
 	return m.getByTagValue(expr, invertSetOfMetaRecords)
 }
 
-func (m metaTagIndex) getByTag(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
+func (m metaTagHierarchy) getByTag(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
 	var res []recordId
 
 	for key := range m {
@@ -580,7 +580,7 @@ func (m metaTagIndex) getByTag(expr tagquery.Expression, invertSetOfMetaRecords 
 	return res
 }
 
-func (m metaTagIndex) getByTagValue(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
+func (m metaTagHierarchy) getByTagValue(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
 	if expr.MatchesExactly() {
 		return m[expr.GetKey()][expr.GetValue()]
 	}

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -2,6 +2,8 @@ package memory
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -46,12 +48,251 @@ var (
 	metaRecordSwapPruned = stats.NewCounter32("idx.memory.meta-tags.swap.ops.meta-records-pruned")
 )
 
+type metaTagIdx struct {
+	sync.RWMutex
+	byOrg    map[uint32]*orgMetaTagIdx
+	idLookup func(uint32, tagquery.Query, func(chan schema.MKey))
+}
+
+func newMetaTagIndex(idLookup func(uint32, tagquery.Query, func(chan schema.MKey))) *metaTagIdx {
+	return &metaTagIdx{
+		byOrg:    make(map[uint32]*orgMetaTagIdx),
+		idLookup: idLookup,
+	}
+}
+
+func (m *metaTagIdx) stop() {
+	m.Lock()
+	for _, idx := range m.byOrg {
+		idx.enricher.stop()
+	}
+	m.byOrg = make(map[uint32]*orgMetaTagIdx)
+	m.Unlock()
+}
+
+func (m *metaTagIdx) getOrgMetaTagIndex(orgId uint32) *orgMetaTagIdx {
+	m.RLock()
+	idx := m.byOrg[orgId]
+	m.RUnlock()
+	if idx != nil {
+		return idx
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	idx = m.byOrg[orgId]
+	if idx != nil {
+		return idx
+	}
+
+	idLookup := func(query tagquery.Query, callback func(chan schema.MKey)) {
+		m.idLookup(orgId, query, callback)
+	}
+	idx = newOrgMetaTagIndex(idLookup)
+
+	m.byOrg[orgId] = idx
+
+	return idx
+}
+
+type orgMetaTagIdx struct {
+	// swapMutex is only used to ensure that no two upsert/swap operations run concurrently
+	swapMutex sync.Mutex
+
+	tags     *metaTagHierarchy
+	records  *metaTagRecords
+	enricher *metaTagEnricher
+}
+
+type idLookup func(tagquery.Query, func(chan schema.MKey))
+
+func newOrgMetaTagIndex(idLookup idLookup) *orgMetaTagIdx {
+	return &orgMetaTagIdx{
+		tags:     newMetaTagHierarchy(),
+		records:  newMetaTagRecords(),
+		enricher: newEnricher(idLookup),
+	}
+}
+
+func (m *orgMetaTagIdx) getMetaTagsById(id schema.Key) tagquery.Tags {
+	return m.records.getMetaTagsByRecordIds(m.enricher.enrich(id))
+}
+
+// MetaTagRecordUpsert inserts or updates a meta record, depending on whether
+// it already exists or is new. The identity of a record is determined by its
+// queries, if the set of queries in the given record already exists in another
+// record, then the existing record will be updated, otherwise a new one gets
+// created.
+func (m *metaTagIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.MetaTagRecord) error {
+	if !TagSupport || !MetaTagSupport {
+		log.Warn("memory-idx: received tag/meta-tag query, but that feature is disabled")
+		return errors.NewBadRequest("Tag/Meta-Tag support is disabled")
+	}
+
+	// expressions need to be sorted because the unique ID of a meta record is
+	// its sorted set of expressions
+	upsertRecord.Expressions.Sort()
+
+	// initialize query in preparation to execute it once we have the swapMutex
+	// doing struct instantiations before acquiring lock to keep mutex time short
+	query, err := tagquery.NewQuery(upsertRecord.Expressions, 0)
+	if err != nil {
+		return fmt.Errorf("Invalid record with expressions/meta tags: %q/%q", upsertRecord.Expressions, upsertRecord.MetaTags)
+	}
+
+	idx := m.getOrgMetaTagIndex(orgId)
+
+	idx.swapMutex.Lock()
+	defer idx.swapMutex.Unlock()
+
+	id, oldId, oldRecord, err := idx.records.upsert(upsertRecord)
+	if err != nil {
+		return err
+	}
+
+	// check if the upsert has replaced a previously existing record
+	if oldId > 0 {
+		// if so we remove all references to it from the enricher
+		// and from the meta tag index
+		idx.enricher.delMetaRecord(oldId)
+		idx.tags.deleteRecord(oldRecord.MetaTags, oldId)
+	}
+
+	// add the newly inserted meta record into the enricher and the
+	// meta tag index
+	idx.enricher.addMetaRecord(id, query)
+	idx.tags.insertRecord(upsertRecord.MetaTags, id)
+
+	return nil
+}
+
+func (m *metaTagIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaTagRecord) error {
+	if !TagSupport || !MetaTagSupport {
+		log.Warn("memory-idx: received a tag/meta-tag query, but that feature is disabled")
+		return errors.NewBadRequest("Tag/Meta-Tag support is disabled")
+	}
+
+	metaRecordSwapExecuting.Inc()
+
+	log.Infof("memory-idx: Initiating Swap with %d records for org %d", len(newRecords), orgId)
+
+	// recordIdsToKeep contains the records that should not
+	// get pruned at the end of this swap
+	recordIdsToKeep := make(map[recordId]struct{}, len(newRecords))
+	var recordsToUpsert uint32
+
+	idx := m.getOrgMetaTagIndex(orgId)
+	idx.swapMutex.Lock()
+	defer idx.swapMutex.Unlock()
+
+	for i := range newRecords {
+		newRecords[i].Expressions.Sort()
+		newRecords[i].MetaTags.Sort()
+	}
+
+	recordComparison := idx.records.compareRecords(newRecords)
+	for _, status := range recordComparison {
+		if status.recordExists && status.isEqual {
+			recordIdsToKeep[status.currentId] = struct{}{}
+			continue
+		}
+		recordsToUpsert++
+	}
+
+	log.Infof("memory-idx: After diff against existing meta records for org %d, going to upsert %d, %d remain unchanged", orgId, recordsToUpsert, len(recordIdsToKeep))
+	recordsUnchanged := uint32(len(recordIdsToKeep))
+
+	var query tagquery.Query
+	var recordsModified, recordsAdded, recordsPruned uint32
+	for i, status := range recordComparison {
+		if status.recordExists && status.isEqual {
+			//  record does not need any modification
+			continue
+		}
+
+		if status.recordExists {
+			// record exists, but its meta tags need to be updated,
+			// we first delete it and then re-add it
+			recordsModified++
+			idx.enricher.delMetaRecord(status.currentId)
+			idx.tags.deleteRecord(status.currentMetaTags, status.currentId)
+		} else {
+			// record does not exist, so it will be added
+			recordsAdded++
+		}
+
+		newRecordId, _, _, err := idx.records.upsert(newRecords[i])
+		if err != nil {
+			log.Errorf("Error when upserting meta record (%q/%q): %s", newRecords[i].Expressions.Strings(), newRecords[i].MetaTags.Strings(), err.Error())
+			continue
+		}
+
+		query, err = tagquery.NewQuery(newRecords[i].Expressions, 0)
+		if err != nil {
+			log.Errorf("Invalid record (%q/%q): %s", newRecords[i].Expressions.Strings(), newRecords[i].MetaTags.Strings(), err)
+			continue
+		}
+		idx.enricher.addMetaRecord(newRecordId, query)
+		idx.tags.insertRecord(newRecords[i].MetaTags, newRecordId)
+
+		// adding the new record id to recordIdsToKeep to prevent that
+		// it gets pruned further down
+		recordIdsToKeep[newRecordId] = struct{}{}
+	}
+
+	// if the number of meta tag records is equal to the number of record
+	// ids to keep, and we've already ensured that the meta tag records are
+	// all up2date, then there's nothing to prune
+	if idx.records.length() != len(recordIdsToKeep) {
+		var pruned map[recordId]tagquery.MetaTagRecord
+		toPrune := idx.records.getPrunable(recordIdsToKeep)
+		if len(toPrune) > 0 {
+			log.Infof("memory-idx: Going to prune %d meta records for org %d", len(toPrune), orgId)
+			recordsPruned = uint32(len(toPrune))
+
+			// we can assume that the toPrune list is still correct because we're
+			// holding the metaRecordLock
+			pruned = make(map[recordId]tagquery.MetaTagRecord, len(toPrune))
+			idx.records.prune(toPrune, pruned)
+		}
+
+		// remove all references to the pruned meta records from the meta
+		// tag index and the enricher
+		for recordId, record := range pruned {
+			idx.enricher.delMetaRecord(recordId)
+			idx.tags.deleteRecord(record.MetaTags, recordId)
+		}
+	}
+
+	metaRecordSwapUnchanged.AddUint32(recordsUnchanged)
+	metaRecordSwapAdded.AddUint32(recordsAdded)
+	metaRecordSwapModified.AddUint32(recordsModified)
+	metaRecordSwapPruned.AddUint32(recordsPruned)
+
+	return nil
+}
+
+func (m *metaTagIdx) MetaTagRecordList(orgId uint32) []tagquery.MetaTagRecord {
+	if !TagSupport || !MetaTagSupport {
+		log.Warn("memory-idx: received a tag/meta-tag query, but that feature is disabled")
+		return nil
+	}
+
+	metaTagIdx := m.getOrgMetaTagIndex(orgId)
+	if metaTagIdx == nil {
+		return nil
+	}
+
+	return metaTagIdx.records.listRecords()
+}
+
 type recordId uint32
 
 // list of meta records keyed by a unique identifier used as ID
 type metaTagRecords struct {
-	metaRecordLock sync.Mutex // used to ensure that we never run multiple swap operations concurrently
-	records        map[recordId]tagquery.MetaTagRecord
+	sync.RWMutex
+	records map[recordId]tagquery.MetaTagRecord
 }
 
 func newMetaTagRecords() *metaTagRecords {
@@ -61,10 +302,16 @@ func newMetaTagRecords() *metaTagRecords {
 }
 
 func (m *metaTagRecords) length() int {
+	m.RLock()
+	defer m.RUnlock()
+
 	return len(m.records)
 }
 
 func (m *metaTagRecords) prune(toPrune map[recordId]struct{}, pruned map[recordId]tagquery.MetaTagRecord) {
+	m.Lock()
+	defer m.Unlock()
+
 	for recordId := range toPrune {
 		pruned[recordId] = m.records[recordId]
 		delete(m.records, recordId)
@@ -72,6 +319,9 @@ func (m *metaTagRecords) prune(toPrune map[recordId]struct{}, pruned map[recordI
 }
 
 func (m *metaTagRecords) getPrunable(toKeep map[recordId]struct{}) map[recordId]struct{} {
+	m.RLock()
+	defer m.RUnlock()
+
 	toPrune := make(map[recordId]struct{}, len(m.records)-len(toKeep))
 	for recordId := range m.records {
 		if _, ok := toKeep[recordId]; !ok {
@@ -81,27 +331,31 @@ func (m *metaTagRecords) getPrunable(toKeep map[recordId]struct{}) map[recordId]
 	return toPrune
 }
 
-func (m *metaTagRecords) getMetaTagsByRecordId(recordId recordId) tagquery.Tags {
-	return m.records[recordId].MetaTags
+func (m *metaTagRecords) getMetaRecordById(recordId recordId) (tagquery.MetaTagRecord, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	record, ok := m.records[recordId]
+	return record, ok
 }
 
 func (m *metaTagRecords) getMetaTagsByRecordIds(recordIds map[recordId]struct{}) tagquery.Tags {
+	m.RLock()
+	defer m.RUnlock()
 	res := make(tagquery.Tags, 0, len(recordIds))
 	for recordId := range recordIds {
-		record, ok := m.records[recordId]
-		if ok {
-			res = append(res, record.MetaTags...)
-		}
+		res = append(res, m.records[recordId].MetaTags...)
 	}
+
 	return res
 }
 
 // recordExists takes a meta record and checks if it exists
 // the identity of a record is determined by its set of query expressions, so if there is
 // any other record with the same query expressions this method returns the id, the record,
-// and true. if it doesn't exist the third return value is false. it is assumed that the
-// expressions of the given record are sorted.
-func (m *metaTagRecords) recordExists(record tagquery.MetaTagRecord) (recordId, *tagquery.MetaTagRecord, bool) {
+// and true. if it doesn't exist the third return value is false.
+// it assumes that the expressions of the given record are sorted.
+// it assumes that a read lock has already been acquired.
+func (m *metaTagRecords) recordExists(record tagquery.MetaTagRecord) (recordId, tagquery.MetaTagRecord, bool) {
 	id := recordId(record.HashExpressions())
 
 	// loop over existing records, starting from id, trying to find one that has
@@ -110,12 +364,12 @@ func (m *metaTagRecords) recordExists(record tagquery.MetaTagRecord) (recordId, 
 		checkingId := id + recordId(i)
 		if existingRecord, ok := m.records[checkingId]; ok {
 			if record.Expressions.Equal(existingRecord.Expressions) {
-				return checkingId, &existingRecord, true
+				return checkingId, existingRecord, true
 			}
 		}
 	}
 
-	return 0, nil, false
+	return 0, tagquery.MetaTagRecord{}, false
 }
 
 // recordExistsAndIsEqual checks if the given record exists
@@ -133,6 +387,46 @@ func (m *metaTagRecords) recordExistsAndIsEqual(record tagquery.MetaTagRecord) (
 	return id, true, record.MetaTags.Equal(existingRecord.MetaTags)
 }
 
+func (m *metaTagRecords) compareRecords(records []tagquery.MetaTagRecord) []struct {
+	currentId       recordId
+	currentMetaTags tagquery.Tags
+	recordExists    bool
+	isEqual         bool
+} {
+	res := make([]struct {
+		currentId       recordId
+		currentMetaTags tagquery.Tags
+		recordExists    bool
+		isEqual         bool
+	}, len(records))
+
+	m.RLock()
+	defer m.RUnlock()
+
+	for i := range records {
+		id, exists, equal := m.recordExistsAndIsEqual(records[i])
+		res[i].currentId = id
+		res[i].currentMetaTags = m.records[id].MetaTags
+		res[i].recordExists = exists
+		res[i].isEqual = equal
+	}
+
+	return res
+}
+
+func (m *metaTagRecords) listRecords() []tagquery.MetaTagRecord {
+	m.RLock()
+	defer m.RUnlock()
+
+	res := make([]tagquery.MetaTagRecord, len(m.records))
+	var i uint32
+	for _, record := range m.records {
+		res[i] = record
+		i++
+	}
+	return res
+}
+
 // upsert inserts or updates a meta tag record according to the given specifications
 // it uses the set of tag query expressions as the identity of the record, if a record with the
 // same identity is already present then its meta tags get updated to the specified ones.
@@ -143,7 +437,10 @@ func (m *metaTagRecords) recordExistsAndIsEqual(record tagquery.MetaTagRecord) (
 // 3) The id of the record that has been replaced if an update was performed
 // 4) Pointer to the metaTagRecord that has been replaced if an update was performed, otherwise nil
 // 5) Error if an error occurred, otherwise it's nil
-func (m *metaTagRecords) upsert(record tagquery.MetaTagRecord) (recordId, *tagquery.MetaTagRecord, recordId, *tagquery.MetaTagRecord, error) {
+func (m *metaTagRecords) upsert(record tagquery.MetaTagRecord) (recordId, recordId, tagquery.MetaTagRecord, error) {
+	m.Lock()
+	defer m.Unlock()
+
 	record.Expressions.Sort()
 
 	oldId, oldRecord, exists := m.recordExists(record)
@@ -152,7 +449,7 @@ func (m *metaTagRecords) upsert(record tagquery.MetaTagRecord) (recordId, *tagqu
 	}
 
 	if !record.HasMetaTags() {
-		return 0, &record, oldId, oldRecord, nil
+		return 0, oldId, oldRecord, nil
 	}
 
 	record.MetaTags.Sort()
@@ -164,13 +461,13 @@ func (m *metaTagRecords) upsert(record tagquery.MetaTagRecord) (recordId, *tagqu
 		if _, ok := m.records[id]; !ok {
 			m.records[id] = record
 
-			return id, &record, oldId, oldRecord, nil
+			return id, oldId, oldRecord, nil
 		}
 
 		id++
 	}
 
-	return 0, nil, 0, nil, errors.NewInternal("Could not find a free ID to insert record")
+	return 0, 0, tagquery.MetaTagRecord{}, errors.NewInternal("Could not find a free ID to insert record")
 }
 
 // metaTagEnricher is responsible for "enriching" metrics resulting from a query by
@@ -200,6 +497,8 @@ type metaTagEnricher struct {
 	addMetricBuffer []schema.MetricDefinition
 	// pool of idx.Archive structs that we use when processing add metric events
 	archivePool sync.Pool
+
+	idLookup idLookup
 }
 
 type enricherEventType uint8
@@ -218,13 +517,14 @@ type enricherEvent struct {
 	payload   interface{}
 }
 
-func newEnricher() *metaTagEnricher {
+func newEnricher(idLookup idLookup) *metaTagEnricher {
 	res := &metaTagEnricher{
 		queriesByRecord: make(map[recordId]tagquery.Query),
 		recordsByMetric: make(map[schema.Key]map[recordId]struct{}),
 		archivePool: sync.Pool{
 			New: func() interface{} { return &idx.Archive{} },
 		},
+		idLookup: idLookup,
 	}
 
 	res.start()
@@ -416,79 +716,85 @@ func (e *metaTagEnricher) _delMetric(payload interface{}) {
 	enricherMetricsWithMetaRecords.SetUint32(uint32(len(e.recordsByMetric)))
 }
 
-func (e *metaTagEnricher) addMetaRecord(id recordId, query tagquery.Query, keys []schema.Key) {
-	e.eventQueue <- enricherEvent{
-		eventType: addMetaRecord,
-		payload: struct {
-			id    recordId
-			query tagquery.Query
-			keys  []schema.Key
-		}{id: id, query: query, keys: keys},
+func (e *metaTagEnricher) addMetaRecord(id recordId, query tagquery.Query) {
+	handleResultCh := func(idCh chan schema.MKey) {
+		e.eventQueue <- enricherEvent{
+			eventType: addMetaRecord,
+			payload: struct {
+				recordId recordId
+				query    tagquery.Query
+				idCh     chan schema.MKey
+			}{recordId: id, query: query, idCh: idCh},
+		}
 	}
+
+	e.idLookup(query, handleResultCh)
 }
 
 func (e *metaTagEnricher) _addMetaRecord(payload interface{}) {
 	data := payload.(struct {
-		id    recordId
-		query tagquery.Query
-		keys  []schema.Key
+		recordId recordId
+		query    tagquery.Query
+		idCh     chan schema.MKey
 	})
 
-	e.Lock()
-	e.queriesByRecord[data.id] = data.query
-	e.Unlock()
-	enricherKnownMetaRecords.SetUint32(uint32(len(e.queriesByRecord)))
+	var added uint32
 
-	for _, key := range data.keys {
-		// we acquire one write lock per iteration, instead of one for the whole loop,
-		// because the performance of addMetaRecord operations is less important than
-		// the enrich() calls which are used by the query processing
-		e.Lock()
-		if _, ok := e.recordsByMetric[key]; ok {
-			e.recordsByMetric[key][data.id] = struct{}{}
-			e.Unlock()
-			continue
+	e.Lock()
+	for id := range data.idCh {
+		if _, ok := e.recordsByMetric[id.Key]; ok {
+			e.recordsByMetric[id.Key][data.recordId] = struct{}{}
+		} else {
+			e.recordsByMetric[id.Key] = map[recordId]struct{}{
+				data.recordId: {},
+			}
 		}
-		e.recordsByMetric[key] = map[recordId]struct{}{data.id: {}}
-		e.Unlock()
+		added++
 	}
+	e.queriesByRecord[data.recordId] = data.query
+	e.Unlock()
 
 	enricherMetricsWithMetaRecords.SetUint32(uint32(len(e.recordsByMetric)))
-	enricherMetricsAddedByQuery.Add(len(data.keys))
+	enricherMetricsAddedByQuery.AddUint32(added)
 }
 
-func (e *metaTagEnricher) delMetaRecord(id recordId, keys []schema.Key) {
-	e.eventQueue <- enricherEvent{
-		eventType: delMetaRecord,
-		payload: struct {
-			id   recordId
-			keys []schema.Key
-		}{id: id, keys: keys},
+func (e *metaTagEnricher) delMetaRecord(id recordId) {
+	e.RLock()
+	query := e.queriesByRecord[id]
+	e.RUnlock()
+
+	handleResultCh := func(idCh chan schema.MKey) {
+		e.eventQueue <- enricherEvent{
+			eventType: delMetaRecord,
+			payload: struct {
+				recordId recordId
+				idCh     chan schema.MKey
+			}{recordId: id, idCh: idCh},
+		}
 	}
+
+	e.idLookup(query, handleResultCh)
 }
 
 func (e *metaTagEnricher) _delMetaRecord(payload interface{}) {
 	data := payload.(struct {
-		id   recordId
-		keys []schema.Key
+		recordId recordId
+		idCh     chan schema.MKey
 	})
 
-	// before deleting the meta record from the e.queriesByRecord map we
-	// delete all references to it from the recordsByMetric map
-	for _, key := range data.keys {
-		e.Lock()
-		delete(e.recordsByMetric[key], data.id)
-		if len(e.recordsByMetric[key]) == 0 {
-			delete(e.recordsByMetric, key)
+	e.Lock()
+	for id := range data.idCh {
+		delete(e.recordsByMetric[id.Key], data.recordId)
+		if len(e.recordsByMetric[id.Key]) == 0 {
+			delete(e.recordsByMetric, id.Key)
 		}
-		e.Unlock()
 	}
-	enricherMetricsWithMetaRecords.SetUint32(uint32(len(e.recordsByMetric)))
+	e.Unlock()
 
 	e.Lock()
-	delete(e.queriesByRecord, data.id)
-	e.Unlock()
+	delete(e.queriesByRecord, data.recordId)
 	enricherKnownMetaRecords.SetUint32(uint32(len(e.queriesByRecord)))
+	e.Unlock()
 }
 
 // enrich resolves a metric key into the associated set of record ids,
@@ -510,37 +816,54 @@ func (e *metaTagEnricher) countMetricsWithMetaTags() int {
 
 // index structure keyed by tag -> value -> list of meta record IDs
 type metaTagValue map[string][]recordId
-type metaTagHierarchy map[string]metaTagValue
+type metaTagKeys map[string]metaTagValue
+type metaTagHierarchy struct {
+	sync.RWMutex
+	tags metaTagKeys
+}
 
-func (m metaTagHierarchy) deleteRecord(keyValue tagquery.Tag, id recordId) {
-	if ids, ok := m[keyValue.Key][keyValue.Value]; ok {
-		for i := 0; i < len(ids); i++ {
-			if ids[i] == id {
-				// no need to keep the order
-				ids[i] = ids[len(ids)-1]
-				m[keyValue.Key][keyValue.Value] = ids[:len(ids)-1]
-				break
+func newMetaTagHierarchy() *metaTagHierarchy {
+	return &metaTagHierarchy{tags: make(metaTagKeys)}
+}
+
+func (m *metaTagHierarchy) deleteRecord(tags tagquery.Tags, id recordId) {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, tag := range tags {
+		if ids, ok := m.tags[tag.Key][tag.Value]; ok {
+			for i := 0; i < len(ids); i++ {
+				if ids[i] == id {
+					// no need to keep the order
+					ids[i] = ids[len(ids)-1]
+					m.tags[tag.Key][tag.Value] = ids[:len(ids)-1]
+					break
+				}
 			}
-		}
-		if len(m[keyValue.Key][keyValue.Value]) == 0 {
-			delete(m[keyValue.Key], keyValue.Value)
-			if len(m[keyValue.Key]) == 0 {
-				delete(m, keyValue.Key)
+			if len(m.tags[tag.Key][tag.Value]) == 0 {
+				delete(m.tags[tag.Key], tag.Value)
+				if len(m.tags[tag.Key]) == 0 {
+					delete(m.tags, tag.Key)
+				}
 			}
 		}
 	}
 }
 
-func (m metaTagHierarchy) insertRecord(keyValue tagquery.Tag, id recordId) {
+func (m *metaTagHierarchy) insertRecord(tags tagquery.Tags, id recordId) {
+	m.Lock()
+	defer m.Unlock()
+
 	var values metaTagValue
 	var ok bool
 
-	if values, ok = m[keyValue.Key]; !ok {
-		values = make(metaTagValue)
-		m[keyValue.Key] = values
+	for _, tag := range tags {
+		if values, ok = m.tags[tag.Key]; !ok {
+			values = make(metaTagValue)
+			m.tags[tag.Key] = values
+		}
+		values[tag.Value] = append(values[tag.Value], id)
 	}
-
-	values[keyValue.Value] = append(values[keyValue.Value], id)
 }
 
 // getMetaRecordIdsByExpression takes an expression and a bool, it returns all meta record
@@ -550,18 +873,29 @@ func (m metaTagHierarchy) insertRecord(keyValue tagquery.Tag, id recordId) {
 // because less meta records will need to be checked against a given MetricDefinition.
 // The caller, after receiving the result set, needs to be aware of whether the result set
 // is inverted and interpret it accordingly.
-func (m metaTagHierarchy) getMetaRecordIdsByExpression(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
+func (m *metaTagHierarchy) getMetaRecordIdsByExpression(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
 	if expr.OperatesOnTag() {
 		return m.getByTag(expr, invertSetOfMetaRecords)
 	}
 	return m.getByTagValue(expr, invertSetOfMetaRecords)
 }
 
-func (m metaTagHierarchy) getByTag(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
+func (m *metaTagHierarchy) getByTag(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
 	var res []recordId
 
-	for key := range m {
+	m.RLock()
+	defer m.RUnlock()
 
+	// optimization for simple "=" expressions
+	if !invertSetOfMetaRecords && expr.MatchesExactly() {
+		for _, records := range m.tags[expr.GetKey()] {
+			res = append(res, records...)
+		}
+
+		return res
+	}
+
+	for key := range m.tags {
 		if invertSetOfMetaRecords {
 			if expr.Matches(key) {
 				continue
@@ -572,7 +906,7 @@ func (m metaTagHierarchy) getByTag(expr tagquery.Expression, invertSetOfMetaReco
 			}
 		}
 
-		for _, ids := range m[key] {
+		for _, ids := range m.tags[key] {
 			res = append(res, ids...)
 		}
 	}
@@ -581,12 +915,16 @@ func (m metaTagHierarchy) getByTag(expr tagquery.Expression, invertSetOfMetaReco
 }
 
 func (m metaTagHierarchy) getByTagValue(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
-	if expr.MatchesExactly() {
-		return m[expr.GetKey()][expr.GetValue()]
+	m.RLock()
+	defer m.RUnlock()
+
+	// optimization for simple "=" expressions
+	if !invertSetOfMetaRecords && expr.MatchesExactly() {
+		return m.tags[expr.GetKey()][expr.GetValue()]
 	}
 
 	var res []recordId
-	for value, ids := range m[expr.GetKey()] {
+	for value, ids := range m.tags[expr.GetKey()] {
 		passes := expr.Matches(value)
 
 		if invertSetOfMetaRecords {
@@ -598,6 +936,70 @@ func (m metaTagHierarchy) getByTagValue(expr tagquery.Expression, invertSetOfMet
 		}
 
 		res = append(res, ids...)
+	}
+
+	return res
+}
+
+func (m *metaTagHierarchy) getTagValuesByRegex(key string, filter *regexp.Regexp) map[string][]recordId {
+	res := make(map[string][]recordId)
+
+	m.RLock()
+	defer m.RUnlock()
+
+	for value, recordIds := range m.tags[key] {
+		if filter != nil && !filter.MatchString(value) {
+			continue
+		}
+
+		res[value] = recordIds
+	}
+
+	return res
+}
+
+func (m *metaTagHierarchy) getTagsByPrefix(prefix string) []string {
+	var res []string
+
+	m.RLock()
+	defer m.RUnlock()
+
+	for tag := range m.tags {
+		if len(prefix) > 0 && !strings.HasPrefix(tag, prefix) {
+			continue
+		}
+		res = append(res, tag)
+	}
+
+	return res
+}
+func (m *metaTagHierarchy) getTagsByFilter(filter *regexp.Regexp) []string {
+	var res []string
+
+	m.RLock()
+	defer m.RUnlock()
+
+	for tag := range m.tags {
+		if filter != nil && !filter.MatchString(tag) {
+			continue
+		}
+		res = append(res, tag)
+	}
+
+	return res
+}
+
+func (m *metaTagHierarchy) getTagValuesByTagAndPrefix(tag, prefix string) []string {
+	var res []string
+
+	m.RLock()
+	defer m.RUnlock()
+
+	for value := range m.tags[tag] {
+		if len(prefix) > 0 && !strings.HasPrefix(value, prefix) {
+			continue
+		}
+		res = append(res, value)
 	}
 
 	return res

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -881,7 +881,7 @@ func (m *metaTagHierarchy) getMetaRecordIdsByExpression(expr tagquery.Expression
 }
 
 func (m *metaTagHierarchy) getByTag(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
-	var res []recordId
+	recordSet := make(map[recordId]struct{})
 
 	m.RLock()
 	defer m.RUnlock()
@@ -889,32 +889,43 @@ func (m *metaTagHierarchy) getByTag(expr tagquery.Expression, invertSetOfMetaRec
 	// optimization for simple "=" expressions
 	if !invertSetOfMetaRecords && expr.MatchesExactly() {
 		for _, records := range m.tags[expr.GetKey()] {
-			res = append(res, records...)
+			for _, record := range records {
+				recordSet[record] = struct{}{}
+			}
 		}
+	} else {
+		for key := range m.tags {
+			if invertSetOfMetaRecords {
+				if expr.Matches(key) {
+					continue
+				}
+			} else {
+				if !expr.Matches(key) {
+					continue
+				}
+			}
 
-		return res
+			for _, records := range m.tags[key] {
+				for _, record := range records {
+					recordSet[record] = struct{}{}
+				}
+			}
+		}
 	}
 
-	for key := range m.tags {
-		if invertSetOfMetaRecords {
-			if expr.Matches(key) {
-				continue
-			}
-		} else {
-			if !expr.Matches(key) {
-				continue
-			}
-		}
-
-		for _, ids := range m.tags[key] {
-			res = append(res, ids...)
-		}
+	res := make([]recordId, len(recordSet))
+	i := 0
+	for record := range recordSet {
+		res[i] = record
+		i++
 	}
 
 	return res
 }
 
-func (m metaTagHierarchy) getByTagValue(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
+func (m *metaTagHierarchy) getByTagValue(expr tagquery.Expression, invertSetOfMetaRecords bool) []recordId {
+	recordSet := make(map[recordId]struct{})
+
 	m.RLock()
 	defer m.RUnlock()
 
@@ -923,8 +934,7 @@ func (m metaTagHierarchy) getByTagValue(expr tagquery.Expression, invertSetOfMet
 		return m.tags[expr.GetKey()][expr.GetValue()]
 	}
 
-	var res []recordId
-	for value, ids := range m.tags[expr.GetKey()] {
+	for value, records := range m.tags[expr.GetKey()] {
 		passes := expr.Matches(value)
 
 		if invertSetOfMetaRecords {
@@ -935,12 +945,20 @@ func (m metaTagHierarchy) getByTagValue(expr tagquery.Expression, invertSetOfMet
 			continue
 		}
 
-		res = append(res, ids...)
+		for _, record := range records {
+			recordSet[record] = struct{}{}
+		}
+	}
+
+	res := make([]recordId, len(recordSet))
+	i := 0
+	for record := range recordSet {
+		res[i] = record
+		i++
 	}
 
 	return res
 }
-
 func (m *metaTagHierarchy) getTagValuesByRegex(key string, filter *regexp.Regexp) map[string][]recordId {
 	res := make(map[string][]recordId)
 

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -379,6 +379,8 @@ func TestMetaTagRecordSwap(t *testing.T) {
 	if len(mti.tags["meta1"]) != 1 {
 		t.Fatalf("Expected metaTagIndex to have 1 value for tag \"meta1\", but id had %d", len(mti.tags["meta1"]))
 	}
+
+	waitForMetaTagEnrichers(t, idx)
 }
 
 func BenchmarkMetaTagEnricher(b *testing.B) {

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -323,7 +323,7 @@ func TestMetaTagRecordSwap(t *testing.T) {
 	idx, _ := getTestIndexWithMetaTags(t, []tagquery.MetaTagRecord{record1, record2}, 3, nil)
 	orgIdx := idx.getOrgMetaTagIndex(1)
 	mtr := orgIdx.records
-	mti := orgIdx.tags
+	mti := orgIdx.hierarchy
 
 	record1Id, exists, equal := mtr.recordExistsAndIsEqual(record1)
 	if !(exists && equal) {

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -749,6 +749,7 @@ func benchmarkFindByMetaTag(b *testing.B, indexSize, metaRecordCount, expectedRe
 	var res []idx.Node
 
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		res = index.FindByTag(1, queries[i%len(queries)])
 		if len(res) != expectedResCount {

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -300,7 +300,7 @@ func TestDeletingMetaRecord(t *testing.T) {
 }
 
 func TestAddingMetricsToEmptyEnricher(t *testing.T) {
-	var mockLookup func(tagquery.Query, chan schema.MKey, bool)
+	var mockLookup func(tagquery.Query, chan schema.MKey)
 	enricher := newEnricher(mockLookup)
 
 	mds := []schema.MetricDefinition{
@@ -348,7 +348,7 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 
 	// mocks a lookup function which would execute the given query on the tag index
 	// and then call the callback to pass it a channel of resulting metric ids
-	mockLookup := func(query tagquery.Query, resCh chan schema.MKey, _ bool) {
+	mockLookup := func(query tagquery.Query, resCh chan schema.MKey) {
 
 		switch query.Expressions[0].GetValue() {
 		case "everyEven":

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -300,7 +300,7 @@ func TestDeletingMetaRecord(t *testing.T) {
 }
 
 func TestAddingMetricsToEmptyEnricher(t *testing.T) {
-	var mockLookup func(tagquery.Query, func(chan schema.MKey))
+	var mockLookup func(tagquery.Query, chan schema.MKey, bool)
 	enricher := newEnricher(mockLookup)
 
 	mds := []schema.MetricDefinition{
@@ -348,9 +348,7 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 
 	// mocks a lookup function which would execute the given query on the tag index
 	// and then call the callback to pass it a channel of resulting metric ids
-	mockLookup := func(query tagquery.Query, callback func(chan schema.MKey)) {
-		resCh := make(chan schema.MKey)
-		callback(resCh)
+	mockLookup := func(query tagquery.Query, resCh chan schema.MKey, _ bool) {
 
 		switch query.Expressions[0].GetValue() {
 		case "everyEven":

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -529,28 +529,6 @@ func (p *PartitionedMemoryIdx) add(archive *idx.Archive) {
 	p.Partition[archive.Partition].add(archive)
 }
 
-func (p *PartitionedMemoryIdx) idsByTagQuery(orgId uint32, query TagQueryContext) chan schema.MKey {
-	g, _ := errgroup.WithContext(context.Background())
-	resCh := make(chan schema.MKey, 100)
-	for _, m := range p.Partition {
-		m := m
-		g.Go(func() error {
-			partitionCh := m.idsByTagQuery(orgId, query)
-			for id := range partitionCh {
-				resCh <- id
-			}
-			return nil
-		})
-	}
-
-	go func() {
-		g.Wait()
-		close(resCh)
-	}()
-
-	return resCh
-}
-
 func (p *PartitionedMemoryIdx) MetaTagRecordList(orgId uint32) []tagquery.MetaTagRecord {
 	for _, m := range p.Partition {
 		// all partitions should have all meta records

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -25,7 +25,7 @@ type TagQueryContext struct {
 
 	index          TagIndex                     // the tag index, hierarchy of tags & values, set by Run()/RunGetTags()
 	byId           map[schema.MKey]*idx.Archive // the metric index by ID, set by Run()/RunGetTags()
-	metaTagIndex   metaTagIndex                 // the meta tag index
+	metaTagIndex   metaTagHierarchy             // the meta tag index
 	metaTagRecords *metaTagRecords              // meta tag records keyed by their recordID
 	startWith      int                          // the expression index to start with
 	subQuery       bool                         // true if this is a subquery created from the expressions of a meta tag record
@@ -183,7 +183,7 @@ func (q *TagQueryContext) filterIdsFromChan(idCh, resCh chan schema.MKey) {
 // mtr:         the meta tag records
 // resCh:       a chan of schema.MKey into which the result set will be pushed
 //              this channel gets closed when the query execution is complete
-func (q *TagQueryContext) RunNonBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagIndex, mtr *metaTagRecords, resCh chan schema.MKey) {
+func (q *TagQueryContext) RunNonBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
 	q.run(index, byId, mti, mtr, resCh)
 
 	go func() {
@@ -195,14 +195,14 @@ func (q *TagQueryContext) RunNonBlocking(index TagIndex, byId map[schema.MKey]*i
 // RunBlocking is very similar to RunNonBlocking, but there are two notable differences:
 // 1) It only returns once the query execution is complete
 // 2) It does not close the resCh which has been passed to it on completion
-func (q *TagQueryContext) RunBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagIndex, mtr *metaTagRecords, resCh chan schema.MKey) {
+func (q *TagQueryContext) RunBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
 	q.run(index, byId, mti, mtr, resCh)
 
 	q.wg.Wait()
 }
 
 // run implements the common parts of RunNonBlocking and RunBlocking
-func (q *TagQueryContext) run(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagIndex, mtr *metaTagRecords, resCh chan schema.MKey) {
+func (q *TagQueryContext) run(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
 	q.index = index
 	q.byId = byId
 	q.metaTagIndex = mti

--- a/idx/memory/tag_query.go
+++ b/idx/memory/tag_query.go
@@ -25,7 +25,7 @@ type TagQueryContext struct {
 
 	index          TagIndex                     // the tag index, hierarchy of tags & values, set by Run()/RunGetTags()
 	byId           map[schema.MKey]*idx.Archive // the metric index by ID, set by Run()/RunGetTags()
-	metaTagIndex   metaTagHierarchy             // the meta tag index
+	metaTagIndex   *metaTagHierarchy            // the meta tag index
 	metaTagRecords *metaTagRecords              // meta tag records keyed by their recordID
 	startWith      int                          // the expression index to start with
 	subQuery       bool                         // true if this is a subquery created from the expressions of a meta tag record
@@ -71,16 +71,18 @@ func (q *TagQueryContext) evaluateExpressionCosts() []expressionCost {
 			if expr.MatchesExactly() {
 				costs[i].operatorCost = expr.GetOperatorCost()
 				costs[i].cardinality = uint32(len(q.index[expr.GetKey()]))
-				_, costs[i].metaTag = q.metaTagIndex[expr.GetKey()]
+				if q.metaTagIndex != nil {
+					_, costs[i].metaTag = q.metaTagIndex.tags[expr.GetKey()]
+				}
 			} else {
 				costs[i].operatorCost = expr.GetOperatorCost()
 				costs[i].cardinality = uint32(len(q.index))
 
-				// if MetaTagIndex is disabled q.metaTagIndex is nil,
-				// so this will not loop at all
-				for tag := range q.metaTagIndex {
-					if expr.Matches(tag) {
-						costs[i].metaTag = true
+				if q.metaTagIndex != nil {
+					for tag := range q.metaTagIndex.tags {
+						if expr.Matches(tag) {
+							costs[i].metaTag = true
+						}
 					}
 				}
 			}
@@ -88,11 +90,15 @@ func (q *TagQueryContext) evaluateExpressionCosts() []expressionCost {
 			if expr.MatchesExactly() {
 				costs[i].operatorCost = expr.GetOperatorCost()
 				costs[i].cardinality = uint32(len(q.index[expr.GetKey()][expr.GetValue()]))
-				_, costs[i].metaTag = q.metaTagIndex[expr.GetKey()][expr.GetValue()]
+				if q.metaTagIndex != nil {
+					_, costs[i].metaTag = q.metaTagIndex.tags[expr.GetKey()][expr.GetValue()]
+				}
 			} else {
 				costs[i].operatorCost = expr.GetOperatorCost()
 				costs[i].cardinality = uint32(len(q.index[expr.GetKey()]))
-				_, costs[i].metaTag = q.metaTagIndex[expr.GetKey()]
+				if q.metaTagIndex != nil {
+					_, costs[i].metaTag = q.metaTagIndex.tags[expr.GetKey()]
+				}
 			}
 		}
 	}
@@ -183,7 +189,7 @@ func (q *TagQueryContext) filterIdsFromChan(idCh, resCh chan schema.MKey) {
 // mtr:         the meta tag records
 // resCh:       a chan of schema.MKey into which the result set will be pushed
 //              this channel gets closed when the query execution is complete
-func (q *TagQueryContext) RunNonBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
+func (q *TagQueryContext) RunNonBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti *metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
 	q.run(index, byId, mti, mtr, resCh)
 
 	go func() {
@@ -195,14 +201,14 @@ func (q *TagQueryContext) RunNonBlocking(index TagIndex, byId map[schema.MKey]*i
 // RunBlocking is very similar to RunNonBlocking, but there are two notable differences:
 // 1) It only returns once the query execution is complete
 // 2) It does not close the resCh which has been passed to it on completion
-func (q *TagQueryContext) RunBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
+func (q *TagQueryContext) RunBlocking(index TagIndex, byId map[schema.MKey]*idx.Archive, mti *metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
 	q.run(index, byId, mti, mtr, resCh)
 
 	q.wg.Wait()
 }
 
 // run implements the common parts of RunNonBlocking and RunBlocking
-func (q *TagQueryContext) run(index TagIndex, byId map[schema.MKey]*idx.Archive, mti metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
+func (q *TagQueryContext) run(index TagIndex, byId map[schema.MKey]*idx.Archive, mti *metaTagHierarchy, mtr *metaTagRecords, resCh chan schema.MKey) {
 	q.index = index
 	q.byId = byId
 	q.metaTagIndex = mti

--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -93,7 +93,7 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 		singleExprPerRecord := true
 		records := make([]tagquery.MetaTagRecord, 0, len(metaRecordIds))
 		for _, id := range metaRecordIds {
-			record, ok := ctx.metaTagRecords.records[id]
+			record, ok := ctx.metaTagRecords.getMetaRecordById(id)
 			if !ok {
 				corruptIndex.Inc()
 				log.Errorf("TagQueryContext: Tried to lookup a meta tag record id that does not exist, index is corrupted")

--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -49,8 +49,6 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 		filters: make([]expressionFilter, len(expressions)),
 	}
 
-	useMetaTags := MetaTagSupport && ctx.metaTagIndex != nil && ctx.metaTagRecords != nil
-
 	for i, expr := range expressions {
 		res.filters[i] = expressionFilter{
 			expr:             expr,
@@ -58,7 +56,7 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 			defaultDecision:  expr.GetDefaultDecision(),
 		}
 
-		if !useMetaTags {
+		if !ctx.useMetaTagIndex() {
 			continue
 		}
 

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -25,15 +25,22 @@ func filterAndCompareResults(t *testing.T, expressions tagquery.Expressions, met
 		index.MetaTagRecordUpsert(1, metaRecords[i])
 	}
 
-	enricher := index.getMetaTagEnricher(1, true)
-	enricher.stop()
-	enricher.start()
+	waitForMetaTagEnrichers(t, index)
+	var ctx *TagQueryContext
+	if index.metaTagIdx != nil {
+		metaTagIdx := index.getOrgMetaTagIndex(1)
 
-	ctx := &TagQueryContext{
-		index:          index.tags[1],
-		byId:           index.defById,
-		metaTagIndex:   index.metaTagIndex[1],
-		metaTagRecords: index.metaTagRecords[1],
+		ctx = &TagQueryContext{
+			index:          index.tags[1],
+			byId:           index.defById,
+			metaTagIndex:   metaTagIdx.tags,
+			metaTagRecords: metaTagIdx.records,
+		}
+	} else {
+		ctx = &TagQueryContext{
+			index: index.tags[1],
+			byId:  index.defById,
+		}
 	}
 
 	filter := newIdFilter(expressions, ctx)

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -33,7 +33,7 @@ func filterAndCompareResults(t *testing.T, expressions tagquery.Expressions, met
 		ctx = &TagQueryContext{
 			index:          index.tags[1],
 			byId:           index.defById,
-			metaTagIndex:   metaTagIdx.tags,
+			metaTagIndex:   metaTagIdx.hierarchy,
 			metaTagRecords: metaTagIdx.records,
 		}
 	} else {

--- a/idx/memory/tag_query_id_selector.go
+++ b/idx/memory/tag_query_id_selector.go
@@ -53,7 +53,7 @@ func (i *idSelector) getIds(resCh chan schema.MKey, stopCh chan struct{}) {
 	// if meta tag support is enabled and we create subqueries out of looked up meta
 	// records, then its possible that we will end up with duplicate results. to
 	// prevent this we spawn a separate worker process which deduplicates them
-	deduplicateResults := MetaTagSupport && !i.ctx.subQuery
+	deduplicateResults := i.useMetaTagIndex()
 
 	var dedupWg sync.WaitGroup
 	if deduplicateResults {
@@ -72,6 +72,13 @@ func (i *idSelector) getIds(resCh chan schema.MKey, stopCh chan struct{}) {
 
 	i.workerWg.Wait()
 	dedupWg.Wait()
+}
+
+func (i *idSelector) useMetaTagIndex() bool {
+	// if this is a sub query we want to ignore the meta tag index,
+	// otherwise we'd risk to create a loop of sub queries creating
+	// each other
+	return MetaTagSupport && !i.ctx.subQuery && i.ctx.metaTagIndex != nil && i.ctx.metaTagRecords != nil
 }
 
 // deduplicateRawResults reads the channel i.rawResCh and deduplicates all the ids
@@ -104,11 +111,7 @@ func (i *idSelector) deduplicateRawResults(dedupWg *sync.WaitGroup, resCh chan s
 func (i *idSelector) byTagValue() {
 	go i.byTagValueFromMetricTagIndex()
 
-	// if this is a sub query we want to ignore the meta tag index,
-	// otherwise we'd risk to create a loop of sub queries creating
-	// each other
-	// same when meta tag support is disabled in the config
-	if !MetaTagSupport || i.ctx.subQuery {
+	if !i.useMetaTagIndex() {
 		i.workerWg.Done()
 		return
 	}
@@ -170,34 +173,13 @@ func (i *idSelector) byTagValueFromMetricTagIndex() {
 func (i *idSelector) byTagValueFromMetaTagIndex() {
 	defer i.workerWg.Done()
 
-	// if expression matches value exactly we can directly look up the ids by it as key.
-	// this is faster than having to call expr.Matches on each value
-	if i.expr.MatchesExactly() {
-		for _, metaRecordId := range i.ctx.metaTagIndex[i.expr.GetKey()][i.expr.GetValue()] {
-			select {
-			case <-i.stopCh:
-				return
-			default:
-			}
-			i.evaluateMetaRecord(metaRecordId)
-		}
-		return
-	}
-
-	for value, records := range i.ctx.metaTagIndex[i.expr.GetKey()] {
+	for _, recordId := range i.ctx.metaTagIndex.getByTagValue(i.expr, false) {
 		select {
 		case <-i.stopCh:
 			return
 		default:
 		}
-
-		if !i.expr.Matches(value) {
-			continue
-		}
-
-		for _, metaRecordId := range records {
-			i.evaluateMetaRecord(metaRecordId)
-		}
+		i.evaluateMetaRecord(recordId)
 	}
 }
 
@@ -207,11 +189,7 @@ func (i *idSelector) byTagValueFromMetaTagIndex() {
 func (i *idSelector) byTag() {
 	go i.byTagFromMetricTagIndex()
 
-	// if this is a sub query we want to ignore the meta tag index,
-	// otherwise we'd risk to create a loop of sub queries creating
-	// each other
-	// same when meta tag support is disabled in the config
-	if !MetaTagSupport || i.ctx.subQuery {
+	if !i.useMetaTagIndex() {
 		i.workerWg.Done()
 		return
 	}
@@ -272,40 +250,27 @@ func (i *idSelector) byTagFromMetricTagIndex() {
 func (i *idSelector) byTagFromMetaTagIndex() {
 	defer i.workerWg.Done()
 
-	if i.expr.MatchesExactly() {
-		for _, records := range i.ctx.metaTagIndex[i.expr.GetKey()] {
-			for _, metaRecordId := range records {
-				i.evaluateMetaRecord(metaRecordId)
-			}
+	for _, recordId := range i.ctx.metaTagIndex.getByTag(i.expr, false) {
+		select {
+		case <-i.stopCh:
+			return
+		default:
 		}
-
-		return
-	}
-
-	for tag := range i.ctx.metaTagIndex {
-		if !i.expr.Matches(tag) {
-			continue
-		}
-
-		for _, records := range i.ctx.metaTagIndex[tag] {
-			for _, metaRecordId := range records {
-				i.evaluateMetaRecord(metaRecordId)
-			}
-		}
+		i.evaluateMetaRecord(recordId)
 	}
 }
 
 // evaluateMetaRecord takes a meta record id, it then looks up the corresponding
 // meta record, builds a sub query from its expressions and executes the sub query
 func (i *idSelector) evaluateMetaRecord(id recordId) {
-	record, ok := i.ctx.metaTagRecords.records[id]
+	record, ok := i.ctx.metaTagRecords.getMetaRecordById(id)
 	if !ok {
-		corruptIndex.Inc()
 		return
 	}
 
 	query, err := i.subQueryFromExpressions(record.Expressions)
 	if err != nil {
+		corruptIndex.Inc()
 		return
 	}
 

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -55,7 +55,7 @@ func selectAndCompareResults(t *testing.T, expression tagquery.Expression, metaR
 		ctx = &TagQueryContext{
 			index:          index.tags[1],
 			byId:           index.defById,
-			metaTagIndex:   metaTagIdx.tags,
+			metaTagIndex:   metaTagIdx.hierarchy,
 			metaTagRecords: metaTagIdx.records,
 		}
 	} else {

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -47,15 +47,22 @@ func selectAndCompareResults(t *testing.T, expression tagquery.Expression, metaR
 		index.MetaTagRecordUpsert(1, metaRecords[i])
 	}
 
-	enricher := index.getMetaTagEnricher(1, true)
-	enricher.stop()
-	enricher.start()
+	waitForMetaTagEnrichers(t, index)
+	var ctx *TagQueryContext
+	if index.metaTagIdx != nil {
+		metaTagIdx := index.getOrgMetaTagIndex(1)
 
-	ctx := &TagQueryContext{
-		index:          index.tags[1],
-		byId:           index.defById,
-		metaTagIndex:   index.metaTagIndex[1],
-		metaTagRecords: index.metaTagRecords[1],
+		ctx = &TagQueryContext{
+			index:          index.tags[1],
+			byId:           index.defById,
+			metaTagIndex:   metaTagIdx.tags,
+			metaTagRecords: metaTagIdx.records,
+		}
+	} else {
+		ctx = &TagQueryContext{
+			index: index.tags[1],
+			byId:  index.defById,
+		}
 	}
 
 	resCh := make(chan schema.MKey)

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -601,12 +601,12 @@ func testGetByTag(t *testing.T) {
 // resulting order is as expected.
 func TestExpressionSortingByCost(t *testing.T) {
 	query, err := tagquery.NewQueryFromStrings([]string{
-		"a=~b", // meta tag             expected to be 6.
-		"c!=d", // metric tag           expected to be 2.
-		"e!=f", // meta tag             expected to be 5.
-		"g=h",  // metric tag           expected to be 1.
-		"i=~j", // metric tag           expected to be 3.
-		"k=l",  // metric and meta tag  expected to be 4.
+		"a=~b", // meta tag
+		"c!=d", // metric tag
+		"e!=f", // meta tag
+		"g=h",  // metric tag
+		"i=~j", // metric tag
+		"k=l",  // metric and meta tag
 	}, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when instantiating query: %s", err)
@@ -639,7 +639,16 @@ func TestExpressionSortingByCost(t *testing.T) {
 	expectedIdxPositions := []int{3, 1, 4, 5, 2, 0}
 	for i, expectedIdxPosition := range expectedIdxPositions {
 		if costs[i].expressionIdx != expectedIdxPosition {
-			t.Fatalf("Order of expressions is not as expected\nExpected:\n%+v\nGot:\n%+v\n", expectedIdxPositions, costs[i].expressionIdx)
+			t.Fatalf("Order of expressions is not as expected with Meta Tag Support\nExpected:\n%+v\nGot:\n%+v\n", expectedIdxPositions[i], costs[i].expressionIdx)
+		}
+	}
+
+	MetaTagSupport = false
+	costs = queryCtx.evaluateExpressionCosts()
+	expectedIdxPositions = []int{3, 5, 2, 1, 0, 4}
+	for i, expectedIdxPosition := range expectedIdxPositions {
+		if costs[i].expressionIdx != expectedIdxPosition {
+			t.Fatalf("Order of expressions is not as expected without Meta Tag Support\nExpected:\n%+v\nGot:\n%+v\n", expectedIdxPositions[i], costs[i].expressionIdx)
 		}
 	}
 }

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -608,10 +608,12 @@ func TestExpressionSortingByCost(t *testing.T) {
 		"i": {"j": {}},
 		"k": {"l": {}},
 	}
-	queryCtx.metaTagIndex = metaTagHierarchy{
-		"a": {"b": {}},
-		"e": {"f": {}},
-		"k": {"l": {}},
+	queryCtx.metaTagIndex = &metaTagHierarchy{
+		tags: metaTagKeys{
+			"a": metaTagValue{"b": {}},
+			"e": metaTagValue{"f": {}},
+			"k": metaTagValue{"l": {}},
+		},
 	}
 
 	costs := queryCtx.evaluateExpressionCosts()

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -608,7 +608,7 @@ func TestExpressionSortingByCost(t *testing.T) {
 		"i": {"j": {}},
 		"k": {"l": {}},
 	}
-	queryCtx.metaTagIndex = metaTagIndex{
+	queryCtx.metaTagIndex = metaTagHierarchy{
 		"a": {"b": {}},
 		"e": {"f": {}},
 		"k": {"l": {}},


### PR DESCRIPTION
Related to the issue https://github.com/grafana/metrictank/issues/1539

This splits the main index lock up by introducing 3 new RW locks. 
1) Used to protect a new data structure called `metaTagIdx` which manages the meta tag data structures on a per org basis. This write lock only needs to be acquired when a new org starts using the meta tag index, so very rarely.  `metaTagIdx` also implements all the exported index methods related to the meta tag index, it is embedded into the main index.
2) The data structure `metaTagIndex` has been renamed to `metaTagHierarchy` to prevent confusion with the main meta tag index struct, and it has it's own RW lock now. It also has a few new accessor methods, because previously some of it's properties were directly accessed by other methods of the index package, but now all interactions go through the new accessors to make sure the lock is used correctly.
3) The data structure `metaTagRecords` also has its own RW lock now, and a few other methods which previously accessed its properties directly are now using its accessor methods to ensure correct locking.

The method `idsByTagQuery` had to be refactored because when we add/delete meta records from the enricher we need to be able to execute a query on the tag index and pass the result into the enricher without releasing the read lock on the main index in-between, otherwise there would be a race condition. So the enricher now has a callback using which it can call `idsByTagQuery` on the main index. When executing such queries we now instantiate the result chan into which the query results will get pushed, pass it into `idsByTagQuery` which acquires the read lock on the main index and starts the query execution in a new routine, then we push the result chan into the enricher's event queue, and only release the read lock on the main index once the query has completed. The enricher's event handler then only needs to consume that result chan. That way we can still ensure consistency in the enricher.