### PR TITLE
update /metrics/delete to delete tags if a seriesByTag query is detected

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -382,7 +382,7 @@ func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
 		return
 	}
 
-	defs, err := s.MetricIndex.Delete(req.OrgId, req.Query)
+	defs, err := s.metricsDeleteLocal(req.OrgId, req.Query)
 	if err != nil {
 		// errors can only be caused by bad request.
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
@@ -390,7 +390,7 @@ func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
 	}
 
 	resp := models.MetricsDeleteResp{
-		DeletedDefs: len(defs),
+		DeletedDefs: defs,
 	}
 	response.Write(ctx, response.NewMsgp(200, &resp))
 }

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -382,7 +382,7 @@ func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
 		return
 	}
 
-	defs, err := s.metricsDeleteLocal(req.OrgId, req.Query)
+	numDeleted, err := s.metricsDeleteLocal(req.OrgId, req.Query)
 	if err != nil {
 		// errors can only be caused by bad request.
 		response.Write(ctx, response.NewError(http.StatusBadRequest, err.Error()))
@@ -390,7 +390,7 @@ func (s *Server) indexDelete(ctx *middleware.Context, req models.IndexDelete) {
 	}
 
 	resp := models.MetricsDeleteResp{
-		DeletedDefs: defs,
+		DeletedDefs: numDeleted,
 	}
 	response.Write(ctx, response.NewMsgp(200, &resp))
 }

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -557,7 +557,7 @@ func (s *Server) metricsDelete(ctx *middleware.Context, req models.MetricsDelete
 		wg.Add(1)
 		if peer.IsLocal() {
 			go func() {
-				result, err := s.metricsDeleteLocal(ctx.OrgId, req.Query)
+				numDeleted, err := s.metricsDeleteLocal(ctx.OrgId, req.Query)
 				var e error
 				if err != nil {
 					cancel()
@@ -570,7 +570,7 @@ func (s *Server) metricsDelete(ctx *middleware.Context, req models.MetricsDelete
 				responses <- struct {
 					deleted int
 					err     error
-				}{result, e}
+				}{numDeleted, e}
 				wg.Done()
 			}()
 		} else {
@@ -618,6 +618,8 @@ func (s *Server) metricsDelete(ctx *middleware.Context, req models.MetricsDelete
 	response.Write(ctx, response.NewJson(200, resp, ""))
 }
 
+//metricsDeleteLocal deletes any metrics from the server's MetricIndex that match the given orgId and query,
+//returning the number of metrics deleted, or the error if one occurred.
 func (s *Server) metricsDeleteLocal(orgId uint32, query string) (int, error) {
 
 	// nothing to do on query nodes.

--- a/docs/cloud/http-api.md
+++ b/docs/cloud/http-api.md
@@ -176,7 +176,8 @@ Should the metrics enter the system again with the same metadata, the data will 
 
 * user name: `api_key`
 * password: Your Grafana.com API Key
-* query (required): [Graphite pattern] (#graphite-patterns)
+* query (required): [Graphite pattern](#graphite-patterns) or a call to the Graphite `seriesByTag` function ([docs](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag))
+
 
 ##### Example
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -155,7 +155,7 @@ POST /metrics/delete
 ```
 
 * header `X-Org-Id` required
-* query (required): can be a metric key, and use all graphite glob patterns (`*`, `{}`, `[]`, `?`)
+* query (required): can be a metric key, and use all graphite glob patterns (`*`, `{}`, `[]`, `?`), or a call to the Graphite `seriesByTag` function ([docs](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag))
 
 #### Example
 


### PR DESCRIPTION
Follow-up to #1654, but with the logic to determine if a query is a `seriesByTag` query out of the index and closer to the http layer.

This also consolidates some duplicate logic by having the `/index/delete` method proxy to the method used by `/metrics/delete`.