### PR TITLE
maxPointsPerReqSoft: reduce resolution respecting same-retention requests

### DIFF
--- a/api/graphite_req.go
+++ b/api/graphite_req.go
@@ -151,28 +151,30 @@ func (rp ReqsPlan) PointsFetch() uint32 {
 // Dump provides a human readable string representation of the ReqsPlan
 func (rp ReqsPlan) Dump() string {
 	out := fmt.Sprintf("ReqsPlan (%d entries):\n", rp.cnt)
-	out += "  Groups:\n"
+	out += "  # Groups:\n"
 	for i, data := range rp.pngroups {
-		out += fmt.Sprintf("    * group %d\nMDP-yes:\n", i)
+		out += fmt.Sprintf("    ## group %d\n", i)
+		out += "      ### MDP-yes:\n"
 		for schemaID, reqs := range data.mdpyes {
 			for _, req := range reqs {
-				out += fmt.Sprintf("      [%d] %s\n", schemaID, req.DebugString())
+				out += fmt.Sprintf("        [%d] %s\n", schemaID, req.DebugString())
 			}
 		}
-		out += "  MDP-no:\n"
+		out += "      ### MDP-no:\n"
 		for schemaID, reqs := range data.mdpno {
 			for _, req := range reqs {
-				out += fmt.Sprintf("      [%d] %s\n", schemaID, req.DebugString())
+				out += fmt.Sprintf("        [%d] %s\n", schemaID, req.DebugString())
 			}
 		}
 	}
-	out += "  Single MDP-yes:\n"
+	out += "  # Single\n"
+	out += "   ## MDP-yes:\n"
 	for schemaID, reqs := range rp.single.mdpyes {
 		for _, req := range reqs {
 			out += fmt.Sprintf("    [%d] %s\n", schemaID, req.DebugString())
 		}
 	}
-	out += "  Single MDP-no:\n"
+	out += "    ## MDP-no:\n"
 	for schemaID, reqs := range rp.single.mdpno {
 		for _, req := range reqs {
 			out += fmt.Sprintf("    [%d] %s\n", schemaID, req.DebugString())

--- a/api/graphite_req.go
+++ b/api/graphite_req.go
@@ -63,6 +63,15 @@ func (rbr ReqsByRet) OutInterval() uint32 {
 	return 0
 }
 
+func (rbr ReqsByRet) HasData() bool {
+	for _, reqs := range rbr {
+		if len(reqs) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // GroupData embodies a PNGroup broken down by whether requests are MDP-optimizable, and by retention
 type GroupData struct {
 	mdpyes ReqsByRet // MDP-optimizable requests

--- a/api/graphite_req.go
+++ b/api/graphite_req.go
@@ -72,6 +72,14 @@ func (rbr ReqsByRet) HasData() bool {
 	return false
 }
 
+func (rbr ReqsByRet) Len() int {
+	var cnt int
+	for _, reqs := range rbr {
+		cnt += len(reqs)
+	}
+	return cnt
+}
+
 // GroupData embodies a PNGroup broken down by whether requests are MDP-optimizable, and by retention
 type GroupData struct {
 	mdpyes ReqsByRet // MDP-optimizable requests
@@ -83,6 +91,10 @@ func NewGroupData() GroupData {
 		mdpyes: make([][]models.Req, mdata.Schemas.Len()),
 		mdpno:  make([][]models.Req, mdata.Schemas.Len()),
 	}
+}
+
+func (gd GroupData) Len() int {
+	return gd.mdpno.Len() + gd.mdpyes.Len()
 }
 
 // ReqsPlan holds requests that have been planned, broken down by PNGroup and MDP-optimizability

--- a/api/graphite_req.go
+++ b/api/graphite_req.go
@@ -52,6 +52,17 @@ func (r ReqMap) Dump() string {
 // Requests indexed by their retention ID
 type ReqsByRet [][]models.Req
 
+// OutInterval returns the outinterval of the ReqsByRet
+// this assumes that all requests have been planned to a consistent out interval, of course.
+func (rbr ReqsByRet) OutInterval() uint32 {
+	for _, reqs := range rbr {
+		if len(reqs) != 0 {
+			return reqs[0].OutInterval
+		}
+	}
+	return 0
+}
+
 // GroupData embodies a PNGroup broken down by whether requests are MDP-optimizable, and by retention
 type GroupData struct {
 	mdpyes ReqsByRet // MDP-optimizable requests

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -68,14 +68,14 @@ func planRequests(now, from, to uint32, reqs *ReqMap, planMDP uint32, mpprSoft, 
 
 	// 1) Initial parameters
 	for group, split := range rp.pngroups {
-		if len(split.mdpyes) > 0 {
+		if split.mdpyes.HasData() {
 			ok = planLowestResForMDPMulti(now, from, to, planMDP, split.mdpyes)
 			if !ok {
 				return nil, errUnSatisfiable
 			}
 			rp.pngroups[group] = split
 		}
-		if len(split.mdpno) > 0 {
+		if split.mdpno.HasData() {
 			ok = planHighestResMulti(now, from, to, split.mdpno)
 			if !ok {
 				return nil, errUnSatisfiable

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -322,9 +322,9 @@ func planLowestResForMDPMulti(now, from, to, mdp uint32, reqs []models.Req) ([]m
 				maxScore = score
 				interval = candidateInterval
 			}
-			if candidateInterval < lowestInterval {
-				lowestInterval = candidateInterval
-			}
+		}
+		if candidateInterval < lowestInterval {
+			lowestInterval = candidateInterval
 		}
 	}
 	// if we didn't find a suitable MDP-optimized one, just pick the lowest one we've seen.

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -289,24 +289,25 @@ func planLowestResForMDPMulti(now, from, to, mdp uint32, reqs []models.Req) ([]m
 	var interval uint32                      // will be set to either of the two above
 	for _, combo := range combos {
 		candidateInterval = util.Lcm(combo)
-		if candidateInterval <= maxInterval {
-			var score int
-			for _, req := range reqs {
-				rets := getRetentions(req)
-				_, ret, ok := findLowestResForInterval(rets, from, minTTL, candidateInterval)
-				if !ok {
-					panic("planLowestResForMDPMulti: could not find coarsest retention. should never happen because we made sure our candidate LCM is based on what we have")
-				}
-				score += len(reqs) * ret.SecondsPerPoint
-			}
-
-			if score > maxScore {
-				maxScore = score
-				interval = candidateInterval
-			}
-		}
 		if candidateInterval < lowestInterval {
 			lowestInterval = candidateInterval
+		}
+		if candidateInterval > maxInterval {
+			continue
+		}
+		var score int
+		for _, req := range reqs {
+			rets := getRetentions(req)
+			_, ret, ok := findLowestResForInterval(rets, from, minTTL, candidateInterval)
+			if !ok {
+				panic("planLowestResForMDPMulti: could not find coarsest retention. should never happen because we made sure our candidate LCM is based on what we have")
+			}
+			score += len(reqs) * ret.SecondsPerPoint
+		}
+
+		if score > maxScore {
+			maxScore = score
+			interval = candidateInterval
 		}
 	}
 	// if we didn't find a suitable MDP-optimized one, just pick the lowest one we've seen.

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -101,15 +101,19 @@ func planRequests(now, from, to uint32, reqs *ReqMap, planMDP uint32, mpprSoft, 
 	}
 
 	if mpprSoft > 0 {
-		// at this point, all MDP-optimizable series have already been optimized
-		// we can try to reduce the resolution of non-MDP-optimizable series
-		// if metrictank is already handling all, or most of your queries, then we have been able to determine
-		// MDP-optimizability very well. If the request came from Graphite, we have to assume it may run GR-functions.
-		// thus in the former case, we pretty much know that this is going to have an adverse effect on your queries,
-		// and you should probably not use this option, or we should even get rid of it.
-		// in the latter case though, it's quite likely we were too cautious and categorized many series as non-MDP
-		// optimizable whereas in reality they should be, so in that case this option is a welcome way to reduce the
-		// impact of big queries
+		// at this point, MDP-optimizable series have already seen a decent resolution reduction
+		// so to meet this constraint, we will try to reduce the resolution of non-MDP-optimizable series
+		// in the future we can make this even more aggressive and also try to reduce MDP-optimized series even more
+		//
+		// Note:
+		// A) if metrictank is already handling all, or most of your queries, then we have been able to determine
+		//    MDP-optimizability very well. In this case we pretty much know that if we need to enforce this option
+		//    it is going to have an adverse effect on your queries, and you should probably not use this option,
+		//    or we should even get rid of it.
+		// B) If the request came from Graphite, we have to assume it may run GR-functions and quite likely we were
+		//    too cautious and categorized many series as non-MDP optimizable whereas in reality they should be,
+		//    so in that case this option is a welcome way to reduce the impact of big queries.
+		//
 		// we could do two approaches: gradually reduce the interval of all series/groups being read, or just aggressively
 		// adjust one group at a time. The latter seems simpler, so for now we do just that.
 		if rp.PointsFetch() > uint32(mpprSoft) {

--- a/api/query_engine_test.go
+++ b/api/query_engine_test.go
@@ -22,7 +22,7 @@ func getReqMap(reqs []models.Req) *ReqMap {
 
 // testPlan verifies the aligment of the given requests, given the retentions (one or more patterns, one or more retentions each)
 // passing mpprSoft/mpprHard 0 means we will set them automatically such that they will never be hit
-func testPlan(reqs []models.Req, retentions []conf.Retentions, outReqs []models.Req, outErr error, now uint32, mpprSoft, mpprHard int, t *testing.T) {
+func testPlan(reqs []models.Req, retentions []conf.Retentions, outReqs []models.Req, outErr error, now uint32, mpprSoft, mpprHard int, t *testing.T) *ReqsPlan {
 	var schemas []conf.Schema
 
 	maxPointsPerReqSoft := mpprSoft
@@ -66,6 +66,7 @@ func testPlan(reqs []models.Req, retentions []conf.Retentions, outReqs []models.
 			}
 		}
 	}
+	return out
 }
 
 // There are a lot of factors to consider. I haven't found a practical way to test all combinations of every factor

--- a/conf/retention.go
+++ b/conf/retention.go
@@ -97,6 +97,11 @@ func (r Retention) MaxRetention() int {
 	return r.SecondsPerPoint * r.NumberOfPoints
 }
 
+// Valid returns whether the given retention has been ready long enough (wrt from), and has a sufficient retention (wrt ttl)
+func (r Retention) Valid(from, ttl uint32) bool {
+	return r.Ready <= from && uint32(r.MaxRetention()) >= ttl
+}
+
 func (r Retention) String() string {
 	s := dur.FormatDuration(uint32(r.SecondsPerPoint))
 	s += ":" + dur.FormatDuration(uint32(r.NumberOfPoints*r.SecondsPerPoint))

--- a/conf/schemas.go
+++ b/conf/schemas.go
@@ -51,6 +51,11 @@ func (s Schemas) List() ([]Schema, Schema) {
 	return s.raw, s.DefaultSchema
 }
 
+// Len returns the max number of possible schemas
+func (s Schemas) Len() int {
+	return len(s.index) + 1 // s.DefaultSchema
+}
+
 func (s *Schemas) BuildIndex() {
 	s.index = make([]Schema, 0)
 	for _, schema := range s.raw {

--- a/conf/schemas.go
+++ b/conf/schemas.go
@@ -181,7 +181,7 @@ func ReadSchemas(file string) (Schemas, error) {
 //   less then the interval of the next rollup.
 // - If the pattern doesnt match, then we skip ahead to the next pattern.
 //
-// eg. from the above diagram we would compare the pattern for schame0
+// eg. from the above diagram we would compare the pattern for schema0
 //     (pattern1), if it doesnt match we will then compare the pattern of
 //     schema2 (pattern2) and if that doesnt match we would try schema5
 //     (pattern3).


### PR DESCRIPTION
if we need to reduce some data to honor max-points-per-req-soft,
1) we should always keep series that have the same retention policy, at the
same resolution. Otherwise we may run into weirdness e.g. in Grafana
with stacking: timestamps should line up.
A bonus here also is that this will perform better as we can typically update many requests all at once
2) instead of using the MDP-optimization functions, which may be too aggressive, use new reduce functions, which will look to reduce requests by whatever the next "step" down is following their retention
3) keep iterating and making progress - possibly reducing more than once - until max-points-per-req-soft is met. This is more thorough than the previous version.

This should fix #1677 