### PR TITLE
yet another WIP refactor for stats tagging that stores the name/tags within the metric itself

### DIFF
--- a/stats/bool.go
+++ b/stats/bool.go
@@ -6,11 +6,22 @@ import (
 )
 
 type Bool struct {
-	val uint32
+	val  uint32
+	name []byte
+	tags []byte
 }
 
 func NewBool(name string) *Bool {
-	return registry.getOrAdd(name, &Bool{}).(*Bool)
+	return registry.getOrAdd(name, &Bool{
+		name: []byte(name),
+	}).(*Bool)
+}
+
+func NewBoolWithTags(name, tags string) *Bool {
+	return registry.getOrAdd(name, &Bool{
+		name: []byte(name),
+		tags: []byte(tags),
+	}).(*Bool)
 }
 
 func (b *Bool) SetTrue() {
@@ -38,6 +49,6 @@ func (b *Bool) Peek() bool {
 
 func (b *Bool) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&b.val)
-	buf = WriteUint32(buf, prefix, []byte("gauge1"), val, now)
+	buf = WriteUint32(buf, prefix, b.name, []byte(".gauge1"), b.tags, val, now)
 	return buf
 }

--- a/stats/latencyhistogram12h32.go
+++ b/stats/latencyhistogram12h32.go
@@ -10,12 +10,25 @@ import (
 type LatencyHistogram12h32 struct {
 	hist  hist12h.Hist12h
 	since time.Time
+	name  []byte
+	tags  []byte
 }
 
 func NewLatencyHistogram12h32(name string) *LatencyHistogram12h32 {
 	return registry.getOrAdd(name, &LatencyHistogram12h32{
 		hist:  hist12h.New(),
 		since: time.Now(),
+		name:  []byte(name),
+	},
+	).(*LatencyHistogram12h32)
+}
+
+func NewLatencyHistogram12h32WithTags(name, tags string) *LatencyHistogram12h32 {
+	return registry.getOrAdd(name, &LatencyHistogram12h32{
+		hist:  hist12h.New(),
+		since: time.Now(),
+		name:  []byte(name),
+		tags:  []byte(tags),
 	},
 	).(*LatencyHistogram12h32)
 }
@@ -30,15 +43,15 @@ func (l *LatencyHistogram12h32) ReportGraphite(prefix, buf []byte, now time.Time
 	// for now, only report the summaries :(
 	r, ok := l.hist.Report(snap)
 	if ok {
-		buf = WriteUint32(buf, prefix, []byte("latency.min.gauge32"), r.Min/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.mean.gauge32"), r.Mean/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.median.gauge32"), r.Median/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p75.gauge32"), r.P75/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p90.gauge32"), r.P90/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.max.gauge32"), r.Max/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.min.gauge32"), l.tags, r.Min/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.mean.gauge32"), l.tags, r.Mean/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.median.gauge32"), l.tags, r.Median/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.p75.gauge32"), l.tags, r.P75/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.p90.gauge32"), l.tags, r.P90/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.max.gauge32"), l.tags, r.Max/1000, now)
 	}
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), r.Count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, l.name, []byte(".values.count32"), l.tags, r.Count, now)
+	buf = WriteFloat64(buf, prefix, l.name, []byte(".values.rate32"), l.tags, float64(r.Count)/now.Sub(l.since).Seconds(), now)
 	l.since = now
 	return buf
 }

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -1,7 +1,6 @@
 package stats
 
 import (
-	"bytes"
 	"io"
 	"net"
 	"sync"
@@ -67,13 +66,8 @@ func (g *Graphite) reporter(interval int) {
 
 		buf := make([]byte, 0)
 
-		var fullPrefix bytes.Buffer
-		for name, metric := range registry.list() {
-			fullPrefix.Reset()
-			fullPrefix.Write(g.prefix)
-			fullPrefix.WriteString(name)
-			fullPrefix.WriteRune('.')
-			buf = metric.ReportGraphite(fullPrefix.Bytes(), buf, now)
+		for _, metric := range registry.list() {
+			buf = metric.ReportGraphite(g.prefix, buf, now)
 		}
 
 		genDataDuration.Set(int(time.Since(pre).Nanoseconds()))

--- a/stats/write.go
+++ b/stats/write.go
@@ -5,9 +5,11 @@ import (
 	"time"
 )
 
-func WriteFloat64(buf, prefix, key []byte, val float64, now time.Time) []byte {
+func WriteFloat64(buf, prefix, name, suffix, tags []byte, val float64, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendFloat(buf, val, 'f', -1, 64)
 	buf = append(buf, ' ')
@@ -15,9 +17,11 @@ func WriteFloat64(buf, prefix, key []byte, val float64, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteUint32(buf, prefix, key []byte, val uint32, now time.Time) []byte {
+func WriteUint32(buf, prefix, name, suffix, tags[]byte, val uint32, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendUint(buf, uint64(val), 10)
 	buf = append(buf, ' ')
@@ -25,9 +29,11 @@ func WriteUint32(buf, prefix, key []byte, val uint32, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteUint64(buf, prefix, key []byte, val uint64, now time.Time) []byte {
+func WriteUint64(buf, prefix, name, suffix, tags []byte, val uint64, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendUint(buf, val, 10)
 	buf = append(buf, ' ')
@@ -35,9 +41,11 @@ func WriteUint64(buf, prefix, key []byte, val uint64, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteInt32(buf, prefix, key []byte, val int32, now time.Time) []byte {
+func WriteInt32(buf, prefix, name, suffix, tags []byte, val int32, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendInt(buf, int64(val), 10)
 	buf = append(buf, ' ')


### PR DESCRIPTION
Alternative to https://github.com/grafana/metrictank/pull/1696 that stores the name/tags within the metric, allowing it to be written without having to pass it's own name in.

Also includes a separate tag friendly constructor.

This version doesn't compile, just demonstrating what metrics/API look like to validate before applying more broadly