### PR TITLE
bugfix: return correct counts when deleting multiple tagged series

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -284,7 +284,7 @@ func (s *Server) indexTagDelSeries(ctx *middleware.Context, request models.Index
 		}
 
 		deleted := s.MetricIndex.DeleteTagged(request.OrgId, query)
-		res.Count = len(deleted)
+		res.Count += len(deleted)
 	}
 
 	response.Write(ctx, response.NewMsgp(200, res))


### PR DESCRIPTION
When deleting many paths in one request to `/tags/delSeries`, the count of deleted metrics gets reset instead of them getting added up. 

Using this branch, deleting two paths in one request:
```
$ curl  'http://localhost:6061/tags/delSeries' -X POST -d 'path=some.id.of.a.metric.1;afewmoretags=forgoodmeasure;anothertag=somelongervalue;goodforpeoplewhojustusetags=forbasicallyeverything;lotsandlotsoftags=morefunforeveryone;manymoreother=lotsoftagstointern;onetwothreefourfivesix=seveneightnineten;os=ubuntu;region=west;secondkey=anothervalue2;thirdkey=onemorevalue' -d 'path=some.id.of.a.metric.3;afewmoretags=forgoodmeasure;anothertag=somelongervalue;goodforpeoplewhojustusetags=forbasicallyeverything;lotsandlotsoftags=morefunforeveryone;manymoreother=lotsoftagstointern;onetwothreefourfivesix=seveneightnineten;os=ubuntu;region=west;secondkey=anothervalue3;thirdkey=onemorevalue' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   708  100    85  100   623   7727  56636 --:--:-- --:--:-- --:--:-- 64363
{
  "count": 0,
  "peers": {
    "metrictank0": 0,
    "metrictank1": 0,
    "metrictank2": 2,
    "metrictank3": 2
  }
}
```