### PR TITLE
add function offset()

### DIFF
--- a/expr/func_offset.go
+++ b/expr/func_offset.go
@@ -1,0 +1,48 @@
+package expr
+
+import (
+	"fmt"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+)
+
+type FuncOffset struct {
+	in     GraphiteFunc
+	factor float64
+}
+
+func NewOffset() GraphiteFunc {
+	return &FuncOffset{}
+}
+
+func (s *FuncOffset) Signature() ([]Arg, []Arg) {
+	return []Arg{
+			ArgSeriesList{val: &s.in},
+			ArgFloat{key: "factor", val: &s.factor},
+		}, []Arg{
+			ArgSeriesList{},
+		}
+}
+
+func (s *FuncOffset) Context(context Context) Context {
+	return context
+}
+
+func (s *FuncOffset) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
+	series, err := s.in.Exec(cache)
+	if err != nil {
+		return nil, err
+	}
+	for i, serie := range series {
+		out := pointSlicePool.Get().([]schema.Point)
+		for _, v := range serie.Datapoints {
+			out = append(out, schema.Point{Val: v.Val + s.factor, Ts: v.Ts})
+		}
+		series[i].Target = fmt.Sprintf("offset(%s,%f)", serie.Target, s.factor)
+		series[i].QueryPatt = fmt.Sprintf("offset(%s,%f)", serie.QueryPatt, s.factor)
+		series[i].Datapoints = out
+	}
+	cache[Req{}] = append(cache[Req{}], series...)
+	return series, nil
+}

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -95,6 +95,7 @@ func init() {
 		"multiplySeries":        {NewAggregateConstructor("multiply", crossSeriesMultiply), true},
 		"movingAverage":         {NewMovingAverage, false},
 		"nonNegativeDerivative": {NewNonNegativeDerivative, true},
+		"offset":                {NewOffset, true},
 		"perSecond":             {NewPerSecond, true},
 		"rangeOfSeries":         {NewAggregateConstructor("rangeOf", crossSeriesRange), true},
 		"removeAbovePercentile": {NewRemoveAboveBelowPercentileConstructor(true), true},


### PR DESCRIPTION
this one was trivial to write. 
it's basically exactly the same as `scale` except we add instead of multiply

```
diff expr/func_scale.go expr/func_offset.go
10c10
< type FuncScale struct {
---
> type FuncOffset struct {
15,16c15,16
< func NewScale() GraphiteFunc {
< 	return &FuncScale{}
---
> func NewOffset() GraphiteFunc {
> 	return &FuncOffset{}
19c19
< func (s *FuncScale) Signature() ([]Arg, []Arg) {
---
> func (s *FuncOffset) Signature() ([]Arg, []Arg) {
28c28
< func (s *FuncScale) Context(context Context) Context {
---
> func (s *FuncOffset) Context(context Context) Context {
32c32
< func (s *FuncScale) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
---
> func (s *FuncOffset) Exec(cache map[Req][]models.Series) ([]models.Series, error) {
40c40
< 			out = append(out, schema.Point{Val: v.Val * s.factor, Ts: v.Ts})
---
> 			out = append(out, schema.Point{Val: v.Val + s.factor, Ts: v.Ts})
42,43c42,43
< 		series[i].Target = fmt.Sprintf("scale(%s,%f)", serie.Target, s.factor)
< 		series[i].QueryPatt = fmt.Sprintf("scale(%s,%f)", serie.QueryPatt, s.factor)
---
> 		series[i].Target = fmt.Sprintf("offset(%s,%f)", serie.Target, s.factor)
> 		series[i].QueryPatt = fmt.Sprintf("offset(%s,%f)", serie.QueryPatt, s.factor)
                                                                                            
```