### PR TITLE
Update `/tags/delSeries` to always propagate delete requests to other nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## breaking changes
 
+* as of `$VERSION` the `/tag/delSeries` no longer accepts a `propagate` parameter.
+  It is no longer possible to send the request to only a single node, it now always propagates to all nodes, bringing this method in line with `/metrics/delete`.
 * as of v0.13.1-38-gb88c3b84 by default we reject data points with a timestamp far in the future.
   By default the cutoff is at 10% of the raw retention's TTL, so for example with the default
   storage schema `1s:35d:10min:7` the cutoff is at `35d*0.1=3.5d`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## breaking changes
 
-* as of `$VERSION` the `/tag/delSeries` no longer accepts a `propagate` parameter.
+* as of `$VERSION` the `/tags/delSeries` no longer accepts a `propagate` parameter.
   It is no longer possible to send the request to only a single node, it now always propagates to all nodes, bringing this method in line with `/metrics/delete`.
 * as of v0.13.1-38-gb88c3b84 by default we reject data points with a timestamp far in the future.
   By default the cutoff is at 10% of the raw retention's TTL, so for example with the default

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1348,11 +1348,6 @@ func (s *Server) graphiteTagDelSeries(ctx *middleware.Context, request models.Gr
 		}
 	}
 
-	if !request.Propagate {
-		response.Write(ctx, response.NewJson(200, res, ""))
-		return
-	}
-
 	data := models.IndexTagDelSeries{OrgId: ctx.OrgId, Paths: request.Paths}
 	responses, errors := s.peerQuery(ctx.Req.Context(), data, "clusterTagDelSeries,", "/index/tags/delSeries")
 

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -148,13 +148,11 @@ type GraphiteTagFindSeriesMetaResp struct {
 
 type GraphiteTagDelSeries struct {
 	Paths     []string `json:"path" form:"path"`
-	Propagate bool     `json:"propagate" form:"propagate" binding:"Default(true)"`
 }
 
 func (g GraphiteTagDelSeries) Trace(span opentracing.Span) {
 	span.LogFields(
 		traceLog.String("paths", fmt.Sprintf("%q", g.Paths)),
-		traceLog.Bool("propagate", g.Propagate),
 	)
 }
 

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -147,7 +147,7 @@ type GraphiteTagFindSeriesMetaResp struct {
 }
 
 type GraphiteTagDelSeries struct {
-	Paths     []string `json:"path" form:"path"`
+	Paths []string `json:"path" form:"path"`
 }
 
 func (g GraphiteTagDelSeries) Trace(span opentracing.Span) {

--- a/api/models/graphite_gen.go
+++ b/api/models/graphite_gen.go
@@ -43,12 +43,6 @@ func (z *GraphiteTagDelSeries) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-		case "Propagate":
-			z.Propagate, err = dc.ReadBool()
-			if err != nil {
-				err = msgp.WrapError(err, "Propagate")
-				return
-			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -62,9 +56,9 @@ func (z *GraphiteTagDelSeries) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *GraphiteTagDelSeries) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 2
+	// map header, size 1
 	// write "Paths"
-	err = en.Append(0x82, 0xa5, 0x50, 0x61, 0x74, 0x68, 0x73)
+	err = en.Append(0x81, 0xa5, 0x50, 0x61, 0x74, 0x68, 0x73)
 	if err != nil {
 		return
 	}
@@ -80,32 +74,19 @@ func (z *GraphiteTagDelSeries) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	}
-	// write "Propagate"
-	err = en.Append(0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
-	if err != nil {
-		return
-	}
-	err = en.WriteBool(z.Propagate)
-	if err != nil {
-		err = msgp.WrapError(err, "Propagate")
-		return
-	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *GraphiteTagDelSeries) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 2
+	// map header, size 1
 	// string "Paths"
-	o = append(o, 0x82, 0xa5, 0x50, 0x61, 0x74, 0x68, 0x73)
+	o = append(o, 0x81, 0xa5, 0x50, 0x61, 0x74, 0x68, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Paths)))
 	for za0001 := range z.Paths {
 		o = msgp.AppendString(o, z.Paths[za0001])
 	}
-	// string "Propagate"
-	o = append(o, 0xa9, 0x50, 0x72, 0x6f, 0x70, 0x61, 0x67, 0x61, 0x74, 0x65)
-	o = msgp.AppendBool(o, z.Propagate)
 	return
 }
 
@@ -146,12 +127,6 @@ func (z *GraphiteTagDelSeries) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-		case "Propagate":
-			z.Propagate, bts, err = msgp.ReadBoolBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Propagate")
-				return
-			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -170,7 +145,6 @@ func (z *GraphiteTagDelSeries) Msgsize() (s int) {
 	for za0001 := range z.Paths {
 		s += msgp.StringPrefixSize + len(z.Paths[za0001])
 	}
-	s += 10 + msgp.BoolSize
 	return
 }
 


### PR DESCRIPTION
This aligns the endpoint behavior with `/metrics/delete`, which ensures requests are forwarded to all nodes.

per @replay : 
>IIRC initially the propagate flag was necessary because when one cluster member received a delete call with propagate:true then it would fan it out to the same endpoint of the other cluster members, but in the sub-sequent calls it would set propagate:false to prevent a loop. now this intra cluster call is using a different endpoint /index/tags/delSeries