### PR TITLE
Include traceID in logs for graphite requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/mdata/cache"
 	"github.com/grafana/metrictank/stats"
+	"github.com/grafana/metrictank/util"
 	opentracing "github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/macaron.v1"
@@ -159,4 +161,9 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	tc.SetKeepAlive(true)
 	tc.SetKeepAlivePeriod(3 * time.Minute)
 	return tc, nil
+}
+
+// write a log message with the requests traceID as a field in the log message.
+func LogWithTraceID(ctx context.Context) *log.Entry {
+	return log.WithField("traceID", util.ExtractTraceID(ctx))
 }

--- a/util/trace.go
+++ b/util/trace.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"context"
+)
+
+type TraceID struct{}
+
+func ExtractTraceID(ctx context.Context) string {
+	traceID := ctx.Value(TraceID{})
+	if traceID == nil {
+		return ""
+	}
+
+	return traceID.(string)
+}


### PR DESCRIPTION
To make troubleshooting easier, log messages generated while processing
a requests should include the requests TraceID.  To allow this, this PR
has made the following changes
- store the requests TraceID in the request's context.Context for easy retrival.
Though you can call opentracing.SpanFromContext(ctx), you cant easily
get the traceID from the span.
- if tracing is disabled, generate a new random traceID and add it to
the request context.  This will ensure that every log message for a
single request has the same TraceID value.
- add a LogWithTraceID(ctx) helper