### PR TITLE
Additional stats refactoring to support tags

### DIFF
--- a/stats/bool.go
+++ b/stats/bool.go
@@ -6,11 +6,15 @@ import (
 )
 
 type Bool struct {
-	val uint32
+	val  uint32
+	name []byte
+	tags []byte
 }
 
 func NewBool(name string) *Bool {
-	return registry.getOrAdd(name, &Bool{}).(*Bool)
+	return registry.getOrAdd(name, &Bool{
+		name: []byte(name),
+	}).(*Bool)
 }
 
 func (b *Bool) SetTrue() {
@@ -36,8 +40,8 @@ func (b *Bool) Peek() bool {
 	return true
 }
 
-func (b *Bool) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (b *Bool) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&b.val)
-	buf = WriteUint32(buf, prefix, []byte("gauge1"), val, now)
+	buf = WriteUint32(buf, prefix, b.name, []byte(".gauge1"), b.tags, val, now)
 	return buf
 }

--- a/stats/counter32.go
+++ b/stats/counter32.go
@@ -6,11 +6,15 @@ import (
 )
 
 type Counter32 struct {
-	val uint32
+	val  uint32
+	name []byte
+	tags []byte
 }
 
 func NewCounter32(name string) *Counter32 {
-	return registry.getOrAdd(name, &Counter32{}).(*Counter32)
+	return registry.getOrAdd(name, &Counter32{
+		name: []byte(name),
+	}).(*Counter32)
 }
 
 func (c *Counter32) SetUint32(val uint32) {
@@ -33,8 +37,8 @@ func (c *Counter32) Peek() uint32 {
 	return atomic.LoadUint32(&c.val)
 }
 
-func (c *Counter32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (c *Counter32) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
-	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
+	buf = WriteUint32(buf, prefix, c.name, []byte(".counter32"), c.tags, val, now)
 	return buf
 }

--- a/stats/counter64.go
+++ b/stats/counter64.go
@@ -6,11 +6,15 @@ import (
 )
 
 type Counter64 struct {
-	val uint64
+	val  uint64
+	name []byte
+	tags []byte
 }
 
 func NewCounter64(name string) *Counter64 {
-	return registry.getOrAdd(name, &Counter64{}).(*Counter64)
+	return registry.getOrAdd(name, &Counter64{
+		name: []byte(name),
+	}).(*Counter64)
 }
 
 func (c *Counter64) SetUint64(val uint64) {
@@ -25,8 +29,8 @@ func (c *Counter64) AddUint64(val uint64) {
 	atomic.AddUint64(&c.val, val)
 }
 
-func (c *Counter64) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (c *Counter64) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint64(&c.val)
-	buf = WriteUint64(buf, prefix, []byte("counter64"), val, now)
+	buf = WriteUint64(buf, prefix, c.name, []byte(".counter64"), c.tags, val, now)
 	return buf
 }

--- a/stats/counterrate32.go
+++ b/stats/counterrate32.go
@@ -10,11 +10,14 @@ type CounterRate32 struct {
 	prev  uint32
 	val   uint32
 	since time.Time
+	name  []byte
+	tags  []byte
 }
 
 func NewCounterRate32(name string) *CounterRate32 {
 	c := CounterRate32{
 		since: time.Now(),
+		name:  []byte(name),
 	}
 	return registry.getOrAdd(name, &c).(*CounterRate32)
 }
@@ -39,10 +42,10 @@ func (c *CounterRate32) Peek() uint32 {
 	return atomic.LoadUint32(&c.val)
 }
 
-func (c *CounterRate32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (c *CounterRate32) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&c.val)
-	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
-	buf = WriteFloat64(buf, prefix, []byte("rate32"), float64(val-c.prev)/now.Sub(c.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, c.name, []byte(".counter32"), c.tags, val, now)
+	buf = WriteFloat64(buf, prefix, c.name, []byte(".rate32"), c.tags, float64(val-c.prev)/now.Sub(c.since).Seconds(), now)
 
 	c.prev = val
 	c.since = now

--- a/stats/gauge32.go
+++ b/stats/gauge32.go
@@ -6,11 +6,15 @@ import (
 )
 
 type Gauge32 struct {
-	val uint32
+	val  uint32
+	name []byte
+	tags []byte
 }
 
 func NewGauge32(name string) *Gauge32 {
-	return registry.getOrAdd(name, &Gauge32{}).(*Gauge32)
+	return registry.getOrAdd(name, &Gauge32{
+		name: []byte(name),
+	}).(*Gauge32)
 }
 
 func (g *Gauge32) Inc() {
@@ -49,8 +53,8 @@ func (g *Gauge32) SetUint32(val uint32) {
 	atomic.StoreUint32(&g.val, val)
 }
 
-func (g *Gauge32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (g *Gauge32) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	val := atomic.LoadUint32(&g.val)
-	buf = WriteUint32(buf, prefix, []byte("gauge32"), val, now)
+	buf = WriteUint32(buf, prefix, g.name, []byte(".gauge32"), g.tags, val, now)
 	return buf
 }

--- a/stats/latencyhistogram12h32.go
+++ b/stats/latencyhistogram12h32.go
@@ -10,12 +10,15 @@ import (
 type LatencyHistogram12h32 struct {
 	hist  hist12h.Hist12h
 	since time.Time
+	name  []byte
+	tags  []byte
 }
 
 func NewLatencyHistogram12h32(name string) *LatencyHistogram12h32 {
 	return registry.getOrAdd(name, &LatencyHistogram12h32{
 		hist:  hist12h.New(),
 		since: time.Now(),
+		name:  []byte(name),
 	},
 	).(*LatencyHistogram12h32)
 }
@@ -24,21 +27,21 @@ func (l *LatencyHistogram12h32) Value(t time.Duration) {
 	l.hist.AddDuration(t)
 }
 
-func (l *LatencyHistogram12h32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (l *LatencyHistogram12h32) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	snap := l.hist.Snapshot()
 	// TODO: once we can actually do cool stuff (e.g. visualize) histogram bucket data, report it
 	// for now, only report the summaries :(
 	r, ok := l.hist.Report(snap)
 	if ok {
-		buf = WriteUint32(buf, prefix, []byte("latency.min.gauge32"), r.Min/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.mean.gauge32"), r.Mean/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.median.gauge32"), r.Median/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p75.gauge32"), r.P75/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p90.gauge32"), r.P90/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.max.gauge32"), r.Max/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.min.gauge32"), l.tags, r.Min/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.mean.gauge32"), l.tags, r.Mean/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.median.gauge32"), l.tags, r.Median/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.p75.gauge32"), l.tags, r.P75/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.p90.gauge32"), l.tags, r.P90/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.max.gauge32"), l.tags, r.Max/1000, now)
 	}
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), r.Count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, l.name, []byte(".values.count32"), l.tags, r.Count, now)
+	buf = WriteFloat64(buf, prefix, l.name, []byte(".values.rate32"), l.tags, float64(r.Count)/now.Sub(l.since).Seconds(), now)
 	l.since = now
 	return buf
 }

