### PR TITLE
Rename Error interface method to avoid collisions with gocql

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -251,7 +251,7 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 	out, meta, err := s.executePlan(execCtx, ctx.OrgId, plan)
 	if err != nil {
 		err := response.WrapError(err)
-		if err.Code() != http.StatusBadRequest {
+		if err.HTTPStatusCode() != http.StatusBadRequest {
 			tracing.Failure(execSpan)
 		}
 		tracing.Error(execSpan, err)

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -143,7 +143,7 @@ func (r *Error) Error() string {
 }
 
 // implement response.Response
-func (r *Error) Code() int {
+func (r *Error) HTTPStatusCode() int {
 	return r.code
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,7 +15,7 @@ func NewInternalf(format string, a ...interface{}) Internal {
 	return Internal(fmt.Sprintf(format, a...))
 }
 
-func (i Internal) Code() int {
+func (i Internal) HTTPStatusCode() int {
 	return http.StatusInternalServerError
 }
 
@@ -33,7 +33,7 @@ func NewBadRequestf(format string, a ...interface{}) BadRequest {
 	return BadRequest(fmt.Sprintf(format, a...))
 }
 
-func (b BadRequest) Code() int {
+func (b BadRequest) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 

--- a/expr/func_aspercent_test.go
+++ b/expr/func_aspercent_test.go
@@ -22,7 +22,7 @@ func (e errAsPercentNumSeriesMismatch) Error() string {
 	return fmt.Sprintf("asPercent got %d input series but %d total series (should  be same amount or 1)", e.numIn, e.numTotal)
 }
 
-func (e errAsPercentNumSeriesMismatch) Code() int {
+func (e errAsPercentNumSeriesMismatch) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -34,7 +34,7 @@ func (e ErrBadArgument) Error() string {
 	return fmt.Sprintf("argument bad type. expected %s - got %s", e.exp, e.got)
 }
 
-func (e ErrBadArgument) Code() int {
+func (e ErrBadArgument) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 
@@ -47,7 +47,7 @@ func (e ErrBadArgumentStr) Error() string {
 	return fmt.Sprintf("argument bad type. expected %s - got %s", e.exp, e.got)
 }
 
-func (e ErrBadArgumentStr) Code() int {
+func (e ErrBadArgumentStr) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 
@@ -57,7 +57,7 @@ func (e ErrUnknownFunction) Error() string {
 	return fmt.Sprintf("unknown function %q", string(e))
 }
 
-func (e ErrUnknownFunction) Code() int {
+func (e ErrUnknownFunction) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 
@@ -69,7 +69,7 @@ func (e ErrUnknownKwarg) Error() string {
 	return fmt.Sprintf("unknown keyword argument %q", e.key)
 }
 
-func (e ErrUnknownKwarg) Code() int {
+func (e ErrUnknownKwarg) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 
@@ -83,7 +83,7 @@ func (e ErrBadKwarg) Error() string {
 	return fmt.Sprintf("keyword argument %q bad type. expected %T - got %s", e.key, e.exp, e.got)
 }
 
-func (e ErrBadKwarg) Code() int {
+func (e ErrBadKwarg) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 
@@ -95,7 +95,7 @@ func (e ErrKwargSpecifiedTwice) Error() string {
 	return fmt.Sprintf("keyword argument %q specified twice", e.key)
 }
 
-func (e ErrKwargSpecifiedTwice) Code() int {
+func (e ErrKwargSpecifiedTwice) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 

--- a/expr/tagquery/expression.go
+++ b/expr/tagquery/expression.go
@@ -18,7 +18,7 @@ func (i InvalidExpressionError) Error() string {
 	return fmt.Sprintf("Invalid expression: %s", string(i))
 }
 
-func (i InvalidExpressionError) Code() int {
+func (i InvalidExpressionError) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 


### PR DESCRIPTION
This was leading to nonsense HTTP status codes as seen in #1678.

Also rolls back the mitigations added in https://github.com/grafana/metrictank/pull/987 now that a permanent fix is in place.

This is the super low effort approach to fixing #1678... If we feel strongly about the old interface names, we could probably make more targeted changes at the Cassandra call sites.
