### PR TITLE
Update 'GraphiteMetric' interface to support tags and better represent actual functionality

### DIFF
--- a/stats/bool.go
+++ b/stats/bool.go
@@ -36,8 +36,8 @@ func (b *Bool) Peek() bool {
 	return true
 }
 
-func (b *Bool) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (b *Bool) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&b.val)
-	buf = WriteUint32(buf, prefix, []byte("gauge1"), val, now)
+	buf = WriteUint32(buf, prefix, name, []byte(".gauge1"), tags, val, now)
 	return buf
 }

--- a/stats/counter32.go
+++ b/stats/counter32.go
@@ -33,8 +33,8 @@ func (c *Counter32) Peek() uint32 {
 	return atomic.LoadUint32(&c.val)
 }
 
-func (c *Counter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (c *Counter32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
-	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
+	buf = WriteUint32(buf, prefix, name, []byte(".counter32"), tags, val, now)
 	return buf
 }

--- a/stats/counter64.go
+++ b/stats/counter64.go
@@ -25,8 +25,8 @@ func (c *Counter64) AddUint64(val uint64) {
 	atomic.AddUint64(&c.val, val)
 }
 
-func (c *Counter64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (c *Counter64) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	val := atomic.LoadUint64(&c.val)
-	buf = WriteUint64(buf, prefix, []byte("counter64"), val, now)
+	buf = WriteUint64(buf, prefix, name, []byte(".counter64"), tags, val, now)
 	return buf
 }

--- a/stats/counterrate32.go
+++ b/stats/counterrate32.go
@@ -39,10 +39,10 @@ func (c *CounterRate32) Peek() uint32 {
 	return atomic.LoadUint32(&c.val)
 }
 
-func (c *CounterRate32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (c *CounterRate32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
-	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
-	buf = WriteFloat64(buf, prefix, []byte("rate32"), float64(val-c.prev)/now.Sub(c.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, name, []byte(".counter32"), tags, val, now)
+	buf = WriteFloat64(buf, prefix, name, []byte(".rate32"), tags, float64(val-c.prev)/now.Sub(c.since).Seconds(), now)
 
 	c.prev = val
 	c.since = now

--- a/stats/gauge32.go
+++ b/stats/gauge32.go
@@ -49,8 +49,8 @@ func (g *Gauge32) SetUint32(val uint32) {
 	atomic.StoreUint32(&g.val, val)
 }
 
-func (g *Gauge32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (g *Gauge32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&g.val)
-	buf = WriteUint32(buf, prefix, []byte("gauge32"), val, now)
+	buf = WriteUint32(buf, prefix, name, []byte(".gauge32"), tags, val, now)
 	return buf
 }

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -48,9 +48,9 @@ func (g *Gauge64) SetUint64(val uint64) {
 	atomic.StoreUint64((*uint64)(g), val)
 }
 
-func (g *Gauge64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (g *Gauge64) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	val := atomic.LoadUint64((*uint64)(g))
-	buf = WriteUint64(buf, prefix, []byte("gauge64"), val, now)
+	buf = WriteUint64(buf, prefix, name, []byte(".gauge64"), tags, val, now)
 	return buf
 }
 

--- a/stats/latencyhistogram12h32.go
+++ b/stats/latencyhistogram12h32.go
@@ -24,21 +24,21 @@ func (l *LatencyHistogram12h32) Value(t time.Duration) {
 	l.hist.AddDuration(t)
 }
 
-func (l *LatencyHistogram12h32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (l *LatencyHistogram12h32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	snap := l.hist.Snapshot()
 	// TODO: once we can actually do cool stuff (e.g. visualize) histogram bucket data, report it
 	// for now, only report the summaries :(
 	r, ok := l.hist.Report(snap)
 	if ok {
-		buf = WriteUint32(buf, prefix, []byte("latency.min.gauge32"), r.Min/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.mean.gauge32"), r.Mean/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.median.gauge32"), r.Median/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p75.gauge32"), r.P75/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p90.gauge32"), r.P90/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.max.gauge32"), r.Max/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.min.gauge32"), tags, r.Min/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.mean.gauge32"), tags, r.Mean/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.median.gauge32"), tags, r.Median/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.p75.gauge32"), tags, r.P75/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.p90.gauge32"), tags, r.P90/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.max.gauge32"), tags, r.Max/1000, now)
 	}
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), r.Count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, name, []byte(".values.count32"), tags, r.Count, now)
+	buf = WriteFloat64(buf, prefix, name, []byte(".values.rate32"), tags, float64(r.Count)/now.Sub(l.since).Seconds(), now)
 	l.since = now
 	return buf
 }

