### PR TITLE
Readded prefixes 'process.' and 'memory.' to graphite metrics that got removed by accident

### DIFF
--- a/stats/memory_reporter.go
+++ b/stats/memory_reporter.go
@@ -50,32 +50,32 @@ func (m *MemoryReporter) WriteGraphiteLine(buf, prefix []byte, now time.Time) []
 	gcPercent := getGcPercent()
 
 	// metric memory.total_bytes_allocated is a counter of total number of bytes allocated during process lifetime
-	buf = WriteUint64(buf, prefix, []byte("total_bytes_allocated.counter64"), nil, nil, m.mem.TotalAlloc, now)
+	buf = WriteUint64(buf, prefix, []byte("memory.total_bytes_allocated.counter64"), nil, nil, m.mem.TotalAlloc, now)
 
 	// metric memory.bytes_allocated_on_heap is a gauge of currently allocated (within the runtime) memory.
-	buf = WriteUint64(buf, prefix, []byte("bytes.allocated_in_heap.gauge64"), nil, nil, m.mem.Alloc, now)
+	buf = WriteUint64(buf, prefix, []byte("memory.bytes.allocated_in_heap.gauge64"), nil, nil, m.mem.Alloc, now)
 
 	// metric memory.bytes.obtained_from_sys is the number of bytes currently obtained from the system by the process.  This is what the profiletrigger looks at.
-	buf = WriteUint64(buf, prefix, []byte("bytes.obtained_from_sys.gauge64"), nil, nil, m.mem.Sys, now)
+	buf = WriteUint64(buf, prefix, []byte("memory.bytes.obtained_from_sys.gauge64"), nil, nil, m.mem.Sys, now)
 
 	// metric memory.total_gc_cycles is a counter of the number of GC cycles since process start
-	buf = WriteUint32(buf, prefix, []byte("total_gc_cycles.counter64"), nil, nil, m.mem.NumGC, now)
+	buf = WriteUint32(buf, prefix, []byte("memory.total_gc_cycles.counter64"), nil, nil, m.mem.NumGC, now)
 
 	// metric memory.gc.cpu_fraction is how much cpu is consumed by the GC across process lifetime, in pro-mille
-	buf = WriteUint32(buf, prefix, []byte("gc.cpu_fraction.gauge32"), nil, nil, uint32(1000*m.mem.GCCPUFraction), now)
+	buf = WriteUint32(buf, prefix, []byte("memory.gc.cpu_fraction.gauge32"), nil, nil, uint32(1000*m.mem.GCCPUFraction), now)
 
 	// metric memory.gc.heap_objects is how many objects are allocated on the heap, it's a key indicator for GC workload
-	buf = WriteUint64(buf, prefix, []byte("gc.heap_objects.gauge64"), nil, nil, m.mem.HeapObjects, now)
+	buf = WriteUint64(buf, prefix, []byte("memory.gc.heap_objects.gauge64"), nil, nil, m.mem.HeapObjects, now)
 
 	// there was no new GC run, we should only report points to represent actual runs
 	if m.gcCyclesTotal != m.mem.NumGC {
 		// metric memory.gc.last_duration is the duration of the last GC STW pause in nanoseconds
-		buf = WriteUint64(buf, prefix, []byte("gc.last_duration.gauge64"), nil, nil, m.mem.PauseNs[(m.mem.NumGC+255)%256], now)
+		buf = WriteUint64(buf, prefix, []byte("memory.gc.last_duration.gauge64"), nil, nil, m.mem.PauseNs[(m.mem.NumGC+255)%256], now)
 		m.gcCyclesTotal = m.mem.NumGC
 	}
 
 	// metric memory.gc.gogc is the current GOGC value (derived from the GOGC environment variable)
-	buf = WriteInt32(buf, prefix, []byte("gc.gogc.sgauge32"), nil, nil, int32(gcPercent), now)
+	buf = WriteInt32(buf, prefix, []byte("memory.gc.gogc.sgauge32"), nil, nil, int32(gcPercent), now)
 
 	return buf
 }

--- a/stats/process_reporter.go
+++ b/stats/process_reporter.go
@@ -31,18 +31,18 @@ func (m *ProcessReporter) WriteGraphiteLine(buf, prefix []byte, now time.Time) [
 		rss := uint64(stat.ResidentMemory())
 
 		// metric process.virtual_memory_bytes.gauge64 is a gauge of the process VSZ from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("virtual_memory_bytes.gauge64"), nil, nil, vsz, now)
+		buf = WriteUint64(buf, prefix, []byte("process.virtual_memory_bytes.gauge64"), nil, nil, vsz, now)
 
 		// metric process.resident_memory_bytes.gauge64 is a gauge of the process RSS from /proc/pid/stat
-		buf = WriteUint64(buf, prefix, []byte("resident_memory_bytes.gauge64"), nil, nil, rss, now)
+		buf = WriteUint64(buf, prefix, []byte("process.resident_memory_bytes.gauge64"), nil, nil, rss, now)
 		// metric process.minor_page_faults.counter64 is the number of minor faults the process has made which have not required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("minor_page_faults.counter64"), nil, nil, uint64(stat.MinFlt), now)
+		buf = WriteUint64(buf, prefix, []byte("process.minor_page_faults.counter64"), nil, nil, uint64(stat.MinFlt), now)
 
 		// metric process.major_page_faults.counter64 is the number of major faults the process has made which have required loading a memory page from disk
-		buf = WriteUint64(buf, prefix, []byte("major_page_faults.counter64"), nil, nil, uint64(stat.MajFlt), now)
+		buf = WriteUint64(buf, prefix, []byte("process.major_page_faults.counter64"), nil, nil, uint64(stat.MajFlt), now)
 
 		// metric is Total user and system CPU time spent in seconds
-		buf = WriteFloat64(buf, prefix, []byte("cpu_seconds_total.counter64"), nil, nil, stat.CPUTime(), now)
+		buf = WriteFloat64(buf, prefix, []byte("process.cpu_seconds_total.counter64"), nil, nil, stat.CPUTime(), now)
 	}
 
 	return buf


### PR DESCRIPTION
Readded prefixes 'process.' and 'memory.' to graphite metrics that got removed by accident in #1706 