### PR TITLE
Reorder params of `GraphiteMetric.ReportGraphite`

### DIFF
--- a/stats/bool.go
+++ b/stats/bool.go
@@ -36,7 +36,7 @@ func (b *Bool) Peek() bool {
 	return true
 }
 
-func (b *Bool) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (b *Bool) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&b.val)
 	buf = WriteUint32(buf, prefix, []byte("gauge1"), val, now)
 	return buf

--- a/stats/counter32.go
+++ b/stats/counter32.go
@@ -33,7 +33,7 @@ func (c *Counter32) Peek() uint32 {
 	return atomic.LoadUint32(&c.val)
 }
 
-func (c *Counter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (c *Counter32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
 	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
 	return buf

--- a/stats/counter64.go
+++ b/stats/counter64.go
@@ -25,7 +25,7 @@ func (c *Counter64) AddUint64(val uint64) {
 	atomic.AddUint64(&c.val, val)
 }
 
-func (c *Counter64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (c *Counter64) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint64(&c.val)
 	buf = WriteUint64(buf, prefix, []byte("counter64"), val, now)
 	return buf

--- a/stats/counterrate32.go
+++ b/stats/counterrate32.go
@@ -39,7 +39,7 @@ func (c *CounterRate32) Peek() uint32 {
 	return atomic.LoadUint32(&c.val)
 }
 
-func (c *CounterRate32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (c *CounterRate32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
 	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
 	buf = WriteFloat64(buf, prefix, []byte("rate32"), float64(val-c.prev)/now.Sub(c.since).Seconds(), now)

--- a/stats/gauge32.go
+++ b/stats/gauge32.go
@@ -49,7 +49,7 @@ func (g *Gauge32) SetUint32(val uint32) {
 	atomic.StoreUint32(&g.val, val)
 }
 
-func (g *Gauge32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (g *Gauge32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&g.val)
 	buf = WriteUint32(buf, prefix, []byte("gauge32"), val, now)
 	return buf

--- a/stats/gauge64.go
+++ b/stats/gauge64.go
@@ -48,7 +48,7 @@ func (g *Gauge64) SetUint64(val uint64) {
 	atomic.StoreUint64((*uint64)(g), val)
 }
 
-func (g *Gauge64) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (g *Gauge64) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint64((*uint64)(g))
 	buf = WriteUint64(buf, prefix, []byte("gauge64"), val, now)
 	return buf

--- a/stats/latencyhistogram12h32.go
+++ b/stats/latencyhistogram12h32.go
@@ -24,7 +24,7 @@ func (l *LatencyHistogram12h32) Value(t time.Duration) {
 	l.hist.AddDuration(t)
 }
 
-func (l *LatencyHistogram12h32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (l *LatencyHistogram12h32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	snap := l.hist.Snapshot()
 	// TODO: once we can actually do cool stuff (e.g. visualize) histogram bucket data, report it
 	// for now, only report the summaries :(

--- a/stats/latencyhistogram15s32.go
+++ b/stats/latencyhistogram15s32.go
@@ -27,7 +27,7 @@ func (l *LatencyHistogram15s32) Value(t time.Duration) {
 	l.hist.AddDuration(t)
 }
 
-func (l *LatencyHistogram15s32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (l *LatencyHistogram15s32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	snap := l.hist.Snapshot()
 	// TODO: once we can actually do cool stuff (e.g. visualize) histogram bucket data, report it
 	// for now, only report the summaries :(

--- a/stats/memory_reporter.go
+++ b/stats/memory_reporter.go
@@ -45,7 +45,7 @@ func getGcPercent() int {
 	return val
 }
 
-func (m *MemoryReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (m *MemoryReporter) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	m.mem = m.timeBoundGetMemStats().(runtime.MemStats)
 	gcPercent := getGcPercent()
 

--- a/stats/meter32.go
+++ b/stats/meter32.go
@@ -92,7 +92,7 @@ func (m *Meter32) ValuesUint32(val, num uint32) {
 	m.Unlock()
 }
 
-func (m *Meter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (m *Meter32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	m.Lock()
 	if m.count == 0 {
 		m.Unlock()

--- a/stats/out_devnull.go
+++ b/stats/out_devnull.go
@@ -10,7 +10,7 @@ func NewDevnull() {
 		buf := make([]byte, 0)
 		for now := range ticker {
 			for _, metric := range registry.list() {
-				metric.ReportGraphite(nil, buf[:], now)
+				metric.ReportGraphite(buf[:], nil, now)
 			}
 		}
 	}()

--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -20,7 +20,7 @@ var (
 
 type GraphiteMetric interface {
 	// Report the measurements in graphite format and reset measurements for the next interval if needed
-	ReportGraphite(prefix []byte, buf []byte, now time.Time) []byte
+	ReportGraphite(buf, prefix []byte, now time.Time) []byte
 }
 
 type Graphite struct {
@@ -73,7 +73,7 @@ func (g *Graphite) reporter(interval int) {
 			fullPrefix.Write(g.prefix)
 			fullPrefix.WriteString(name)
 			fullPrefix.WriteRune('.')
-			buf = metric.ReportGraphite(fullPrefix.Bytes(), buf, now)
+			buf = metric.ReportGraphite(buf, fullPrefix.Bytes(), now)
 		}
 
 		genDataDuration.Set(int(time.Since(pre).Nanoseconds()))

--- a/stats/process_reporter.go
+++ b/stats/process_reporter.go
@@ -23,7 +23,7 @@ func NewProcessReporter() (*ProcessReporter, error) {
 	return registry.getOrAdd("process", &p).(*ProcessReporter), nil
 }
 
-func (m *ProcessReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (m *ProcessReporter) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	stat, err := m.proc.NewStat()
 
 	if err == nil {

--- a/stats/range32.go
+++ b/stats/range32.go
@@ -41,7 +41,7 @@ func (r *Range32) ValueUint32(val uint32) {
 	r.Unlock()
 }
 
-func (r *Range32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (r *Range32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	r.Lock()
 	// if no values were seen, don't report anything to graphite
 	if r.valid {

--- a/stats/timediff_reporter.go
+++ b/stats/timediff_reporter.go
@@ -22,7 +22,7 @@ func (g *TimeDiffReporter32) Set(target uint32) {
 	atomic.StoreUint32(&g.target, target)
 }
 
-func (g *TimeDiffReporter32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+func (g *TimeDiffReporter32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
 	target := atomic.LoadUint32(&g.target)
 	now32 := uint32(now.Unix())
 	report := uint32(0)


### PR DESCRIPTION
The order of parameters is inconsistent between `GraphiteMetric.ReportGraphite` and the `Write*` methods in `stats/write.go`

https://github.com/grafana/metrictank/blob/5738869139b5ed55c3586537cbbe6f91bb92a027/stats/out_graphite.go#L23

https://github.com/grafana/metrictank/blob/5738869139b5ed55c3586537cbbe6f91bb92a027/stats/write.go#L8

This PR updates `GraphiteMetric.ReportGraphite` to have `buf` as the first parameter, as that is the value that we are essentially mutating and returning.

Changes made automatically by intellij's `Change Signature` refactor

(more related PRs to come, keeping them short and easily reviewable)