### PR TITLE
add filter to only load latest metricDef from bt idx

### DIFF
--- a/idx/bigtable/bigtable.go
+++ b/idx/bigtable/bigtable.go
@@ -348,7 +348,7 @@ func (b *BigtableIdx) LoadPartition(partition int32, defs []schema.MetricDefinit
 		nameWithTags := def.NameWithTags()
 		defsByNames[nameWithTags] = append(defsByNames[nameWithTags], def)
 		return true
-	}, bigtable.RowFilter(bigtable.FamilyFilter(COLUMN_FAMILY)))
+	}, bigtable.RowFilter(bigtable.ChainFilters(bigtable.FamilyFilter(COLUMN_FAMILY), bigtable.LatestNFilter(1))))
 	if err != nil {
 		log.Fatalf("bigtable-idx: failed to load defs from Bigtable. %s", err)
 	}


### PR DESCRIPTION
this ensures that when we load metric definitions from the big table index we only load each cell's latest version, as opposed to loading any version that has been stored since the last bt compaction, using the `LatestNFilter()` (https://godoc.org/cloud.google.com/go/bigtable#LatestNFilter)

Fixes: #1563 