### PR TITLE
Add standalone Docker image for mt-gateway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run: mkdir build_docker
       - run: docker save -o build_docker/metrictank.tar grafana/metrictank
       - run: docker save -o build_docker/metrictank-gcr.tar us.gcr.io/metrictank-gcr/metrictank
+      - run: docker save -o build_docker/mt-gateway.tar grafana/mt-gateway
       - persist_to_workspace:
           root: .
           paths:
@@ -76,6 +77,7 @@ jobs:
               docker login -u $DOCKER_USER -p $DOCKER_PASS
               docker load -i build_docker/metrictank.tar
               docker load -i build_docker/metrictank-gcr.tar
+              docker load -i build_docker/mt-gateway.tar
               scripts/push/dockerhub.sh
               scripts/push/gcr.sh
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
     working_directory: /home/circleci/.go_workspace/src/github.com/grafana/metrictank
     machine:
       image: ubuntu-1604:201903-01
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/cmd/mt-gateway/main.go
+++ b/cmd/mt-gateway/main.go
@@ -13,10 +13,10 @@ import (
 var (
 	version       = "(none)"
 	showVersion   = flag.Bool("version", false, "print version string")
+	addr          = flag.String("addr", ":6059", "http service address")
 	metrictankUrl = flag.String("metrictank-url", "http://localhost:6060", "metrictank address")
 	graphiteURL   = flag.String("graphite-url", "http://localhost:8080", "graphite-api address")
 	importerURL   = flag.String("importer-url", "", "mt-whisper-importer-writer address")
-	addr          = flag.String("addr", ":80", "http service address")
 	defaultOrgId  = flag.Int("default-org-id", -1, "default org ID to send to downstream services if none is provided")
 	brokers       = flag.String("kafka-tcp-addr", "localhost:9092", "kafka tcp address(es) for metrics, in csv host[:port] format")
 )

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -56,7 +56,7 @@ Usage:
 
 Flags:
   -addr string
-    	http service address (default ":80")
+    	http service address (default ":6059")
   -default-org-id int
     	default org ID to send to downstream services if none is provided (default -1)
   -discard-prefixes string

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,3 +1,6 @@
+#############################
+# unpublished builder image #
+#############################
 FROM golang:1.11.4-alpine AS gobase
 RUN apk add --no-cache git bash
 
@@ -8,7 +11,22 @@ ADD . $MT_SRC_DIR
 RUN $MT_SRC_DIR/scripts/build.sh
 RUN cp -r $MT_SRC_DIR/build /tmp/build
 
+####################
+# mt-gateway image #
+####################
+FROM alpine:3.10.0 AS mt-gateway
 
+RUN mkdir -p /etc/gw
+COPY scripts/config/storage-schemas.conf /etc/gw/storage-schemas.conf
+COPY --from=gobase /tmp/build/mt-gateway /usr/bin/
+
+EXPOSE 80
+
+ENTRYPOINT ["/usr/bin/mt-gateway"]
+
+#########################
+# main metrictank image #
+#########################
 FROM alpine:3.10.0
 MAINTAINER Dieter Plaetinck dieter@grafana.com
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -16,7 +16,7 @@ RUN cp -r $MT_SRC_DIR/build /tmp/build
 ####################
 FROM alpine:3.10.0 AS mt-gateway
 
-RUN mkdir -p /etc/gw
+RUN mkdir -p /etc/metrictank
 COPY scripts/config/storage-schemas.conf /etc/metrictank/storage-schemas.conf
 COPY --from=gobase /tmp/build/mt-gateway /usr/bin/
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /etc/gw
 COPY scripts/config/storage-schemas.conf /etc/metrictank/storage-schemas.conf
 COPY --from=gobase /tmp/build/mt-gateway /usr/bin/
 
-EXPOSE 80
+EXPOSE 6059
 
 ENTRYPOINT ["/usr/bin/mt-gateway"]
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -17,7 +17,7 @@ RUN cp -r $MT_SRC_DIR/build /tmp/build
 FROM alpine:3.10.0 AS mt-gateway
 
 RUN mkdir -p /etc/gw
-COPY scripts/config/storage-schemas.conf /etc/gw/storage-schemas.conf
+COPY scripts/config/storage-schemas.conf /etc/metrictank/storage-schemas.conf
 COPY --from=gobase /tmp/build/mt-gateway /usr/bin/
 
 EXPOSE 80

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -14,6 +14,10 @@ then
     docker tag grafana/metrictank grafana/metrictank:$tag
     docker tag grafana/metrictank grafana/metrictank:$version
 
+    docker build -t grafana/mt-gateway --target=mt-gateway -f ${DIR}/Dockerfile .
+    docker tag grafana/mt-gateway grafana/mt-gateway:$tag
+    docker tag grafana/mt-gateway grafana/mt-gateway:$version
+
     # k8s image
     cd ${DIR}/k8s
     docker build -t us.gcr.io/metrictank-gcr/metrictank .

--- a/scripts/push/dockerhub.sh
+++ b/scripts/push/dockerhub.sh
@@ -16,3 +16,16 @@ echo "### docker push grafana/metrictank:$tag"
 echo
 
 docker push grafana/metrictank:$tag
+
+
+echo
+echo "### docker push grafana/mt-gateway:$version"
+echo
+
+docker push grafana/mt-gateway:$version
+
+echo
+echo "### docker push grafana/mt-gateway:$tag"
+echo
+
+docker push grafana/mt-gateway:$tag


### PR DESCRIPTION
Adds a new `mt-gateway` target to the existing Dockerfile.

Currently only publishes to dockerhub (no gcr)