### PR TITLE
auto complete should not ignore meta tags if they are also metric tags

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1451,20 +1451,11 @@ func (m *UnpartitionedMemoryIdx) FindTagValuesWithQuery(orgId uint32, tag, prefi
 	m.RLock()
 	defer m.RUnlock()
 
-	tags, ok := m.tags[orgId]
-	if !ok {
-		return nil
-	}
-
-	// check whether the tag of which we're looking up values is a metric tag
-	// if so we can skip the meta tag enrichment
-	_, isMetricTag := tags[tag]
-
 	resMap := make(map[string]struct{})
 
 	var enricher *metaTagEnricher
 	var mtr *metaTagRecords
-	if MetaTagSupport && !isMetricTag {
+	if MetaTagSupport {
 		mtr, _, enricher = m.getMetaTagDataStructures(orgId, false)
 		if enricher != nil && enricher.countMetricsWithMetaTags() == 0 {
 			// if the enricher is empty we set it back to nil so it doesn't even get called

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -1119,7 +1119,7 @@ func testAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {
 			prefix: "",
 			expr:   []string{"host=~.+"},
 			limit:  100,
-			expRes: []string{"read", "write"},
+			expRes: []string{"none", "read", "write"},
 		}, {
 			tag:    "direction",
 			prefix: "wr",
@@ -1131,13 +1131,13 @@ func testAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {
 			prefix: "no",
 			expr:   []string{"host=~.+"},
 			limit:  100,
-			expRes: []string{},
+			expRes: []string{"none"},
 		}, {
 			tag:    "direction",
 			prefix: "",
 			expr:   []string{"host=~.+"},
-			limit:  1,
-			expRes: []string{"read"},
+			limit:  2,
+			expRes: []string{"none", "read"},
 		}, {
 			tag:    "all",
 			prefix: "",


### PR DESCRIPTION
This PR is just undoing what was supposed to be a performance optimization. 

Fixes: #1648 

Tested with this scenario:

Created two metrics with `fakemetrics`:
* `some.id.of.a.metric.1;anothertag=somelongervalue`
* `some.id.of.a.metric.2`

Created meta record:
```
{
  "metaTags": [
    "anothertag=metavalue"
  ],
  "expressions": [
    "name=some.id.of.a.metric.2"
  ]
}
```

Using `master`, I call the `autoComplete` endpoint and get a result for the metric ending in `.1` (metric tag) but not for the one ending with `.2` (meta tag):
```
$ curl -s http://localhost:6070/tags/autoComplete/values -H 'Content-Type: json' -d '{"tag": "anothertag", "expr": ["name=some.id.of.a.metric.1"]}'  | jq
[
  "somelongervalue"
]
$ curl -s http://localhost:6070/tags/autoComplete/values -H 'Content-Type: json' -d '{"tag": "anothertag", "expr": ["name=some.id.of.a.metric.2"]}'  | jq
[]
```

Using this branch, I do the same two calls one more time, and now i get a result for both of them:
```
$ curl -s http://localhost:6070/tags/autoComplete/values -H 'Content-Type: json' -d '{"tag": "anothertag", "expr": ["name=some.id.of.a.metric.1"]}'  | jq
[
  "somelongervalue"
]
$ curl -s http://localhost:6070/tags/autoComplete/values -H 'Content-Type: json' -d '{"tag": "anothertag", "expr": ["name=some.id.of.a.metric.2"]}'  | jq
[
  "metavalue"
]
```

They can also be mixed in a single call:
```
$ curl -s http://localhost:6070/tags/autoComplete/values -H 'Content-Type: json' -d '{"tag": "anothertag", "expr": ["name=~some.id.of.a.metric.[12]"]}'  | jq
[
  "metavalue",
  "somelongervalue"
]
```