--- a/stats/latencyhistogram15s32.go
+++ b/stats/latencyhistogram15s32.go
@@ -27,22 +27,22 @@ func (l *LatencyHistogram15s32) Value(t time.Duration) {
 	l.hist.AddDuration(t)
 }
 
-func (l *LatencyHistogram15s32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (l *LatencyHistogram15s32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	snap := l.hist.Snapshot()
 	// TODO: once we can actually do cool stuff (e.g. visualize) histogram bucket data, report it
 	// for now, only report the summaries :(
 	r, ok := l.hist.Report(snap)
 	if ok {
 		sum := atomic.SwapUint64(&l.sum, 0)
-		buf = WriteUint32(buf, prefix, []byte("latency.min.gauge32"), r.Min/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.mean.gauge32"), uint32((sum / uint64(r.Count) / 1000)), now)
-		buf = WriteUint32(buf, prefix, []byte("latency.median.gauge32"), r.Median/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p75.gauge32"), r.P75/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p90.gauge32"), r.P90/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.max.gauge32"), r.Max/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.min.gauge32"), tags, r.Min/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.mean.gauge32"), tags, uint32((sum / uint64(r.Count) / 1000)), now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.median.gauge32"), tags, r.Median/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.p75.gauge32"), tags, r.P75/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.p90.gauge32"), tags, r.P90/1000, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".latency.max.gauge32"), tags, r.Max/1000, now)
 	}
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), r.Count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, name, []byte(".values.count32"), tags, r.Count, now)
+	buf = WriteFloat64(buf, prefix, name, []byte(".values.rate32"), tags, float64(r.Count)/now.Sub(l.since).Seconds(), now)
 
 	l.since = now
 	return buf

--- a/stats/meter32.go
+++ b/stats/meter32.go
@@ -92,7 +92,7 @@ func (m *Meter32) ValuesUint32(val, num uint32) {
 	m.Unlock()
 }
 
