### PR TITLE
change tooltip to display individual values

### DIFF
--- a/dashboards/main/metrictank.json
+++ b/dashboards/main/metrictank.json
@@ -4119,7 +4119,7 @@
         "msResolution": false,
         "shared": true,
         "sort": 1,
-        "value_type": "cumulative"
+        "value_type": "individual"
       },
       "type": "graph",
       "xaxis": {


### PR DESCRIPTION
Previously the values in the Chunk Cache panel were being displayed as the cumulative of the stack which was causing some confusion.

Pre-change (notice the tooltip on the bottom of the screenshot):
![pre-change](https://user-images.githubusercontent.com/42070645/72730242-4446aa80-3b91-11ea-8f8e-fb5fa3c39587.png)

Post-change (notice the tooltip on the bottom of the screenshot):
![post-change](https://user-images.githubusercontent.com/42070645/72730260-4e68a900-3b91-11ea-9068-fa7dedc32f8c.png)
