### PR TITLE
Refactor: stats.Graphite: allow manual reporting for given timestamp.

### DIFF
--- a/stats/out_graphite.go
+++ b/stats/out_graphite.go
@@ -33,7 +33,14 @@ type Graphite struct {
 	toGraphite chan []byte
 }
 
-func NewGraphite(prefix, addr string, interval, bufferSize int, timeout time.Duration) {
+//NewGraphite creates and starts a graphite reporter which.
+//prefix is a string prefix which is added to every metric
+//addr is the graphite address to report to
+//interval is the interval in seconds that metrics should be reported.  If interval is negative, metrics will not be reported automatically.
+//bufferSize determines how many reporting intervals should be buffered in memory.  If full, new intervals will not be reported
+//timeout determines how long to wait while reporting an interval
+//returns a new graphite instance which should only be used for manual reporting if interval is < 0
+func NewGraphite(prefix, addr string, interval, bufferSize int, timeout time.Duration) *Graphite {
 	if len(prefix) != 0 && prefix[len(prefix)-1] != '.' {
 		prefix = prefix + "."
 	}
@@ -52,31 +59,40 @@ func NewGraphite(prefix, addr string, interval, bufferSize int, timeout time.Dur
 		timeout:    timeout,
 	}
 	go g.writer()
-	go g.reporter(interval)
+	if interval > 0 {
+		go g.reporter(interval)
+	}
+	return g
+}
+
+//Report sends graphite metrics with the given timestamp.
+//This should only be used if a negative reporting interval has been set.
+func (g *Graphite) Report(now time.Time) {
+	log.Debugf("stats flushing for %s to graphite", now)
+	queueItems.Value(len(g.toGraphite))
+	if cap(g.toGraphite) != 0 && len(g.toGraphite) == cap(g.toGraphite) {
+		// no space in buffer, no use in doing any work
+		return
+	}
+
+	pre := time.Now()
+
+	buf := make([]byte, 0)
+
+	for _, metric := range registry.list() {
+		buf = metric.WriteGraphiteLine(buf, g.prefix, now)
+	}
+
+	genDataDuration.Set(int(time.Since(pre).Nanoseconds()))
+	messageSize.Set(len(buf))
+	g.toGraphite <- buf
+	queueItems.Value(len(g.toGraphite))
 }
 
 func (g *Graphite) reporter(interval int) {
 	ticker := tick(time.Duration(interval) * time.Second)
 	for now := range ticker {
-		log.Debugf("stats flushing for %s to graphite", now)
-		queueItems.Value(len(g.toGraphite))
-		if cap(g.toGraphite) != 0 && len(g.toGraphite) == cap(g.toGraphite) {
-			// no space in buffer, no use in doing any work
-			continue
-		}
-
-		pre := time.Now()
-
-		buf := make([]byte, 0)
-
-		for _, metric := range registry.list() {
-			buf = metric.WriteGraphiteLine(buf, g.prefix, now)
-		}
-
-		genDataDuration.Set(int(time.Since(pre).Nanoseconds()))
-		messageSize.Set(len(buf))
-		g.toGraphite <- buf
-		queueItems.Value(len(g.toGraphite))
+		g.Report(now)
 	}
 }
 


### PR DESCRIPTION
This is done to support manual timestamp reporting for parrot (#1680).