### PR TITLE
update cass/bt index when deleting tagged metrics

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -283,7 +283,11 @@ func (s *Server) indexTagDelSeries(ctx *middleware.Context, request models.Index
 			return
 		}
 
-		deleted := s.MetricIndex.DeleteTagged(request.OrgId, query)
+		deleted, err := s.MetricIndex.DeleteTagged(request.OrgId, query)
+		if err != nil {
+			response.Write(ctx, response.WrapErrorForTagDB(err))
+			return
+		}
 		res.Count += len(deleted)
 	}
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1278,7 +1278,12 @@ func (s *Server) graphiteTagDelSeries(ctx *middleware.Context, request models.Gr
 				return
 			}
 
-			deleted := s.MetricIndex.DeleteTagged(ctx.OrgId, query)
+			deleted, err := s.MetricIndex.DeleteTagged(ctx.OrgId, query)
+			if err != nil {
+				response.Write(ctx, response.WrapErrorForTagDB(err))
+				return
+			}
+
 			res.Count += len(deleted)
 		}
 	}

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -149,7 +149,7 @@ type MetricIndex interface {
 
 	// DeleteTagged deletes the series returned by the given query from the tag index
 	// and also the DefById index.
-	DeleteTagged(orgId uint32, query tagquery.Query) []Archive
+	DeleteTagged(orgId uint32, query tagquery.Query) ([]Archive, error)
 
 	// MetaTagRecordUpsert inserts, updates or deletes a meta record, depending on
 	// whether it already exists or is new. The identity of a record is determined

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1755,10 +1755,10 @@ func (m *UnpartitionedMemoryIdx) List(orgId uint32) []idx.Archive {
 	return defs
 }
 
-func (m *UnpartitionedMemoryIdx) DeleteTagged(orgId uint32, query tagquery.Query) []idx.Archive {
+func (m *UnpartitionedMemoryIdx) DeleteTagged(orgId uint32, query tagquery.Query) ([]idx.Archive, error) {
 	if !TagSupport {
 		log.Warn("memory-idx: received tag query, but tag support is disabled")
-		return nil
+		return nil, nil
 	}
 
 	queryCtx := NewTagQueryContext(query)
@@ -1774,7 +1774,7 @@ func (m *UnpartitionedMemoryIdx) DeleteTagged(orgId uint32, query tagquery.Query
 
 	m.Lock()
 	defer m.Unlock()
-	return m.deleteTaggedByIdSet(orgId, ids)
+	return m.deleteTaggedByIdSet(orgId, ids), nil
 }
 
 // deleteTaggedByIdSet deletes a map of ids from the tag index and also the DefByIds

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -484,7 +484,8 @@ func testDeleteTagged(t *testing.T) {
 		So(err, ShouldBeNil)
 		query, err := tagquery.NewQueryFromStrings(tags.Strings(), 0)
 		So(err, ShouldBeNil)
-		ids := ix.DeleteTagged(1, query)
+		ids, err := ix.DeleteTagged(1, query)
+		So(err, ShouldBeNil)
 		So(ids, ShouldHaveLength, 1)
 		So(ids[0].Id.String(), ShouldEqual, org1Series[3].Id)
 		Convey("series should not be present in the metricDef index", func() {


### PR DESCRIPTION
This implements deletion of tagged metrics in the cass / bt indexes, which is currently missing.

Fixes: https://github.com/grafana/metrictank/issues/1640