### PR TITLE
update machine image for end2end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: 
+      - run: go version
       - run: scripts/qa/docs.sh
       - run: docker load -i build_docker/metrictank.tar
       - run: go test -v ./stacktest/tests/end2end_carbon

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,13 @@ jobs:
 
   qa-post-build:
     working_directory: /home/circleci/.go_workspace/src/github.com/grafana/metrictank
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
       - checkout
       - attach_workspace:
           at: .
+      - run: 
       - run: scripts/qa/docs.sh
       - run: docker load -i build_docker/metrictank.tar
       - run: go test -v ./stacktest/tests/end2end_carbon


### PR DESCRIPTION
ubuntu-1604:201903-01 is the recommended image version to use when using Machine mode for jobs.
https://circleci.com/docs/2.0/executor-types/#using-machine


The documentation on machine images is sparse, and i am not sure what version of Golang is in the latest ubuntu-1604:201903-01 image.   May also need to add a step to update Golang.