--- a/stats/latencyhistogram15s32.go
+++ b/stats/latencyhistogram15s32.go
@@ -12,12 +12,15 @@ type LatencyHistogram15s32 struct {
 	hist  hist15s.Hist15s
 	since time.Time
 	sum   uint64 // in micros. to generate more accurate mean
+	name  []byte
+	tags  []byte
 }
 
 func NewLatencyHistogram15s32(name string) *LatencyHistogram15s32 {
 	return registry.getOrAdd(name, &LatencyHistogram15s32{
 		hist:  hist15s.New(),
 		since: time.Now(),
+		name:  []byte(name),
 	},
 	).(*LatencyHistogram15s32)
 }
@@ -27,22 +30,22 @@ func (l *LatencyHistogram15s32) Value(t time.Duration) {
 	l.hist.AddDuration(t)
 }
 
-func (l *LatencyHistogram15s32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (l *LatencyHistogram15s32) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	snap := l.hist.Snapshot()
 	// TODO: once we can actually do cool stuff (e.g. visualize) histogram bucket data, report it
 	// for now, only report the summaries :(
 	r, ok := l.hist.Report(snap)
 	if ok {
 		sum := atomic.SwapUint64(&l.sum, 0)
-		buf = WriteUint32(buf, prefix, []byte("latency.min.gauge32"), r.Min/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.mean.gauge32"), uint32((sum / uint64(r.Count) / 1000)), now)
-		buf = WriteUint32(buf, prefix, []byte("latency.median.gauge32"), r.Median/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p75.gauge32"), r.P75/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.p90.gauge32"), r.P90/1000, now)
-		buf = WriteUint32(buf, prefix, []byte("latency.max.gauge32"), r.Max/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.min.gauge32"), l.tags, r.Min/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.mean.gauge32"), l.tags, uint32((sum / uint64(r.Count) / 1000)), now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.median.gauge32"), l.tags, r.Median/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.p75.gauge32"), l.tags, r.P75/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.p90.gauge32"), l.tags, r.P90/1000, now)
+		buf = WriteUint32(buf, prefix, l.name, []byte(".latency.max.gauge32"), l.tags, r.Max/1000, now)
 	}
