### PR TITLE
Fix registration of metrictank.stats.*.*.input.kafka-mdm.partition.*

### DIFF
--- a/stats/kafka.go
+++ b/stats/kafka.go
@@ -15,19 +15,19 @@ func NewKafka(prefix string, partitions []int32) Kafka {
 
 // KafkaPartition tracks the health of a partition consumer
 type KafkaPartition struct {
-	Offset   Gauge64
-	LogSize  Gauge64
-	Lag      Gauge64
-	Priority Gauge64
-	Ready    Bool
+	Offset   *Gauge64
+	LogSize  *Gauge64
+	Lag      *Gauge64
+	Priority *Gauge64
+	Ready    *Bool
 }
 
 func NewKafkaPartition(prefix string) *KafkaPartition {
 	k := KafkaPartition{}
-	registry.getOrAdd(prefix+".offset", &k.Offset)
-	registry.getOrAdd(prefix+".log_size", &k.LogSize)
-	registry.getOrAdd(prefix+".lag", &k.Lag)
-	registry.getOrAdd(prefix+".priority", &k.Priority)
-	registry.getOrAdd(prefix+".ready", &k.Ready)
+	k.Offset = NewGauge64(prefix + ".offset")
+	k.LogSize = NewGauge64(prefix + ".log_size")
+	k.Lag = NewGauge64(prefix + ".lag")
+	k.Priority = NewGauge64(prefix + ".priority")
+	k.Ready = NewBool(prefix + ".ready")
 	return &k
 }


### PR DESCRIPTION
Registration of metrics `metrictank.stats.*.*.input.kafka-mdm.partition.*` were broken after changes in registration mechanism in #1706

Actual bug is that the `name` property is not adequately set `WriteGraphiteLine(...)` will not work properly.