### PR TITLE
Revert to smaller CI instance size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
     working_directory: /home/circleci/.go_workspace/src/github.com/grafana/metrictank
     machine:
       image: ubuntu-1604:201903-01
-    resource_class: large
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
There was concern about angering the CircleCI billing gods if we stayed at the larger instance size, and we're not entirely sure it's necessary.

Let's see if this PR passes it's checks.