-	buf = WriteUint32(buf, prefix, []byte("values.count32"), r.Count, now)
-	buf = WriteFloat64(buf, prefix, []byte("values.rate32"), float64(r.Count)/now.Sub(l.since).Seconds(), now)
+	buf = WriteUint32(buf, prefix, l.name, []byte(".values.count32"), l.tags, r.Count, now)
+	buf = WriteFloat64(buf, prefix, l.name, []byte(".values.rate32"), l.tags, float64(r.Count)/now.Sub(l.since).Seconds(), now)
 
 	l.since = now
 	return buf

--- a/stats/memory_reporter.go
+++ b/stats/memory_reporter.go
@@ -45,37 +45,37 @@ func getGcPercent() int {
 	return val
 }
 
-func (m *MemoryReporter) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (m *MemoryReporter) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	m.mem = m.timeBoundGetMemStats().(runtime.MemStats)
 	gcPercent := getGcPercent()
 
 	// metric memory.total_bytes_allocated is a counter of total number of bytes allocated during process lifetime
-	buf = WriteUint64(buf, prefix, []byte("total_bytes_allocated.counter64"), m.mem.TotalAlloc, now)
+	buf = WriteUint64(buf, prefix, []byte("total_bytes_allocated.counter64"), nil, nil, m.mem.TotalAlloc, now)
 
 	// metric memory.bytes_allocated_on_heap is a gauge of currently allocated (within the runtime) memory.
-	buf = WriteUint64(buf, prefix, []byte("bytes.allocated_in_heap.gauge64"), m.mem.Alloc, now)
+	buf = WriteUint64(buf, prefix, []byte("bytes.allocated_in_heap.gauge64"), nil, nil, m.mem.Alloc, now)
 
 	// metric memory.bytes.obtained_from_sys is the number of bytes currently obtained from the system by the process.  This is what the profiletrigger looks at.
-	buf = WriteUint64(buf, prefix, []byte("bytes.obtained_from_sys.gauge64"), m.mem.Sys, now)
+	buf = WriteUint64(buf, prefix, []byte("bytes.obtained_from_sys.gauge64"), nil, nil, m.mem.Sys, now)
 
 	// metric memory.total_gc_cycles is a counter of the number of GC cycles since process start
-	buf = WriteUint32(buf, prefix, []byte("total_gc_cycles.counter64"), m.mem.NumGC, now)
+	buf = WriteUint32(buf, prefix, []byte("total_gc_cycles.counter64"), nil, nil, m.mem.NumGC, now)
 
 	// metric memory.gc.cpu_fraction is how much cpu is consumed by the GC across process lifetime, in pro-mille
-	buf = WriteUint32(buf, prefix, []byte("gc.cpu_fraction.gauge32"), uint32(1000*m.mem.GCCPUFraction), now)
+	buf = WriteUint32(buf, prefix, []byte("gc.cpu_fraction.gauge32"), nil, nil, uint32(1000*m.mem.GCCPUFraction), now)
 
 	// metric memory.gc.heap_objects is how many objects are allocated on the heap, it's a key indicator for GC workload
-	buf = WriteUint64(buf, prefix, []byte("gc.heap_objects.gauge64"), m.mem.HeapObjects, now)
+	buf = WriteUint64(buf, prefix, []byte("gc.heap_objects.gauge64"), nil, nil, m.mem.HeapObjects, now)
 
 	// there was no new GC run, we should only report points to represent actual runs
 	if m.gcCyclesTotal != m.mem.NumGC {
 		// metric memory.gc.last_duration is the duration of the last GC STW pause in nanoseconds
-		buf = WriteUint64(buf, prefix, []byte("gc.last_duration.gauge64"), m.mem.PauseNs[(m.mem.NumGC+255)%256], now)
+		buf = WriteUint64(buf, prefix, []byte("gc.last_duration.gauge64"), nil, nil, m.mem.PauseNs[(m.mem.NumGC+255)%256], now)
 		m.gcCyclesTotal = m.mem.NumGC
 	}
 
 	// metric memory.gc.gogc is the current GOGC value (derived from the GOGC environment variable)
