### PR TITLE
mt-whisper-importer-reader: print message when everything done with the final stats

### DIFF
--- a/cmd/mt-whisper-importer-reader/main.go
+++ b/cmd/mt-whisper-importer-reader/main.go
@@ -137,6 +137,10 @@ func main() {
 
 	getFileListIntoChan(pos, fileChan)
 	wg.Wait()
+
+	processed := atomic.LoadUint32(&processedCount)
+	skipped := atomic.LoadUint32(&skippedCount)
+	log.Infof("All done. Processed %d files, %d skipped", processed, skipped)
 }
 
 func processFromChan(pos *posTracker, files chan string, wg *sync.WaitGroup) {


### PR DESCRIPTION
afaict we currently have no other way to determine it cleanly finished and what the final stats are