### PR TITLE
Push renderer to last position so that logger middleware properly captures all errors

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -16,10 +16,10 @@ func (s *Server) RegisterRoutes() {
 	}
 	r.Use(middleware.RequestStats())
 	r.Use(middleware.Tracer(s.Tracer))
-	r.Use(macaron.Renderer())
 	r.Use(middleware.OrgMiddleware(multiTenant))
 	r.Use(middleware.Logger())
 	r.Use(middleware.CorsHandler())
+	r.Use(macaron.Renderer())
 	bind := binding.Bind
 	withOrg := middleware.RequireOrg()
 	cBody := middleware.CaptureBody


### PR DESCRIPTION
When the handler (`renderMetrics` for example) does not call directly `response.Write` but instead `ctx.Error` that results in the logger middleware not being able to capture the response body. This is due to an incorrect ordering of the middlewares: the `macaron.Renderer()` needs to be set last (and the `logger` before).