-	buf = WriteInt32(buf, prefix, []byte("gc.gogc.sgauge32"), int32(gcPercent), now)
+	buf = WriteInt32(buf, prefix, []byte("gc.gogc.sgauge32"), nil, nil, int32(gcPercent), now)
 
 	return buf
 }

--- a/stats/out_devnull.go
+++ b/stats/out_devnull.go
@@ -10,7 +10,7 @@ func NewDevnull() {
 		buf := make([]byte, 0)
 		for now := range ticker {
 			for _, metric := range registry.list() {
-				metric.ReportGraphite(buf[:], nil, now)
+				metric.WriteGraphiteLine(buf[:], nil, now)
 			}
 		}
 	}()

--- a/stats/process_reporter.go
+++ b/stats/process_reporter.go
@@ -23,7 +23,7 @@ func NewProcessReporter() (*ProcessReporter, error) {
 	return registry.getOrAdd("process", &p).(*ProcessReporter), nil
 }
 
-func (m *ProcessReporter) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (m *ProcessReporter) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	stat, err := m.proc.NewStat()
 
 	if err == nil {
@@ -31,18 +31,18 @@ func (m *ProcessReporter) ReportGraphite(buf, prefix []byte, now time.Time) []by
 		rss := uint64(stat.ResidentMemory())
 
 		// metric process.virtual_memory_bytes.gauge64 is a gauge of the process VSZ from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("virtual_memory_bytes.gauge64"), vsz, now)
+		buf = WriteUint64(buf, prefix, []byte("virtual_memory_bytes.gauge64"), nil, nil, vsz, now)
 
 		// metric process.resident_memory_bytes.gauge64 is a gauge of the process RSS from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("resident_memory_bytes.gauge64"), rss, now)
+		buf = WriteUint64(buf, prefix, []byte("resident_memory_bytes.gauge64"), nil, nil, rss, now)
 		// metric process.minor_page_faults.counter64 is the number of minor faults the process has made which have not required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("minor_page_faults.counter64"), uint64(stat.MinFlt), now)
+		buf = WriteUint64(buf, prefix, []byte("minor_page_faults.counter64"), nil, nil, uint64(stat.MinFlt), now)
 
 		// metric process.major_page_faults.counter64 is the number of major faults the process has made which have required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("major_page_faults.counter64"), uint64(stat.MajFlt), now)
+		buf = WriteUint64(buf, prefix, []byte("major_page_faults.counter64"), nil, nil, uint64(stat.MajFlt), now)
 
 		// metric is Total user and system CPU time spent in seconds
-		buf = WriteFloat64(buf, prefix, []byte("cpu_seconds_total.counter64"), stat.CPUTime(), now)
+		buf = WriteFloat64(buf, prefix, []byte("cpu_seconds_total.counter64"), nil, nil, stat.CPUTime(), now)
 	}
 
 	return buf

--- a/stats/range32.go
+++ b/stats/range32.go
@@ -16,11 +16,14 @@ type Range32 struct {
 	min   uint32
 	max   uint32
 	valid bool // whether any values have been seen
+	name  []byte
+	tags  []byte
 }
 
 func NewRange32(name string) *Range32 {
 	return registry.getOrAdd(name, &Range32{
-		min: math.MaxUint32,
+		min:  math.MaxUint32,
+		name: []byte(name),
 	},
 	).(*Range32)
 }
@@ -41,12 +44,12 @@ func (r *Range32) ValueUint32(val uint32) {
 	r.Unlock()
 }
 
