### PR TITLE
metrictank datasources: set 'metrictank' type to unlock MT-specific grafana features

### DIFF
--- a/docker/docker-chaos/grafana-datasources/metrictank.yaml
+++ b/docker/docker-chaos/grafana-datasources/metrictank.yaml
@@ -8,5 +8,6 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-cluster-query/grafana-datasources/metrictank.yaml
+++ b/docker/docker-cluster-query/grafana-datasources/metrictank.yaml
@@ -8,6 +8,7 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true
 - name: metrictank2
@@ -18,5 +19,6 @@ datasources:
   isDefault: false
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-cluster/grafana-datasources/metrictank.yaml
+++ b/docker/docker-cluster/grafana-datasources/metrictank.yaml
@@ -8,6 +8,7 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true
 - name: metrictank2
@@ -18,5 +19,6 @@ datasources:
   isDefault: false
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-dev-bigtable/grafana-datasources/metrictank.yaml
+++ b/docker/docker-dev-bigtable/grafana-datasources/metrictank.yaml
@@ -8,5 +8,6 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-dev-custom-cfg-kafka/grafana-datasources/metrictank.yaml
+++ b/docker/docker-dev-custom-cfg-kafka/grafana-datasources/metrictank.yaml
@@ -8,6 +8,7 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true
 - name: metrictank2
@@ -18,5 +19,6 @@ datasources:
   isDefault: false
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-dev-debug/grafana-datasources/metrictank.yaml
+++ b/docker/docker-dev-debug/grafana-datasources/metrictank.yaml
@@ -8,5 +8,6 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-dev-scylla/grafana-datasources/metrictank.yaml
+++ b/docker/docker-dev-scylla/grafana-datasources/metrictank.yaml
@@ -8,5 +8,6 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-dev/grafana-datasources/metrictank.yaml
+++ b/docker/docker-dev/grafana-datasources/metrictank.yaml
@@ -8,5 +8,6 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true

--- a/docker/docker-standard/grafana-datasources/metrictank.yaml
+++ b/docker/docker-standard/grafana-datasources/metrictank.yaml
@@ -8,5 +8,6 @@ datasources:
   isDefault: true
   jsonData:
      graphiteVersion: "1.1"
+     graphiteType: "metrictank"
   version: 1
   editable: true


### PR DESCRIPTION
like the new inspector for metadata