-func (m *Meter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (m *Meter32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	m.Lock()
 	if m.count == 0 {
 		m.Unlock()
@@ -123,16 +123,16 @@ func (m *Meter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 		runningsum += uint64(m.hist[key]) * uint64(key)
 		p := float64(runningcount) / float64(m.count)
 		for pidx < len(quantiles) && quantiles[pidx].p <= p {
-			buf = WriteUint32(buf, prefix, []byte(quantiles[pidx].str), key, now)
+			buf = WriteUint32(buf, prefix, name, []byte(quantiles[pidx].str), tags, key, now)
 			pidx++
 		}
 	}
 
-	buf = WriteUint32(buf, prefix, []byte("min.gauge32"), m.min, now)
-	buf = WriteUint32(buf, prefix, []byte("mean.gauge32"), uint32(runningsum/uint64(m.count)), now)
-	buf = WriteUint32(buf, prefix, []byte("max.gauge32"), m.max, now)
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), m.count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(m.count)/now.Sub(m.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, name, []byte(".min.gauge32"), tags, m.min, now)
+	buf = WriteUint32(buf, prefix, name, []byte(".mean.gauge32"), tags, uint32(runningsum/uint64(m.count)), now)
+	buf = WriteUint32(buf, prefix, name, []byte(".max.gauge32"), tags, m.max, now)
+	buf = WriteUint32(buf, prefix, name, []byte(".values.count32"), tags, m.count, now)
+	buf = WriteFloat64(buf, prefix, name, []byte(".values.rate32"), tags, float64(m.count)/now.Sub(m.since).Seconds(), now)
 	m.since = now
 
 	m.clear()

--- a/stats/out_devnull.go
+++ b/stats/out_devnull.go
@@ -10,7 +10,7 @@ func NewDevnull() {
 		buf := make([]byte, 0)
 		for now := range ticker {
 			for _, metric := range registry.list() {
-				metric.ReportGraphite(nil, buf[:], now)
+				metric.WriteGraphiteLine(nil, nil, buf[:], nil, now)
 			}
 		}
 	}()

--- a/stats/process_reporter.go
+++ b/stats/process_reporter.go
@@ -23,7 +23,7 @@ func NewProcessReporter() (*ProcessReporter, error) {
 	return registry.getOrAdd("process", &p).(*ProcessReporter), nil
 }
 
-func (m *ProcessReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (m *ProcessReporter) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	stat, err := m.proc.NewStat()
 
 	if err == nil {
@@ -31,18 +31,18 @@ func (m *ProcessReporter) ReportGraphite(prefix, buf []byte, now time.Time) []by
 		rss := uint64(stat.ResidentMemory())
 
 		// metric process.virtual_memory_bytes.gauge64 is a gauge of the process VSZ from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("virtual_memory_bytes.gauge64"), vsz, now)
+		buf = WriteUint64(buf, prefix, name, []byte(".virtual_memory_bytes.gauge64"), tags, vsz, now)
 
 		// metric process.resident_memory_bytes.gauge64 is a gauge of the process RSS from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("resident_memory_bytes.gauge64"), rss, now)
+		buf = WriteUint64(buf, prefix, name, []byte(".resident_memory_bytes.gauge64"), tags, rss, now)
 		// metric process.minor_page_faults.counter64 is the number of minor faults the process has made which have not required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("minor_page_faults.counter64"), uint64(stat.MinFlt), now)
+		buf = WriteUint64(buf, prefix, name, []byte(".minor_page_faults.counter64"), tags, uint64(stat.MinFlt), now)
 
 		// metric process.major_page_faults.counter64 is the number of major faults the process has made which have required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("major_page_faults.counter64"), uint64(stat.MajFlt), now)
+		buf = WriteUint64(buf, prefix, name, []byte(".major_page_faults.counter64"), tags, uint64(stat.MajFlt), now)
 
 		// metric is Total user and system CPU time spent in seconds
-		buf = WriteFloat64(buf, prefix, []byte("cpu_seconds_total.counter64"), stat.CPUTime(), now)
+		buf = WriteFloat64(buf, prefix, name, []byte(".cpu_seconds_total.counter64"), tags, stat.CPUTime(), now)
 	}
 
 	return buf

--- a/stats/range32.go
+++ b/stats/range32.go
@@ -41,12 +41,12 @@ func (r *Range32) ValueUint32(val uint32) {
 	r.Unlock()
 }
 
-func (r *Range32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (r *Range32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	r.Lock()
 	// if no values were seen, don't report anything to graphite
 	if r.valid {
-		buf = WriteUint32(buf, prefix, []byte("min.gauge32"), r.min, now)
-		buf = WriteUint32(buf, prefix, []byte("max.gauge32"), r.max, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".min.gauge32"), tags, r.min, now)
+		buf = WriteUint32(buf, prefix, name, []byte(".max.gauge32"), tags, r.max, now)
 		r.min = math.MaxUint32
 		r.max = 0
 		r.valid = false

--- a/stats/timediff_reporter.go
+++ b/stats/timediff_reporter.go
@@ -22,13 +22,13 @@ func (g *TimeDiffReporter32) Set(target uint32) {
 	atomic.StoreUint32(&g.target, target)
 }
 
-func (g *TimeDiffReporter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (g *TimeDiffReporter32) WriteGraphiteLine(buf, prefix, name, tags []byte, now time.Time) []byte {
 	target := atomic.LoadUint32(&g.target)
 	now32 := uint32(now.Unix())
 	report := uint32(0)
 	if now32 < target {
 		report = target - now32
 	}
-	buf = WriteUint32(buf, prefix, []byte("gauge32"), report, now)
+	buf = WriteUint32(buf, prefix, name, []byte(".gauge32"), tags, report, now)
 	return buf
 }

--- a/stats/write.go
+++ b/stats/write.go
@@ -5,9 +5,20 @@ import (
 	"time"
 )
 
-func WriteFloat64(buf, prefix, key []byte, val float64, now time.Time) []byte {
+// Write* functions append a graphite metric line to the given buffer.
+// `buf` is the incoming buffer to be appended to
+// `prefix` is an optional prefix to the metric name which must have a trailing '.' if present
+// `name` is the required name of the metric. It should not have a leading or trailing '.' or a trailing ';'
+// `suffix` is an optional suffix to the metric name which must have a leading '.' if present.  It should not have a trailing ';'
+// `tags` is an optional list of tags which must have a leading ';' if present.
+// `val` is the value of the metric
+// `now` is the time that the metrics should be reported at
+// returns `buf` with the new metric line appended
+func WriteFloat64(buf, prefix, name, suffix, tags []byte, val float64, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendFloat(buf, val, 'f', -1, 64)
 	buf = append(buf, ' ')
@@ -15,9 +26,11 @@ func WriteFloat64(buf, prefix, key []byte, val float64, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteUint32(buf, prefix, key []byte, val uint32, now time.Time) []byte {
+func WriteUint32(buf, prefix, name, suffix, tags []byte, val uint32, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendUint(buf, uint64(val), 10)
 	buf = append(buf, ' ')
@@ -25,9 +38,11 @@ func WriteUint32(buf, prefix, key []byte, val uint32, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteUint64(buf, prefix, key []byte, val uint64, now time.Time) []byte {
+func WriteUint64(buf, prefix, name, suffix, tags []byte, val uint64, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendUint(buf, val, 10)
 	buf = append(buf, ' ')
@@ -35,9 +50,11 @@ func WriteUint64(buf, prefix, key []byte, val uint64, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteInt32(buf, prefix, key []byte, val int32, now time.Time) []byte {
+func WriteInt32(buf, prefix, name, suffix, tags []byte, val int32, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendInt(buf, int64(val), 10)
 	buf = append(buf, ' ')


### PR DESCRIPTION
This PR changes the primary method in `stats.GraphiteMetric` to better represent what the method actually does... `ReportGraphite` implies that some sort of I/O is happening, when in fact it's actually just appending a metric line to a buffer.

The new name (`WriteGraphiteLine` better represents that functionality, and adds some additional parameters to support tags and make it clearer what the function is doing.

The other major changes are at the call site of `WriteGraphiteLine`, and the `Write*` functions which `WriteGraphiteLine` delegate to.

To ease review, the first commit contains the changes to the interface and call sites, and the second commit contains updates of structs implementing the interface.

Note: while we're not actually using tags anywhere in the codebase, they would be instantiated by just passing in the metric name with the tags included

```go
   metric := stats.NewCounter32("some.metric;key=value")
```

I did some local testing in docker to ensure that metrics were still being reported
<img width="1470" alt="Screen Shot 2020-02-27 at 4 14 26 PM" src="https://user-images.githubusercontent.com/131809/75487325-3f3cfe00-597c-11ea-8af4-bf57594dd29d.png">



Inspired by issues I ran into while working on #1685.