-func (r *Range32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (r *Range32) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	r.Lock()
 	// if no values were seen, don't report anything to graphite
 	if r.valid {
-		buf = WriteUint32(buf, prefix, []byte("min.gauge32"), r.min, now)
-		buf = WriteUint32(buf, prefix, []byte("max.gauge32"), r.max, now)
+		buf = WriteUint32(buf, prefix, r.name, []byte(".min.gauge32"), r.tags, r.min, now)
+		buf = WriteUint32(buf, prefix, r.name, []byte(".max.gauge32"), r.tags, r.max, now)
 		r.min = math.MaxUint32
 		r.max = 0
 		r.valid = false

--- a/stats/timediff_reporter.go
+++ b/stats/timediff_reporter.go
@@ -9,11 +9,14 @@ import (
 // once reached, reports 0
 type TimeDiffReporter32 struct {
 	target uint32
+	name   []byte
+	tags   []byte
 }
 
 func NewTimeDiffReporter32(name string, target uint32) *TimeDiffReporter32 {
 	return registry.getOrAdd(name, &TimeDiffReporter32{
 		target: target,
+		name:   []byte(name),
 	},
 	).(*TimeDiffReporter32)
 }
@@ -22,13 +25,13 @@ func (g *TimeDiffReporter32) Set(target uint32) {
 	atomic.StoreUint32(&g.target, target)
 }
 
-func (g *TimeDiffReporter32) ReportGraphite(buf, prefix []byte, now time.Time) []byte {
+func (g *TimeDiffReporter32) WriteGraphiteLine(buf, prefix []byte, now time.Time) []byte {
 	target := atomic.LoadUint32(&g.target)
 	now32 := uint32(now.Unix())
 	report := uint32(0)
 	if now32 < target {
 		report = target - now32
 	}
-	buf = WriteUint32(buf, prefix, []byte("gauge32"), report, now)
+	buf = WriteUint32(buf, prefix, g.name, []byte(".gauge32"), g.tags, report, now)
 	return buf
 }

--- a/stats/write.go
+++ b/stats/write.go
@@ -5,9 +5,20 @@ import (
 	"time"
 )
 
-func WriteFloat64(buf, prefix, key []byte, val float64, now time.Time) []byte {
+// Write* functions append a graphite metric line to the given buffer.
+// `buf` is the incoming buffer to be appended to
+// `prefix` is an optional prefix to the metric name which must have a trailing '.' if present
+// `name` is the required name of the metric. It should not have a leading or trailing '.' or a trailing ';'
+// `suffix` is an optional suffix to the metric name which must have a leading '.' if present.  It should not have a trailing ';'
+// `tags` is an optional list of tags which must have a leading ';' if present.
+// `val` is the value of the metric
+// `now` is the time that the metrics should be reported at
+// returns `buf` with the new metric line appended
+func WriteFloat64(buf, prefix, name, suffix, tags []byte, val float64, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendFloat(buf, val, 'f', -1, 64)
 	buf = append(buf, ' ')
@@ -15,9 +26,11 @@ func WriteFloat64(buf, prefix, key []byte, val float64, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteUint32(buf, prefix, key []byte, val uint32, now time.Time) []byte {
+func WriteUint32(buf, prefix, name, suffix, tags []byte, val uint32, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendUint(buf, uint64(val), 10)
 	buf = append(buf, ' ')
@@ -25,9 +38,11 @@ func WriteUint32(buf, prefix, key []byte, val uint32, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteUint64(buf, prefix, key []byte, val uint64, now time.Time) []byte {
+func WriteUint64(buf, prefix, name, suffix, tags []byte, val uint64, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendUint(buf, val, 10)
 	buf = append(buf, ' ')
@@ -35,9 +50,11 @@ func WriteUint64(buf, prefix, key []byte, val uint64, now time.Time) []byte {
 	return append(buf, '\n')
 }
 
-func WriteInt32(buf, prefix, key []byte, val int32, now time.Time) []byte {
+func WriteInt32(buf, prefix, name, suffix, tags []byte, val int32, now time.Time) []byte {
 	buf = append(buf, prefix...)
-	buf = append(buf, key...)
+	buf = append(buf, name...)
+	buf = append(buf, suffix...)
+	buf = append(buf, tags...)
 	buf = append(buf, ' ')
 	buf = strconv.AppendInt(buf, int64(val), 10)
 	buf = append(buf, ' ')


### PR DESCRIPTION
Cleaned up/more easily reviewable version of #1698.

First commit updates the `GraphiteMetric` interface and usages of it, second commit updates structs that implement `GraphiteMetric`.

Does not yet add a way to actually set tags yet (future commit or PR).