### PR TITLE
add custom headers to importer reader

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -726,6 +726,8 @@ to see UTC times, just prefix command with TZ=UTC
 
 ```
 Usage of ./mt-whisper-importer-reader:
+  -custom-headers string
+    	headers to add to every request, in the format "<name>:<value>;<name>:<value>"
   -dst-schemas string
     	The filename of the output schemas definition file
   -http-auth string


### PR DESCRIPTION
this is useful when testing the importer without wanting to spin up a tsdb for auth. the custom headers allow me to add the `X-Org-Id: <id>` header manually when testing. it would also be useful in other scenarios where a user wants to add custom headers to their http requests.