### PR TITLE
Fix deadlock when write queue full

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/stats"
+	"github.com/grafana/metrictank/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -327,23 +328,9 @@ func (m *UnpartitionedMemoryIdx) Stop() {
 	return
 }
 
-// bumpLastUpdate increases lastUpdate.
-// note:
-// * received point may be older than a previously received point, in which case the previous value was correct
-// * someone else may have just concurrently updated lastUpdate to a higher value than what we have, which we should restore
-// * by the time we look at the previous value and try to restore it, someone else may have updated it to a higher value
-// all these scenarios are unlikely but we should accommodate them anyway.
-func bumpLastUpdate(loc *int64, newVal int64) {
-	prev := atomic.SwapInt64(loc, newVal)
-	for prev > newVal {
-		newVal = prev
-		prev = atomic.SwapInt64(loc, newVal)
-	}
-}
-
 // updates the partition and lastUpdate ts in an archive. Returns the previously set partition
 func updateExisting(existing *idx.Archive, partition int32, lastUpdate int64, pre time.Time) int32 {
-	bumpLastUpdate(&existing.LastUpdate, lastUpdate)
+	util.AtomicallySwapIfLargerInt64(&existing.LastUpdate, lastUpdate)
 
 	oldPart := atomic.SwapInt32(&existing.Partition, partition)
 	statUpdate.Inc()
@@ -915,7 +902,7 @@ func (m *UnpartitionedMemoryIdx) add(archive *idx.Archive) {
 		// cant be passed back to the caller (cassandraIdx,BigtableIdx).
 		// If the partition has changed, then the next datapoint will update
 		// the partition and notify the caller of the change.
-		bumpLastUpdate(&existing.LastUpdate, archive.LastUpdate)
+		util.AtomicallySwapIfLargerInt64(&existing.LastUpdate, archive.LastUpdate)
 		return
 	}
 

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -93,7 +93,7 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 // Sync the saved state of a chunk by its T0.
 func (a *AggMetric) SyncChunkSaveState(ts uint32, sendPersist bool) ChunkSaveCallback {
 	return func() {
-		util.AtomicallySwapIfLargerUint32(&a.lastSaveStart, ts)
+		util.AtomicBumpUint32(&a.lastSaveStart, ts)
 
 		log.Debugf("AM: metric %s at chunk T0=%d has been saved.", a.key, ts)
 		if sendPersist {
@@ -406,7 +406,7 @@ func (a *AggMetric) persist(pos int) {
 	}
 
 	// Every chunk with a T0 <= this chunks' T0 is now either saved, or in the writeQueue.
-	util.AtomicallySwapIfLargerUint32(&a.lastSaveStart, chunk.Series.T0)
+	util.AtomicBumpUint32(&a.lastSaveStart, chunk.Series.T0)
 
 	log.Debugf("AM: persist(): sending %d chunks to write queue", len(pending))
 
@@ -488,7 +488,7 @@ func (a *AggMetric) add(ts uint32, val float64) {
 		log.Debugf("AM: %s Add(): created first chunk with first point: %v", a.key, a.chunks[0])
 		a.lastWrite = uint32(time.Now().Unix())
 		if a.dropFirstChunk {
-			util.AtomicallySwapIfLargerUint32(&a.lastSaveStart, t0)
+			util.AtomicBumpUint32(&a.lastSaveStart, t0)
 		}
 		a.addAggregators(ts, val)
 		return

--- a/util/atomic.go
+++ b/util/atomic.go
@@ -4,15 +4,9 @@ import (
 	"sync/atomic"
 )
 
-// AtomicallySwapIfLarger<Type> increases the value at the given location to the given value, unless the given value is not higher
-// than the present value. In case of a race condition where multiple routines are executing this function on one location concurrently,
-// the final value once they have all returned will be the highest value passed into any of them.
-// note:
-// * someone else may have just concurrently updated value at location to a higher value than what we have, which we should restore
-// * by the time we look at the previous value and try to restore it, someone else may have updated it to a higher value
-// both these scenarios are unlikely but we should accommodate them anyway.
-
-func AtomicallySwapIfLargerInt64(loc *int64, newVal int64) {
+// AtomicBumpInt64 assures the given address stores the highest int64 between the current value,
+// the value provided and the value provided by any other concurrently executing call
+func AtomicBumpInt64(loc *int64, newVal int64) {
 	prev := atomic.SwapInt64(loc, newVal)
 	for prev > newVal {
 		newVal = prev
@@ -20,7 +14,9 @@ func AtomicallySwapIfLargerInt64(loc *int64, newVal int64) {
 	}
 }
 
-func AtomicallySwapIfLargerUint32(loc *uint32, newVal uint32) {
+// AtomicBumpUint32 assures the given address stores the highest uint32 between the current value,
+// the value provided and the value provided by any other concurrently executing call
+func AtomicBumpUint32(loc *uint32, newVal uint32) {
 	prev := atomic.SwapUint32(loc, newVal)
 	for prev > newVal {
 		newVal = prev

--- a/util/atomic.go
+++ b/util/atomic.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"sync/atomic"
+)
+
+// AtomicallySwapIfLarger<Type> increases the value at the given location to the given value, unless the given value is not higher
+// than the present value. In case of a race condition where multiple routines are executing this function on one location concurrently,
+// the final value once they have all returned will be the highest value passed into any of them.
+// note:
+// * someone else may have just concurrently updated value at location to a higher value than what we have, which we should restore
+// * by the time we look at the previous value and try to restore it, someone else may have updated it to a higher value
+// both these scenarios are unlikely but we should accommodate them anyway.
+
+func AtomicallySwapIfLargerInt64(loc *int64, newVal int64) {
+	prev := atomic.SwapInt64(loc, newVal)
+	for prev > newVal {
+		newVal = prev
+		prev = atomic.SwapInt64(loc, newVal)
+	}
+}
+
+func AtomicallySwapIfLargerUint32(loc *uint32, newVal uint32) {
+	prev := atomic.SwapUint32(loc, newVal)
+	for prev > newVal {
+		newVal = prev
+		prev = atomic.SwapUint32(loc, newVal)
+	}
+}


### PR DESCRIPTION
there is a deadlock because when the cassandra store consumes its write
queue it needs to call a callback which acquires a lock on the
aggemetrics which generated this chunk. when this aggmetric pushes new
chunk write requests into the queue it is holding that lock. this means
if the queue is full we can end up in a situation where the aggmetric
is blocked on pushing into the write queue while the write queue
consumer is blocked on calling the callback which is trying to acquire
that same aggmetric lock.
by switching the aggmetric properties which the callback is trying to
update to atomics we should be able to avoid such a deadlock.

the property `aggmetric.lastSaveFinish` is never used, so there is no 
point maintaining its value. this removes the property and all places 
which maintain it.

Related #726 
Fixes https://github.com/grafana/metrictank-ops/issues/536