### PR TITLE
support longer aggregation spans

### DIFF
--- a/schema/archive.go
+++ b/schema/archive.go
@@ -103,7 +103,7 @@ var spanCodeToHuman map[uint8]uint32
 
 func init() {
 	// all the aggregation spans we support, their index position in this slice is their code
-	spans := []uint32{2, 5, 10, 15, 30, 60, 90, 120, 150, 300, 600, 900, 1200, 1800, 45 * 60, 3600, 3600 + 30*60, 2 * 3600, 3 * 3600, 4 * 3600, 5 * 3600, 6 * 3600, 8 * 3600, 12 * 3600, 24 * 3600}
+	spans := []uint32{2, 5, 10, 15, 30, 60, 90, 120, 150, 300, 600, 900, 1200, 1800, 45 * 60, 3600, 3600 + 30*60, 2 * 3600, 3 * 3600, 4 * 3600, 5 * 3600, 6 * 3600, 8 * 3600, 12 * 3600, 24 * 3600, 3 * 24 * 3600, 7 * 24 * 3600, 14 * 24 * 3600, 28 * 24 * 3600, 30 * 24 * 3600}
 
 	spanHumanToCode = make(map[uint32]uint8)
 	spanCodeToHuman = make(map[uint8]uint32)


### PR DESCRIPTION
I extended the list of supported aggregation spans because we have a user who needs them. 
Actually this user doesn't need all of the spans which I added, only `14d` and `30d`, but once we appended an aggregation span to this list we can't add any new ones in front of it because it would move the index of the ones after it, so i tried to put reasonable values in the spaces between the highest previously present one `1d` and the ones we need to add.
This change shouldn't affect any of the existing aggregation spans, but to verify i back filled `30d` of data into an instance which is running `master` with the schema `1s:1d:2min:2,1d:35d:6h:2`. Then I updated it to use this branch and queried the data without any issue.