### PR TITLE
Ensure that metric id is always set during kafka ingestion

### DIFF
--- a/cmd/mt-gateway/ingest/metrics.go
+++ b/cmd/mt-gateway/ingest/metrics.go
@@ -89,6 +89,7 @@ func prepareIngest(in []*schema.MetricData, toPublish []*schema.MetricData) ([]*
 			promDiscards.Add(m.OrgId, err.Error())
 			continue
 		}
+		m.SetId()
 		metricTimestamp = getMetricsTimestampStat(m.OrgId)
 		metricTimestamp.ValueUint32(uint32(m.Time))
 		toPublish = append(toPublish, m)

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -276,13 +276,12 @@ func (m *mtPublisher) Publish(metrics []*schema.MetricData) error {
 
 	for _, metric := range metrics {
 		if metric.Interval == 0 {
-			if m.autoInterval {
-				_, s := m.schemas.Match(metric.Name, 0)
-				metric.Interval = s.Retentions.Rets[0].SecondsPerPoint
-			} else {
-				log.Error("interval is 0 but can't deduce interval automatically. this should never happen")
-				return errors.New("need to deduce interval but cannot")
-			}
+			log.Error("interval must be set before publishing")
+			return errors.New("interval must be set before publishing")
+		}
+		if metric.Id == "" {
+			log.Error("metric ID must be set before publishing")
+			return errors.New("metric ID must be set before publishing")
 		}
 
 		isMD := false

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -279,12 +279,12 @@ func (m *mtPublisher) Publish(metrics []*schema.MetricData) error {
 			if m.autoInterval {
 				_, s := m.schemas.Match(metric.Name, 0)
 				metric.Interval = s.Retentions.Rets[0].SecondsPerPoint
-				metric.SetId()
 			} else {
 				log.Error("interval is 0 but can't deduce interval automatically. this should never happen")
 				return errors.New("need to deduce interval but cannot")
 			}
 		}
+		metric.SetId()
 
 		isMD := false
 		isMP := false

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -284,7 +284,6 @@ func (m *mtPublisher) Publish(metrics []*schema.MetricData) error {
 				return errors.New("need to deduce interval but cannot")
 			}
 		}
-		metric.SetId()
 
 		isMD := false
 		isMP := false

--- a/publish/publish.go
+++ b/publish/publish.go
@@ -18,7 +18,10 @@ var (
 )
 
 type Publisher interface {
+	//Publish the given metrics.
+	//Requires that the metric interval and ID have been set
 	Publish(metrics []*schema.MetricData) error
+	//Type returns the type of system the Publisher publishes to
 	Type() string
 }
 


### PR DESCRIPTION
While generating fake metric with parrot for https://github.com/grafana/metrictank/pull/1680, kafka ingestion was failed due to the metric ID not being set.

This PR ensures that the metric ID is always set, instead of only setting it if `autoInterval` is true.