### PR TITLE
Logger middleware: support gzipped responses from graphite-web

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -11,14 +11,14 @@ import (
 
 func (s *Server) RegisterRoutes() {
 	r := s.Macaron
+	r.Use(middleware.RequestStats())
+	r.Use(middleware.Tracer(s.Tracer))
+	r.Use(middleware.OrgMiddleware(multiTenant))
+	r.Use(middleware.Logger())
 	if useGzip {
 		r.Use(gziper.Gziper())
 	}
-	r.Use(middleware.RequestStats())
-	r.Use(middleware.Tracer(s.Tracer))
 	r.Use(macaron.Renderer())
-	r.Use(middleware.OrgMiddleware(multiTenant))
-	r.Use(middleware.Logger())
 	r.Use(middleware.CorsHandler())
 	bind := binding.Bind
 	withOrg := middleware.RequireOrg()

--- a/util/compression.go
+++ b/util/compression.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+)
+
+func DecompressGzip(r io.Reader) (string, error) {
+	reader, err := gzip.NewReader(r)
+	if err != nil {
+		return "", err
+	}
+
+	unzipped, err := ioutil.ReadAll(reader)
+	return string(unzipped), err
+}


### PR DESCRIPTION
graphite-web can (and in my testing does) gzip compress its responses. When it errors and we want to log that error, metrictank needs to unzip the body.

Caveat: detecting gzip compression is done based on the `Content-Encoding` header which sometimes is set too early by the `gziper` middleware *before* compression has happened. We handle that case by logging the uncompressed error when decompression fails.