### PR TITLE
increase stack tests startup wait times

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1067,6 +1067,7 @@
     "github.com/docker/docker/client",
     "github.com/go-macaron/binding",
     "github.com/gocql/gocql",
+    "github.com/golang/snappy",
     "github.com/google/go-cmp/cmp",
     "github.com/grafana/globalconf",
     "github.com/hailocab/go-hostpool",

--- a/stacktest/tests/chaos_cluster/chaos_cluster_test.go
+++ b/stacktest/tests/chaos_cluster/chaos_cluster_test.go
@@ -109,7 +109,7 @@ func TestClusterStartup(t *testing.T) {
 	case <-tracker.Match(matchers):
 		log.Println("stack now running.")
 		log.Println("Go to http://localhost:3000 (and login as admin:admin) to see what's going on")
-	case <-time.After(time.Second * 40):
+	case <-time.After(time.Second * 80):
 		grafana.PostAnnotation("TestClusterStartup:FAIL")
 		t.Fatal("timed out while waiting for all metrictank instances to come up")
 	}

--- a/stacktest/tests/end2end_carbon/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon/end2end_carbon_test.go
@@ -105,7 +105,7 @@ func TestStartup(t *testing.T) {
 	case <-tracker.Match(matchers):
 		log.Println("stack now running.")
 		log.Println("Go to http://localhost:3000 (and login as admin:admin) to see what's going on")
-	case <-time.After(time.Second * 100):
+	case <-time.After(time.Second * 180):
 		grafana.PostAnnotation("TestStartup:FAIL")
 		t.Fatal("timed out while waiting for all metrictank instances to come up")
 	}

--- a/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
@@ -105,7 +105,7 @@ func TestStartup(t *testing.T) {
 	case <-tracker.Match(matchers):
 		log.Println("stack now running.")
 		log.Println("Go to http://localhost:3000 (and login as admin:admin) to see what's going on")
-	case <-time.After(time.Second * 100):
+	case <-time.After(time.Second * 180):
 		grafana.PostAnnotation("TestStartup:FAIL")
 		t.Fatal("timed out while waiting for all metrictank instances to come up")
 	}


### PR DESCRIPTION
Increase stack tests startup wait times in order to accommodate heavy load on CircleCI. This is probably not the final solution, but should help with the high number of failing tests we are currently experiencing due to the stack tests timing out.