### PR TITLE
Add tag based constructors for simple metrics.

### DIFF
--- a/stats/bool.go
+++ b/stats/bool.go
@@ -38,6 +38,6 @@ func (b *Bool) Peek() bool {
 
 func (b *Bool) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&b.val)
-	buf = WriteUint32(buf, prefix, []byte("gauge1"), val, now)
+	buf = WriteUint32(buf, prefix, []byte(".gauge1"), val, now)
 	return buf
 }

--- a/stats/counter32.go
+++ b/stats/counter32.go
@@ -6,11 +6,20 @@ import (
 )
 
 type Counter32 struct {
-	val uint32
+	val    uint32
+	suffix []byte
 }
 
 func NewCounter32(name string) *Counter32 {
-	return registry.getOrAdd(name, &Counter32{}).(*Counter32)
+	return registry.getOrAdd(name, &Counter32{
+		suffix: []byte(".counter32"),
+	}).(*Counter32)
+}
+
+func NewCounter32WithTags(name string) *Counter32 {
+	return registry.getOrAdd(name, &Counter32{
+		suffix: []byte(";type=counter32"),
+	}).(*Counter32)
 }
 
 func (c *Counter32) SetUint32(val uint32) {
@@ -35,6 +44,6 @@ func (c *Counter32) Peek() uint32 {
 
 func (c *Counter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
-	buf = WriteUint32(buf, prefix, []byte(".counter32"), val, now)
+	buf = WriteUint32(buf, prefix, c.suffix, val, now)
 	return buf
 }

--- a/stats/counter32.go
+++ b/stats/counter32.go
@@ -35,6 +35,6 @@ func (c *Counter32) Peek() uint32 {
 
 func (c *Counter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
-	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
+	buf = WriteUint32(buf, prefix, []byte(".counter32"), val, now)
 	return buf
 }

--- a/stats/counter64.go
+++ b/stats/counter64.go
@@ -27,6 +27,6 @@ func (c *Counter64) AddUint64(val uint64) {
 
 func (c *Counter64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint64(&c.val)
-	buf = WriteUint64(buf, prefix, []byte("counter64"), val, now)
+	buf = WriteUint64(buf, prefix, []byte(".counter64"), val, now)
 	return buf
 }

--- a/stats/counter64.go
+++ b/stats/counter64.go
@@ -6,11 +6,20 @@ import (
 )
 
 type Counter64 struct {
-	val uint64
+	val    uint64
+	suffix []byte
 }
 
 func NewCounter64(name string) *Counter64 {
-	return registry.getOrAdd(name, &Counter64{}).(*Counter64)
+	return registry.getOrAdd(name, &Counter64{
+		suffix: []byte(".counter64"),
+	}).(*Counter64)
+}
+
+func NewCounter64WithTags(name string) *Counter64 {
+	return registry.getOrAdd(name, &Counter64{
+		suffix: []byte(";type=counter64"),
+	}).(*Counter64)
 }
 
 func (c *Counter64) SetUint64(val uint64) {
@@ -27,6 +36,6 @@ func (c *Counter64) AddUint64(val uint64) {
 
 func (c *Counter64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint64(&c.val)
-	buf = WriteUint64(buf, prefix, []byte(".counter64"), val, now)
+	buf = WriteUint64(buf, prefix, c.suffix, val, now)
 	return buf
 }

--- a/stats/counterrate32.go
+++ b/stats/counterrate32.go
@@ -41,8 +41,8 @@ func (c *CounterRate32) Peek() uint32 {
 
 func (c *CounterRate32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
-	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
-	buf = WriteFloat64(buf, prefix, []byte("rate32"), float64(val-c.prev)/now.Sub(c.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, []byte(".counter32"), val, now)
+	buf = WriteFloat64(buf, prefix, []byte(".rate32"), float64(val-c.prev)/now.Sub(c.since).Seconds(), now)
 
 	c.prev = val
 	c.since = now

--- a/stats/gauge32.go
+++ b/stats/gauge32.go
@@ -6,11 +6,20 @@ import (
 )
 
 type Gauge32 struct {
-	val uint32
+	val    uint32
+	suffix []byte
 }
 
 func NewGauge32(name string) *Gauge32 {
-	return registry.getOrAdd(name, &Gauge32{}).(*Gauge32)
+	return registry.getOrAdd(name, &Gauge32{
+		suffix: []byte(".gauge32"),
+	}).(*Gauge32)
+}
+
+func NewGauge32WithTags(name string) *Gauge32 {
+	return registry.getOrAdd(name, &Gauge32{
+		suffix: []byte(";type=gauge32"),
+	}).(*Gauge32)
 }
 
 func (g *Gauge32) Inc() {
@@ -51,6 +60,6 @@ func (g *Gauge32) SetUint32(val uint32) {
 
 func (g *Gauge32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&g.val)
-	buf = WriteUint32(buf, prefix, []byte(".gauge32"), val, now)
+	buf = WriteUint32(buf, prefix, g.suffix, val, now)
 	return buf
 }

--- a/stats/gauge32.go
+++ b/stats/gauge32.go
@@ -51,6 +51,6 @@ func (g *Gauge32) SetUint32(val uint32) {
 
 func (g *Gauge32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&g.val)
-	buf = WriteUint32(buf, prefix, []byte("gauge32"), val, now)
+	buf = WriteUint32(buf, prefix, []byte(".gauge32"), val, now)
 	return buf
 }

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -6,11 +6,20 @@ import (
 )
 
 type Gauge64 struct {
-	val uint64
+	val    uint64
+	suffix []byte
 }
 
 func NewGauge64(name string) *Gauge64 {
-	return registry.getOrAdd(name, &Gauge64{}).(*Gauge64)
+	return registry.getOrAdd(name, &Gauge64{
+		suffix: []byte(".gauge64"),
+	}).(*Gauge64)
+}
+
+func NewGauge64WithTags(name string) *Gauge64 {
+	return registry.getOrAdd(name, &Gauge64{
+		suffix: []byte(";type=gauge64"),
+	}).(*Gauge64)
 }
 
 func (g *Gauge64) Inc() {
@@ -51,7 +60,7 @@ func (g *Gauge64) SetUint64(val uint64) {
 
 func (g *Gauge64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint64(&g.val)
-	buf = WriteUint64(buf, prefix, []byte(".gauge64"), val, now)
+	buf = WriteUint64(buf, prefix, g.suffix, val, now)
 	return buf
 }
 

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -5,27 +5,28 @@ import (
 	"time"
 )
 
-type Gauge64 uint64
+type Gauge64 struct {
+	val uint64
+}
 
 func NewGauge64(name string) *Gauge64 {
-	u := Gauge64(0)
-	return registry.getOrAdd(name, &u).(*Gauge64)
+	return registry.getOrAdd(name, &Gauge64{}).(*Gauge64)
 }
 
 func (g *Gauge64) Inc() {
-	atomic.AddUint64((*uint64)(g), 1)
+	atomic.AddUint64(&g.val, 1)
 }
 
 func (g *Gauge64) Dec() {
-	atomic.AddUint64((*uint64)(g), ^uint64(0))
+	atomic.AddUint64(&g.val, ^uint64(0))
 }
 
 func (g *Gauge64) AddUint64(val uint64) {
-	atomic.AddUint64((*uint64)(g), val)
+	atomic.AddUint64(&g.val, val)
 }
 
 func (g *Gauge64) DecUint64(val uint64) {
-	atomic.AddUint64((*uint64)(g), ^uint64(val-1))
+	atomic.AddUint64(&g.val, ^uint64(val-1))
 }
 
 func (g *Gauge64) Add(val int) {
@@ -41,19 +42,19 @@ func (g *Gauge64) Add(val int) {
 }
 
 func (g *Gauge64) Set(val int) {
-	atomic.StoreUint64((*uint64)(g), uint64(val))
+	atomic.StoreUint64(&g.val, uint64(val))
 }
 
 func (g *Gauge64) SetUint64(val uint64) {
-	atomic.StoreUint64((*uint64)(g), val)
+	atomic.StoreUint64(&g.val, val)
 }
 
 func (g *Gauge64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
-	val := atomic.LoadUint64((*uint64)(g))
+	val := atomic.LoadUint64(&g.val)
 	buf = WriteUint64(buf, prefix, []byte("gauge64"), val, now)
 	return buf
 }
 
 func (g *Gauge64) Peek() uint64 {
-	return atomic.LoadUint64((*uint64)(g))
+	return atomic.LoadUint64(&g.val)
 }

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -51,7 +51,7 @@ func (g *Gauge64) SetUint64(val uint64) {
 
 func (g *Gauge64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint64(&g.val)
-	buf = WriteUint64(buf, prefix, []byte("gauge64"), val, now)
+	buf = WriteUint64(buf, prefix, []byte(".gauge64"), val, now)
 	return buf
 }
 

--- a/stats/latencyhistogram12h32.go
+++ b/stats/latencyhistogram12h32.go
@@ -30,15 +30,15 @@ func (l *LatencyHistogram12h32) ReportGraphite(prefix, buf []byte, now time.Time
 	// for now, only report the summaries :(
 	r, ok := l.hist.Report(snap)
 	if ok {
-		buf = WriteUint32(buf, prefix, []byte("latency.min.gauge32"), r.Min/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.mean.gauge32"), r.Mean/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.median.gauge32"), r.Median/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p75.gauge32"), r.P75/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p90.gauge32"), r.P90/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.max.gauge32"), r.Max/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.min.gauge32"), r.Min/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.mean.gauge32"), r.Mean/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.median.gauge32"), r.Median/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.p75.gauge32"), r.P75/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.p90.gauge32"), r.P90/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.max.gauge32"), r.Max/1000, now)
 	}
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), r.Count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, []byte(".values.count32"), r.Count, now)
+	buf = WriteFloat64(buf, prefix, []byte(".values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
 	l.since = now
 	return buf
 }

--- a/stats/latencyhistogram15s32.go
+++ b/stats/latencyhistogram15s32.go
@@ -34,15 +34,15 @@ func (l *LatencyHistogram15s32) ReportGraphite(prefix, buf []byte, now time.Time
 	r, ok := l.hist.Report(snap)
 	if ok {
 		sum := atomic.SwapUint64(&l.sum, 0)
-		buf = WriteUint32(buf, prefix, []byte("latency.min.gauge32"), r.Min/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.mean.gauge32"), uint32((sum / uint64(r.Count) / 1000)), now)
-		buf = WriteUint32(buf, prefix, []byte("latency.median.gauge32"), r.Median/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p75.gauge32"), r.P75/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p90.gauge32"), r.P90/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.max.gauge32"), r.Max/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.min.gauge32"), r.Min/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.mean.gauge32"), uint32((sum / uint64(r.Count) / 1000)), now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.median.gauge32"), r.Median/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.p75.gauge32"), r.P75/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.p90.gauge32"), r.P90/1000, now)
+		buf = WriteUint32(buf, prefix, []byte(".latency.max.gauge32"), r.Max/1000, now)
 	}
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), r.Count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, []byte(".values.count32"), r.Count, now)
+	buf = WriteFloat64(buf, prefix, []byte(".values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
 
 	l.since = now
 	return buf

--- a/stats/memory_reporter.go
+++ b/stats/memory_reporter.go
@@ -50,32 +50,32 @@ func (m *MemoryReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byt
 	gcPercent := getGcPercent()
 
 	// metric memory.total_bytes_allocated is a counter of total number of bytes allocated during process lifetime
-	buf = WriteUint64(buf, prefix, []byte("total_bytes_allocated.counter64"), m.mem.TotalAlloc, now)
+	buf = WriteUint64(buf, prefix, []byte(".total_bytes_allocated.counter64"), m.mem.TotalAlloc, now)
 
 	// metric memory.bytes_allocated_on_heap is a gauge of currently allocated (within the runtime) memory.
-	buf = WriteUint64(buf, prefix, []byte("bytes.allocated_in_heap.gauge64"), m.mem.Alloc, now)
+	buf = WriteUint64(buf, prefix, []byte(".bytes.allocated_in_heap.gauge64"), m.mem.Alloc, now)
 
 	// metric memory.bytes.obtained_from_sys is the number of bytes currently obtained from the system by the process.  This is what the profiletrigger looks at.
-	buf = WriteUint64(buf, prefix, []byte("bytes.obtained_from_sys.gauge64"), m.mem.Sys, now)
+	buf = WriteUint64(buf, prefix, []byte(".bytes.obtained_from_sys.gauge64"), m.mem.Sys, now)
 
 	// metric memory.total_gc_cycles is a counter of the number of GC cycles since process start
-	buf = WriteUint32(buf, prefix, []byte("total_gc_cycles.counter64"), m.mem.NumGC, now)
+	buf = WriteUint32(buf, prefix, []byte(".total_gc_cycles.counter64"), m.mem.NumGC, now)
 
 	// metric memory.gc.cpu_fraction is how much cpu is consumed by the GC across process lifetime, in pro-mille
-	buf = WriteUint32(buf, prefix, []byte("gc.cpu_fraction.gauge32"), uint32(1000*m.mem.GCCPUFraction), now)
+	buf = WriteUint32(buf, prefix, []byte(".gc.cpu_fraction.gauge32"), uint32(1000*m.mem.GCCPUFraction), now)
 
 	// metric memory.gc.heap_objects is how many objects are allocated on the heap, it's a key indicator for GC workload
-	buf = WriteUint64(buf, prefix, []byte("gc.heap_objects.gauge64"), m.mem.HeapObjects, now)
+	buf = WriteUint64(buf, prefix, []byte(".gc.heap_objects.gauge64"), m.mem.HeapObjects, now)
 
 	// there was no new GC run, we should only report points to represent actual runs
 	if m.gcCyclesTotal != m.mem.NumGC {
 		// metric memory.gc.last_duration is the duration of the last GC STW pause in nanoseconds
-		buf = WriteUint64(buf, prefix, []byte("gc.last_duration.gauge64"), m.mem.PauseNs[(m.mem.NumGC+255)%256], now)
+		buf = WriteUint64(buf, prefix, []byte(".gc.last_duration.gauge64"), m.mem.PauseNs[(m.mem.NumGC+255)%256], now)
 		m.gcCyclesTotal = m.mem.NumGC
 	}
 
 	// metric memory.gc.gogc is the current GOGC value (derived from the GOGC environment variable)
-	buf = WriteInt32(buf, prefix, []byte("gc.gogc.sgauge32"), int32(gcPercent), now)
+	buf = WriteInt32(buf, prefix, []byte(".gc.gogc.sgauge32"), int32(gcPercent), now)
 
 	return buf
 }

--- a/stats/meter32.go
+++ b/stats/meter32.go
@@ -128,11 +128,11 @@ func (m *Meter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 		}
 	}
 
-	buf = WriteUint32(buf, prefix, []byte("min.gauge32"), m.min, now)
-	buf = WriteUint32(buf, prefix, []byte("mean.gauge32"), uint32(runningsum/uint64(m.count)), now)
-	buf = WriteUint32(buf, prefix, []byte("max.gauge32"), m.max, now)
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), m.count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(m.count)/now.Sub(m.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, []byte(".min.gauge32"), m.min, now)
+	buf = WriteUint32(buf, prefix, []byte(".mean.gauge32"), uint32(runningsum/uint64(m.count)), now)
+	buf = WriteUint32(buf, prefix, []byte(".max.gauge32"), m.max, now)
+	buf = WriteUint32(buf, prefix, []byte(".values.count32"), m.count, now)
+	buf = WriteFloat64(buf, prefix, []byte(".values.rate32"), float64(m.count)/now.Sub(m.since).Seconds(), now)
 	m.since = now
 
 	m.clear()

--- a/stats/meter32.go
+++ b/stats/meter32.go
@@ -108,9 +108,9 @@ func (m *Meter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 		p   float64
 		str string
 	}{
-		{0.50, "median.gauge32"},
-		{0.75, "p75.gauge32"},
-		{0.90, "p90.gauge32"},
+		{0.50, ".median.gauge32"},
+		{0.75, ".p75.gauge32"},
+		{0.90, ".p90.gauge32"},
 	}
 
 	pidx := 0

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -72,7 +72,6 @@ func (g *Graphite) reporter(interval int) {
 			fullPrefix.Reset()
 			fullPrefix.Write(g.prefix)
 			fullPrefix.WriteString(name)
-			fullPrefix.WriteRune('.')
 			buf = metric.ReportGraphite(fullPrefix.Bytes(), buf, now)
 		}
 

--- a/stats/process_reporter.go
+++ b/stats/process_reporter.go
@@ -31,18 +31,18 @@ func (m *ProcessReporter) ReportGraphite(prefix, buf []byte, now time.Time) []by
 		rss := uint64(stat.ResidentMemory())
 
 		// metric process.virtual_memory_bytes.gauge64 is a gauge of the process VSZ from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("virtual_memory_bytes.gauge64"), vsz, now)
+		buf = WriteUint64(buf, prefix, []byte(".virtual_memory_bytes.gauge64"), vsz, now)
 
 		// metric process.resident_memory_bytes.gauge64 is a gauge of the process RSS from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("resident_memory_bytes.gauge64"), rss, now)
+		buf = WriteUint64(buf, prefix, []byte(".resident_memory_bytes.gauge64"), rss, now)
 		// metric process.minor_page_faults.counter64 is the number of minor faults the process has made which have not required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("minor_page_faults.counter64"), uint64(stat.MinFlt), now)
+		buf = WriteUint64(buf, prefix, []byte(".minor_page_faults.counter64"), uint64(stat.MinFlt), now)
 
 		// metric process.major_page_faults.counter64 is the number of major faults the process has made which have required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("major_page_faults.counter64"), uint64(stat.MajFlt), now)
+		buf = WriteUint64(buf, prefix, []byte(".major_page_faults.counter64"), uint64(stat.MajFlt), now)
 
 		// metric is Total user and system CPU time spent in seconds
-		buf = WriteFloat64(buf, prefix, []byte("cpu_seconds_total.counter64"), stat.CPUTime(), now)
+		buf = WriteFloat64(buf, prefix, []byte(".cpu_seconds_total.counter64"), stat.CPUTime(), now)
 	}
 
 	return buf

--- a/stats/range32.go
+++ b/stats/range32.go
@@ -45,8 +45,8 @@ func (r *Range32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	r.Lock()
 	// if no values were seen, don't report anything to graphite
 	if r.valid {
-		buf = WriteUint32(buf, prefix, []byte("min.gauge32"), r.min, now)
-		buf = WriteUint32(buf, prefix, []byte("max.gauge32"), r.max, now)
+		buf = WriteUint32(buf, prefix, []byte(".min.gauge32"), r.min, now)
+		buf = WriteUint32(buf, prefix, []byte(".max.gauge32"), r.max, now)
 		r.min = math.MaxUint32
 		r.max = 0
 		r.valid = false

--- a/stats/timediff_reporter.go
+++ b/stats/timediff_reporter.go
@@ -29,6 +29,6 @@ func (g *TimeDiffReporter32) ReportGraphite(prefix, buf []byte, now time.Time) [
 	if now32 < target {
 		report = target - now32
 	}
-	buf = WriteUint32(buf, prefix, []byte("gauge32"), report, now)
+	buf = WriteUint32(buf, prefix, []byte(".gauge32"), report, now)
 	return buf
 }


### PR DESCRIPTION
While attempting to add `partition` tags to metrics in #1680, I discovered that the existing stats library does not work with tags, as the suffix is always tacked on the end of the metric, leaving us with stats like `sample.metric;key=value.gauge32` (as opposed to `sample.metric.gauge32;key=value` or `sample.metric;key=value;type=gauge32`).


This PR adds a `NewxxxWithTags()` function for gauges and counters, adding a `type` tag to those metrics instead of the current `.<type>` suffix.

Metrics other than counters and gauges have more complicated suffixes (`.min`, `.max`), so I'm punting for those at the moment and only addressing the trivial metrics.

Initial commits migrated `Gauge64` to use a struct like all other metrics do and move the extra `x` that precedes all suffixes out of the writer method so that it isn't automatically added when using tags.  You'll probably want to review this commit by commit.

