### PR TITLE
graphite response type: if json decode fails, save response body

### DIFF
--- a/stacktest/graphite/validate.go
+++ b/stacktest/graphite/validate.go
@@ -15,6 +15,7 @@ type Response struct {
 	Code      int
 	TraceID   string
 	Decoded   Data
+	BodyErr   string // set if we could not decode json
 }
 
 func (r Response) StringWithoutData() string {


### PR DESCRIPTION
this makes it easy to see what's wrong, when using the client. E.g.:
```
(graphite.Response) {
 HTTPErr: (error) <nil>,
 DecodeErr: (*json.UnmarshalTypeError)(0xc00033e000)(json: cannot unmarshal string into Go value of type graphite.Data),
 Code: (int) 401,
 TraceID: (string) "",
 Decoded: (graphite.Data) <nil>,
 BodyErr: (string) (len=36) "\"invalid authentication credentials\""
}
```