### PR TITLE
Sync docs with website repo

### DIFF
--- a/.github/actions/gha-publish-to-git/Dockerfile
+++ b/.github/actions/gha-publish-to-git/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+RUN apk update
+RUN apk add rsync git bash
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/.github/actions/gha-publish-to-git/LICENSE
+++ b/.github/actions/gha-publish-to-git/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Sean Middleditch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/gha-publish-to-git/README.md
+++ b/.github/actions/gha-publish-to-git/README.md
@@ -1,0 +1,60 @@
+publish-to-git
+==============
+
+[GitHub Action](https://github.com/features/actions) for publishing a directory
+and its contents to another git repository.
+
+This can be especially useful for publishing static website, such as with
+[GitHub Pages](https://pages.github.com/), from built files in other job
+steps, such as [Doxygen](http://www.doxygen.nl/) generated HTML files.
+
+**NOTE**: GitHub currently requires the use of a Personal Access Token for
+pushing to other repositories. Pushing to the current repository should work
+with the always-available GitHub Token (available via
+`{{ secrets.GITHUB_TOKEN }}`. If pushing to another repository, a Personal
+Access Token will need to be [created](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) and assigned to the
+workflow [secrets](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables).
+
+Inputs
+------
+
+- `repository`: Destination repository (default: current repository).
+- `branch`: Destination branch (required).
+- `host`: Destination git host (default: `github.com`).
+- `github_token`: GitHub Token (required; use `secrets.GITHUB_TOKEN`).
+- `github_pat`: Personal Access Token or other https credentials.
+- `source_folder`: Source folder in workspace to copy (default: workspace root).
+- `target_folder`: Target folder in destination branch to copy to (default: repository root).
+- `commit_author`: Override commit author (default: `{github.actor}@users.noreply.github.com`).
+- `commit_message`: Set commit message (default: `[workflow] Publish from [repository]:[branch]/[folder]`).
+- `dry_run`: Does not push if non-empty (default: empty).
+- `working_directory`: Location to checkout repository (default: random location in `${HOME}`)
+
+Outputs
+-------
+
+- `commit_hash`: SHA hash of the new commit.
+- `working_directory`: Working directory of git clone of repository.
+
+License
+-------
+
+MIT License. See [LICENSE](LICENSE) for details.
+
+Usage Example
+-------------
+
+```yaml
+jobs:
+  publish:
+    - uses: actions/checkout@master
+    - run: |
+        sh scripts/build-doxygen-html.sh --out static/html
+    - uses: seanmiddleditch/gha-publish-to-git@master
+      with:
+        branch: gh-pages
+        github_token: '${{ secrets.GITHUB_TOKEN  }}'
+        github_pat: '${{ secrets.GH_PAT }}'
+        source_folder: static/html
+      if: success() && github.event == 'push'
+```

--- a/.github/actions/gha-publish-to-git/action.yml
+++ b/.github/actions/gha-publish-to-git/action.yml
@@ -1,0 +1,60 @@
+---
+name: publish-to-git
+description: 'Publish files to a git repository'
+branding:
+  icon: 'git-commit'
+  color: 'blue'
+inputs:
+  repository:
+    description: 'Destination repository (default: current repository)'
+    default: ''
+  branch:
+    description: 'Destination branch'
+    required: true
+  host:
+    description: 'Destination git host'
+    default: 'github.com'
+  github_token:
+    description: 'GitHub Token (use `secrets.GITHUB_TOKEN`)'
+    required: true
+  github_pat:
+    description: 'Personal Access Token or other https credentials'
+    default: ''
+  source_folder:
+    description: 'Source folder in workspace to copy (default: workspace root)'
+    defaault: ''
+  target_folder:
+    description: 'Target folder in destination branch to copy to (default: repository root)'
+    default: ''
+  commit_author:
+    description: 'User Name <email@address> (default: [github.actor]@users.noreply.github.com)'
+    default: ''
+  commit_message:
+    description: 'Commit message (default: [workflow] Publish from [repository]:[branch]/[folder])'
+    default: ''
+  dry_run:
+    description: 'Do not push to repository (set to non-empty string to make dry-run)'
+    default: ''
+  working_directory:
+    description: 'Working directory for clone (default: random location in `${HOME}`)'
+    default: ''
+outputs:
+  commit_hash:
+    description: 'Hash of the new commit'
+  working_directory:
+    description: 'Working directory of temporary repository'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.repository }}
+    - ${{ inputs.branch }}
+    - ${{ inputs.host }}
+    - ${{ inputs.github_token }}
+    - ${{ inputs.github_pat }}
+    - ${{ inputs.source_folder }}
+    - ${{ inputs.target_folder }}
+    - ${{ inputs.commit_author }}
+    - ${{ inputs.commit_message }}
+    - ${{ inputs.dry_run }}
+    - ${{ inputs.working_directory }}

--- a/.github/actions/gha-publish-to-git/entrypoint.sh
+++ b/.github/actions/gha-publish-to-git/entrypoint.sh
@@ -1,0 +1,99 @@
+#/bin/bash
+
+# Name the Docker inputs.
+#
+INPUT_REPOSITORY="$1"
+INPUT_BRANCH="$2"
+INPUT_HOST="$3"
+INPUT_GITHUB_TOKEN="$4"
+INPUT_GITHUB_PAT="$5"
+INPUT_SOURCE_FOLDER="$6"
+INPUT_TARGET_FOLDER="$7"
+INPUT_COMMIT_AUTHOR="$8"
+INPUT_COMMIT_MESSAGE="$9"
+INPUT_DRYRUN="${10}"
+INPUT_WORKDIR="${11}"
+
+# Check for required inputs.
+#
+[ -z "$INPUT_BRANCH" ] && echo >&2 "::error::'branch' is required" && exit 1
+[ -z "$INPUT_GITHUB_TOKEN" -a -z "$INPUT_GITHUB_PAT" ] && echo >&2 "::error::'github_token' or 'github_pat' is required" && exit 1
+
+# Set state from inputs or defaults.
+#
+REPOSITORY="${INPUT_REPOSITORY:-${GITHUB_REPOSITORY}}"
+BRANCH="${INPUT_BRANCH}"
+HOST="${INPUT_GIT_HOST:-github.com}"
+TOKEN="${INPUT_GITHUB_PAT:-${INPUT_GITHUB_TOKEN}}"
+REMOTE="${INPUT_REMOTE:-https://${TOKEN}@${HOST}/${REPOSITORY}.git}"
+
+SOURCE_FOLDER="${INPUT_SOURCE_FOLDER:-.}"
+TARGET_FOLDER="${INPUT_TARGET_FOLDER}"
+
+REF="${GITHUB_BASE_REF:-${GITHUB_REF}}"
+REF_BRANCH=$(echo "${REF}" | rev | cut -d/ -f1 | rev)
+[ -z "$REF_BRANCH" ] && echo 2>&1 "No ref branch" && exit 1
+
+COMMIT_AUTHOR="${INPUT_AUTHOR:-${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>}"
+COMMIT_MESSAGE="${INPUT_COMMIT_MESSAGE:-[${GITHUB_WORKFLOW}] Publish from ${GITHUB_REPOSITORY}:${REF_BRANCH}/${SOURCE_FOLDER}}"
+
+# Calculate the real source path.
+#
+SOURCE_PATH="$(realpath "${SOURCE_FOLDER}")"
+[ -z "${SOURCE_PATH}" ] && exit 1
+echo "::debug::SOURCE_PATH=${SOURCE_PATH}"
+
+# Let's start doing stuff.
+echo "Publishing ${SOURCE_FOLDER} to ${REMOTE}:${BRANCH}/${TARGET_FOLDER}"
+
+# Create a working directory; the workspace may be filled with other important
+# files.
+#
+WORK_DIR="${INPUT_WORKDIR:-$(mktemp -d "${HOME}/gitrepo.XXXXXX")}"
+[ -z "${WORK_DIR}" ] && echo >&2 "::error::Failed to create temporary working directory" && exit 1
+cd "${WORK_DIR}"
+
+# Initialize git repo and configure for remote access.
+#
+echo "Initializing repository with remote ${REMOTE}"
+git init || exit 1
+git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com" || exit 1
+git config --local user.name  "${GITHUB_ACTOR}" || exit 1
+git remote add origin "${REMOTE}" || exit 1
+git remote -v
+
+# Fetch initial (current contents).
+#
+echo "Fetching ${REMOTE}:${BRANCH}"
+git fetch --depth 1 origin "${BRANCH}" || exit 1
+git checkout -b "${BRANCH}" || exit 1
+git pull origin "${BRANCH}" || exit 1
+
+# Create the target directory (if necessary) and copy files from source.
+#
+TARGET_PATH="${WORK_DIR}/${TARGET_FOLDER}"
+echo "Populating ${TARGET_PATH}"
+mkdir -p "${TARGET_PATH}" || exit 1
+rsync -a --quiet --delete "${SOURCE_PATH}/" "${TARGET_PATH}" || exit 1
+
+# Create commit with changes.
+#
+echo "Creating commit"
+git add "${TARGET_PATH}" || exit 1
+git commit -m "${COMMIT_MESSAGE}" --author "${COMMIT_AUTHOR}" || exit 1
+COMMIT_HASH="$(git rev-parse HEAD)"
+echo "Created commit ${COMMIT_HASH}"
+
+# Publish output variables.
+#
+echo "::set-output name=commit_hash::${COMMIT_HASH}"
+echo "::set-output name=working_directory::${WORK_DIR}"
+
+# Push if not a dry-run.
+#
+if [ -z "${INPUT_DRYRUN}" ] ; then
+    echo "Pushing to ${REMOTE}:${BRANCH}"
+    git push origin "${BRANCH}" || exit 1
+else
+    echo "[DRY-RUN] Not pushing to ${REMOTE}:${BRANCH}"
+fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: publish_docs
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'docs/sources/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: publish-to-git
+      uses: ./.github/actions/gha-publish-to-git
+      id: publish
+      with:
+        repository: grafana/website
+        branch: docs-hosted-metrics-api
+        host: github.com
+        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
+        source_folder: docs/sources
+        target_folder: content/docs/hosted-metrics-api/latest
+    - shell: bash
+      run: |
+        test -n "${{ steps.publish.outputs.commit_hash }}"
+        test -n "${{ steps.publish.outputs.working_directory }}"

--- a/docs/cloud/_index.md
+++ b/docs/cloud/_index.md
@@ -1,0 +1,13 @@
+---
+title: Grafana Cloud Graphite
+header: false
+---
+
+# Hosted Metrics - Graphite
+
+Grafana Labs' Hosted metrics Graphite service offers a graphite-compatible monitoring backend as a service.
+It acts and behaves as a regular graphite datasource within Grafana (or other tools), but behind the scenes, it is a sophisticated platform run by a team of dedicated engineers.
+
+* [data ingestion]({{< relref "data-ingestion" >}})
+* [http api]({{< relref "http-api" >}})
+* [faq]({{< relref "faq" >}})

--- a/docs/cloud/data-ingestion.md
+++ b/docs/cloud/data-ingestion.md
@@ -1,0 +1,23 @@
+---
+title: Data Ingestion
+weight: 1
+---
+
+# Data Ingestion
+
+We support:
+
+* [carbon-relay-ng](https://github.com/graphite-ng/carbon-relay-ng), which is a graphite carbon relay, which supports aggregations and sending data to our endpoint over a secure, robust transport.
+* custom tools that use our API. See our [golang, python and shell examples](https://github.com/grafana/hosted-metrics-sender-example)
+* direct carbon input. This is discouraged though, as it is not reliable over the internet and not secure.
+
+The recommended and most popular option is using carbon-relay-ng.
+Customers typically deploy using either of these 2 options:
+
+* run the relay as an extra component external to your existing graphite pipeline. Data can be directed to it from any existing carbon relay.
+* replace an existing carbon-relay with carbon-relay-ng
+
+If your Graphite stack does not currently contain any relay, then you can simply add carbon-relay-ng, have your clients (statsd, collectd, diamond, etc) send data to the relay, which in turn can send data to your existing graphite server *and* to our platform.
+
+When creating a Hosted Metrics Graphite instance, we provide a carbon-relay-ng config file that you can plug in and be ready to use out of the box.
+We also have Grafana Labs engineers ready to advise further on set up, if needed.

--- a/docs/cloud/faq.md
+++ b/docs/cloud/faq.md
@@ -1,0 +1,32 @@
+---
+title: FAQ
+weight: 3
+---
+# FAQ
+
+### Can I use tags?
+
+Yes, our platform supports graphite tags as well as [meta tags](https://grafana.com/blog/2019/04/09/metrictank-meta-tags/), allowing to add extra metadata tags your series.
+
+### Can I import my existing data?
+
+You can import pre-existing data into the hosted platform, from either a Graphite or metrictank installation.
+We either provide you with the tools and instructions, or if provided access, we offer this service for a hands-off experience.
+Grafana dashboards can also be imported if you choose to use a hosted Grafana instance.
+
+### How do I send data to the service?
+
+See [data ingestion]({{< relref "data-ingestion" >}}).
+
+### How does this compare to stock graphite?
+
+The hosted platform is built on top of [metrictank](/oss/metrictank) and [graphite](/oss/graphite)
+Important differences with stock Graphite to be aware of:
+
+* support for meta tags
+* the platform is optimized for append-only workloads. While historical data can be imported, we generally don't support out of order writes.
+* timeseries can change resolution (interval) over time, they will be merged automatically.
+
+## Do I have to use hosted grafana or exclusively the hosted platform?
+
+No, the hosted platform is a datasource that you can use however you like. E.g. in combination with other datasources, and queried from any Grafana instance or other client.

--- a/docs/cloud/http-api.md
+++ b/docs/cloud/http-api.md
@@ -1,40 +1,9 @@
 ---
-title: Hosted Metrics - Graphite
-header: false
+title: HTTP API
+weight: 2
 ---
 
-# Hosted Metrics - Graphite
-
-Grafana Labs' Hosted metrics Graphite service offers a graphite-compatible monitoring backend as a service.
-It acts and behaves as a regular graphite datasource within Grafana (or other tools), but behind the scenes, it is a sophisticated platform run by a team of dedicated engineers.
-
-* [data ingestion](#data-ingestion)
-* [http api](#http-api)
-* [faq](#faq)
-
----
-
-## Data Ingestion
-
-We support:
-* [carbon-relay-ng](https://github.com/graphite-ng/carbon-relay-ng), which is a graphite carbon relay, which supports aggregations and sending data to our endpoint over a secure, robust transport.
-* custom tools that use our API. See our [golang, python and shell examples](https://github.com/grafana/hosted-metrics-sender-example)
-* direct carbon input. This is discouraged though, as it is not reliable over the internet and not secure.
-
-The recommended and most popular option is using carbon-relay-ng.
-Customers typically deploy using either of these 2 options:
-
-* run the relay as an extra component external to your existing graphite pipeline. Data can be directed to it from any existing carbon relay.
-* replace an existing carbon-relay with carbon-relay-ng
-
-If your Graphite stack does not currently contain any relay, then you can simply add carbon-relay-ng, have your clients (statsd, collectd, diamond, etc) send data to the relay, which in turn can send data to your existing graphite server *and* to our platform.
-
-When creating a Hosted Metrics Graphite instance, we provide a carbon-relay-ng config file that you can plug in and be ready to use out of the box.
-We also have Grafana Labs engineers ready to advise further on set up, if needed.
-
----
-
-## HTTP API
+# HTTP API
 
 The HTTP API is the same as that of Graphite, with the addition of ingestion, authentication and meta tags.
 
@@ -309,35 +278,3 @@ Data queried for must be stored under the given org or be public data (see [mult
 ```bash
 curl -H "Authorization: Bearer $key" "http://localhost:6060/render?target=statsd.fakesite.counters.session_start.*.count&from=3h&to=2h"
 ```
-
-
----
-
-## FAQ
-
-### Can I use tags?
-
-Yes, our platform supports graphite tags as well as [meta tags](https://grafana.com/blog/2019/04/09/metrictank-meta-tags/), allowing to add extra metadata tags your series.
-
-### Can I import my existing data?
-
-You can import pre-existing data into the hosted platform, from either a Graphite or metrictank installation.
-We either provide you with the tools and instructions, or if provided access, we offer this service for a hands-off experience.
-Grafana dashboards can also be imported if you choose to use a hosted Grafana instance.
-
-### How do I send data to the service?
-
-See [data ingestion](#data-ingestion)
-
-### How does this compare to stock graphite?
-
-The hosted platform is built on top of [metrictank](/oss/metrictank) and [graphite](/oss/graphite)
-Important differences with stock Graphite to be aware of:
-
-* support for meta tags
-* the platform is optimized for append-only workloads. While historical data can be imported, we generally don't support out of order writes.
-* timeseries can change resolution (interval) over time, they will be merged automatically.
-
-## Do I have to use hosted grafana or exclusively the hosted platform?
-
-No, the hosted platform is a datasource that you can use however you like. E.g. in combination with other datasources, and queried from any Grafana instance or other client.

--- a/docs/cloud/http-api.md
+++ b/docs/cloud/http-api.md
@@ -7,7 +7,8 @@ weight: 2
 
 The HTTP API is the same as that of Graphite, with the addition of ingestion, authentication and meta tags.
 
-First of all, there are two endpoints you will be talking to. They are provided in your grafana.com Hosted Metrics instance UI.
+First of all, there are two endpoints you will be talking to. They are provided on your grafana.com Hosted Metrics instance details page.
+
 They will look something like:
 
 * `<base_in>` : `https://tsdb-<id>.hosted-metrics.grafana.net/metrics`

--- a/docs/cloud/http-api.md
+++ b/docs/cloud/http-api.md
@@ -21,7 +21,9 @@ Furthermore, you will need to provision API keys to talk to the API. Each key wi
 * Editor
 * Admin
 
-API keys can be provisioned on your Grafana.com organisation page under "security > API Keys".
+A "Viewer" key can only be used to execute queries, while a "MetricsPublisher" key can only be used to push metrics into the platform.  "Editor" and "Admin" keys can be used for both pushing metrics and performing queries.
+
+API keys can be provisioned on your Grafana.com organization page under "Security > API Keys".
 
 ## Authentication
 
@@ -63,7 +65,8 @@ Authorization: Bearer <instance id>:<api key>
 Note that you can find the instance ID as the username in the "Using Grafana with Hosted Metrics" section of your Grafana.com instance details page
 
 So essentially you can use basic auth with username "api_key" (for dedicated clusters) or your instance ID (for shared clusters) and password the api key that you provisoned
-And you can also use a bearer token in "username:password" format (if username not specified, "api_key" is assumed)
+
+You can also use a bearer token in "username:password" format (if username not specified, "api_key" is assumed)
 
 ## Common Request Parameters
 

--- a/docs/cloud/http-api.md
+++ b/docs/cloud/http-api.md
@@ -11,8 +11,8 @@ First of all, there are two endpoints you will be talking to. They are provided 
 
 They will look something like:
 
-* `<base_in>` : `https://tsdb-<id>.hosted-metrics.grafana.net/metrics`
-* `<base_out>` : `https://tsdb-<id>.hosted-metrics.grafana.net/graphite`
+* `<base_in>` : `https://something.grafana.net/metrics`
+* `<base_out>` : `https://something.grafana.net/graphite`
 
 Furthermore, you will need to provision API keys to talk to the API. Each key will be of one of these types:
 
@@ -21,6 +21,49 @@ Furthermore, you will need to provision API keys to talk to the API. Each key wi
 * Editor
 * Admin
 
+API keys can be provisioned on your Grafana.com organisation page under "security > API Keys".
+
+## Authentication
+
+Authentication differs depending on whether your instance is provisioned on a dedicated or a shared cluster.
+How to tell the difference?
+On your Grafana.com instance details page, if your query and metrics endpoint look generic like this:
+
+```
+https://graphite-us-central1.grafana.net/graphite
+https://graphite-us-central1.grafana.net/metrics
+```
+
+Then you are on a shared cluster. However if your URL's look more like this:
+
+```
+https://tsdb-123-your-company-name.hosted-metrics.grafana.net/graphite
+https://tsdb-123-your-company-name.hosted-metrics.grafana.net/metrics
+```
+
+Then you are on a dedicated cluster.
+
+You have several ways to authenticate:
+
+* For dedicated clusters, any of these HTTP headers will work:
+
+```
+Authorization: Basic base64(api_key:<api key>)
+Authorization: Bearer <api key>
+Authorization: Bearer api_key:<api key>
+```
+
+* For shared clusters, use any of these HTTP headers:
+
+```
+Authorization: Basic base64(<instance id>:<api key>)
+Authorization: Bearer <instance id>:<api key>
+```
+
+Note that you can find the instance ID as the username in the "Using Grafana with Hosted Metrics" section of your Grafana.com instance details page
+
+So essentially you can use basic auth with username "api_key" (for dedicated clusters) or your instance ID (for shared clusters) and password the api key that you provisoned
+And you can also use a bearer token in "username:password" format (if username not specified, "api_key" is assumed)
 
 ## Common Request Parameters
 
@@ -60,7 +103,7 @@ The main entry point for any publisher to publish data to, be it [carbon-relay-n
 
 #### Headers
 
-* `Authorization: Bearer <api-key>` required
+* `Authorization:` header is required (see authentication section above)
 * `Content-Type`: supports 3 values:
   - `application/json`: the simplest one, and the one used here
   - `rt-metric-binary`: same datastructure, but messagepack encoded. (see [the MetricData Marshal/Encode methods](https://godoc.org/github.com/grafana/metrictank/schema#MetricData))


### PR DESCRIPTION
What this does:
- Brings docs in line to work with https://github.com/grafana/website templating (front matter, file names, etc.)
-Adds GitHub action to sync docs to the website repo

Todo:
- [ ] Add `GH_BOT_ACCESS_TOKEN` as a secret in this repo - the value is a personal access token from the https://github.com/grafanabot user
- [ ] Merge https://github.com/grafana/website/pull/663