### PR TITLE
FuncGroupByTags: don't mangle tags of input series

### DIFF
--- a/expr/func_groupbytags.go
+++ b/expr/func_groupbytags.go
@@ -57,7 +57,9 @@ func (s *FuncGroupByTags) Exec(cache map[Req][]models.Series) ([]models.Series, 
 		if tag == "name" {
 			// We handle name explicitly, remove it from tags
 			useName = true
-			groupTags = append(groupTags[:i], groupTags[i+1:]...)
+			groupTags = make([]string, len(s.tags)-1)
+			copy(groupTags, s.tags[:i])
+			copy(groupTags[i:], s.tags[i+1:])
 			break
 		}
 	}


### PR DESCRIPTION
We have to copy-on-write, as explained in devdocs/expr.md
see the difference with https://play.golang.org/p/MjV9zSysYdy