### PR TITLE
mt-gateway docker compose

### DIFF
--- a/docker/docker-cosmosdb/docker-compose.yml
+++ b/docker/docker-cosmosdb/docker-compose.yml
@@ -76,3 +76,14 @@ services:
       GW_STATS_ENABLED: "true"
       GW_STATS_PREFIX: "tsdb-gw.stats.dev.tsdbgw_tsdb-gw_1"
       GW_STATS_ADDR: "graphite:2003"
+
+  mt-gateway:
+    hostname: mt-gateway
+    image: grafana/mt-gateway
+    ports:
+      - "6059:6059"
+    environment:
+      MT_GRAPHITE_URL: http://metrictank:6060
+      MT_METRICS_PUBLISH: "true"
+      MT_METRICS_KAFKA_COMP: snappy
+      MT_KAFKA_TCP_ADDR: kafka:9092

--- a/docker/docker-cosmosdb/docker-compose.yml
+++ b/docker/docker-cosmosdb/docker-compose.yml
@@ -87,3 +87,6 @@ services:
       MT_METRICS_PUBLISH: "true"
       MT_METRICS_KAFKA_COMP: snappy
       MT_KAFKA_TCP_ADDR: kafka:9092
+      MT_STATS_ENABLED: "true"
+      MT_STATS_PREFIX: "mt-gateway.stats.dev.mt-gateway-gw_1"
+      MT_STATS_ADDR: "graphite:2003"

--- a/docker/docker-dev-custom-cfg-kafka/docker-compose.yml
+++ b/docker/docker-dev-custom-cfg-kafka/docker-compose.yml
@@ -150,14 +150,27 @@ services:
     hostname: tsdb-gw
     image: raintank/tsdb-gw
     ports:
-     - "9000:80"
+      - "9000:80"
     volumes:
       - ../../scripts/config/storage-schemas.conf:/etc/metrictank/storage-schemas.conf
       - ./gw:/etc/gw/
     environment:
-     WAIT_HOSTS: kafka:9092
-     WAIT_TIMEOUT: 60
+      WAIT_HOSTS: kafka:9092
+      WAIT_TIMEOUT: 60
     links:
-     - metrictank
-     - graphite
-     - kafka
+      - metrictank
+      - graphite
+      - kafka
+
+  mt-gateway:
+    hostname: mt-gateway
+    image: grafana/mt-gateway
+    ports:
+      - "6059:6059"
+    volumes:
+      - ../../scripts/config/storage-schemas.conf:/etc/metrictank/storage-schemas.conf
+      - ./gw/mt-gateway.ini:/etc/metrictank/mt-gateway.ini
+    links:
+      - metrictank
+      - graphite
+      - kafka

--- a/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
+++ b/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
@@ -1,0 +1,63 @@
+
+#http service address
+addr = :5059
+
+#graphite api address
+graphite-url = http://localhost:8080
+
+#mt-whisper-importer-writer address
+#importer-url =
+
+#metrictank address
+metrictank-url = http://localhost:6060
+
+
+#default org ID to send to downstream services if none is provided (ignored if value = -1)
+default-org-id = -1
+
+
+###
+### The properties below are for configuring ingestion to kafka via the `/metrics` endpoint
+###
+
+#enable metric publishing
+metrics-publish = false
+
+#path to carbon storage-schemas.conf
+schemas-file = /etc/metrictank/storage-schemas.conf
+
+#Kafka tcp address (may be given multiple times as a comma-separated list)
+kafka-tcp-addr = localhost:9092
+
+#Kafka version in semver format. All brokers must be this version or newer.
+kafka-version = 0.10.0.0
+
+#The best-effort frequency of flushes to kafka
+metrics-flush-freq = 50ms
+
+#compression: none|gzip|snappy
+metrics-kafka-comp = snappy
+
+#The maximum number of messages the producer will send in a single request
+metrics-max-messages = 5000
+
+#method used for partitioning metrics. (byOrg|bySeries|bySeriesWithTags|bySeriesWithTagsFnv) (may be given multiple times, once per topic, as a comma-separated list)
+metrics-partition-scheme = bySeries
+
+#topic for metrics (may be given multiple times as a comma-separated list)
+metrics-topic = mdm
+
+#restrict publishing data belonging to org id; 0 means no restriction (may be given multiple times, once per topic, as a comma-separated list)
+only-org-id = 0
+
+#discard data points starting with one of the given prefixes separated by | (may be given multiple times, once per topic, as a comma-separated list)
+#discard-prefixes =
+
+#enable optimized MetricPoint payload
+v2 = true
+
+#interval after which we always resend a full MetricData
+v2-clear-interval = 1h0m0s
+
+#encode org-id in messages
+v2-org = true

