### PR TITLE
Fix index corruption on swap

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -686,7 +686,7 @@ func (m *UnpartitionedMemoryIdx) MetaTagRecordSwap(orgId uint32, newRecords []ta
 			// change when we update it
 			recordsModified++
 			enricher.delMetaRecord(existingRecordId, metricKeys)
-			for _, tag := range record.MetaTags {
+			for _, tag := range mtr.getMetaTagsByRecordId(existingRecordId) {
 				mti.deleteRecord(tag, existingRecordId)
 			}
 		} else {

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -81,6 +81,10 @@ func (m *metaTagRecords) getPrunable(toKeep map[recordId]struct{}) map[recordId]
 	return toPrune
 }
 
+func (m *metaTagRecords) getMetaTagsByRecordId(recordId recordId) tagquery.Tags {
+	return m.records[recordId].MetaTags
+}
+
 func (m *metaTagRecords) getMetaTagsByRecordIds(recordIds map[recordId]struct{}) tagquery.Tags {
 	res := make(tagquery.Tags, 0, len(recordIds))
 	for recordId := range recordIds {


### PR DESCRIPTION
First commit adds a unit test which exposes a bug (described in https://github.com/grafana/metrictank/issues/1661#issuecomment-582969272). 
Then fixes the bug with the second commit.

I also manually went through the procedure described in that issue comment to verify that the bug is fixed.

Fixes: #1661 