--- a/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
+++ b/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
@@ -1,6 +1,6 @@
 
 #http service address
-addr = :5059
+addr = :6059
 
 #graphite api address
 graphite-url = http://graphite:8080

--- a/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
+++ b/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
@@ -3,7 +3,7 @@
 addr = :6059
 
 #graphite api address
-graphite-url = http://graphite:8080
+graphite-url = http://graphite:80
 
 #mt-whisper-importer-writer address
 #importer-url =
@@ -61,3 +61,26 @@ v2-clear-interval = 1h0m0s
 
 #encode org-id in messages
 v2-org = true
+
+
+###
+### Stats
+###
+
+#enable sending graphite messages for instrumentation
+stats-enabled = true
+
+#stats prefix (will add trailing dot automatically if needed)
+stats-prefix = mt-gateway.stats.default.$hostname
+
+#graphite address
+stats-addr = metrictank:2003
+
+#interval in seconds to send statistics
+stats-interval = 10
+
+#how many messages (holding all measurements from one interval) to buffer up in case graphite endpoint is unavailable
+stats-buffer-size = 20000
+
+#timeout after which a write is considered not successful
+stats-timeout = 10s

--- a/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
+++ b/docker/docker-dev-custom-cfg-kafka/gw/mt-gateway.ini
@@ -3,17 +3,17 @@
 addr = :5059
 
 #graphite api address
-graphite-url = http://localhost:8080
+graphite-url = http://graphite:8080
 
 #mt-whisper-importer-writer address
 #importer-url =
 
 #metrictank address
-metrictank-url = http://localhost:6060
+metrictank-url = http://metrictank:6060
 
 
 #default org ID to send to downstream services if none is provided (ignored if value = -1)
-default-org-id = -1
+default-org-id = 1
 
 
 ###
@@ -21,13 +21,13 @@ default-org-id = -1
 ###
 
 #enable metric publishing
-metrics-publish = false
+metrics-publish = true
 
 #path to carbon storage-schemas.conf
 schemas-file = /etc/metrictank/storage-schemas.conf
 
 #Kafka tcp address (may be given multiple times as a comma-separated list)
-kafka-tcp-addr = localhost:9092
+kafka-tcp-addr = kafka:9092
 
 #Kafka version in semver format. All brokers must be this version or newer.
 kafka-version = 0.10.0.0

--- a/scripts/config/mt-gateway.ini
+++ b/scripts/config/mt-gateway.ini
@@ -1,6 +1,6 @@
 
 #http service address
-addr = :5059
+addr = :6059
 
 #graphite api address
 graphite-url = http://localhost:8080

--- a/scripts/config/mt-gateway.ini
+++ b/scripts/config/mt-gateway.ini
@@ -74,7 +74,7 @@ stats-enabled = false
 stats-prefix = mt-gateway.stats.default.$hostname
 
 #graphite address
-stats-addr = localhost:2003
+stats-addr = metrictank:2003
 
 #interval in seconds to send statistics
 stats-interval = 10


### PR DESCRIPTION
Add mt-gateway docker-compose configuration to stacks that currently include tsdb-gw (`docker-cosmosdb` and `docker-dev-custom-cfg-kafka`).

While we will eventually want to remove the `tsdb-gw` configurations (and possibly move them to the `tsdb-gw` repo?) I have not done so yet, as there is nothing preventing them from running concurrently.

Also fixes an incorrect default port in `mt-gateway.ini`.


While I was able to verify metrics ingestion for the custom Kafka stack, I was not able to do so for the cosmos stack (no cosmos db available).