### PR TITLE
Revert "finish PostRaw span after completing the read"

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -256,11 +256,11 @@ func (s *Server) getTargetsRemote(ctx context.Context, ss *models.StorageStats, 
 			return resp, nil
 		}
 		body, err := node.PostRaw(rCtx, "getTargetsRemote", "/getdata", models.GetData{Requests: reqs})
-		defer body.Close()
-		if err != nil {
+		if body == nil || err != nil {
 			return nil, err
 		}
 		err = msgp.Decode(body, &resp)
+		body.Close()
 		return resp, err
 	})
 

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1031,11 +1031,11 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 		func(reqCtx context.Context, peer cluster.Node) (interface{}, error) {
 			resp := models.IndexFindByTagResp{}
 			body, err := peer.PostRaw(reqCtx, "clusterFindByTag", "/index/find_by_tag", data)
-			defer body.Close()
-			if err != nil {
+			if body == nil || err != nil {
 				return nil, err
 			}
 			err = msgp.Decode(body, &resp)
+			body.Close()
 			return resp, err
 		})
 

--- a/cluster/if.go
+++ b/cluster/if.go
@@ -12,7 +12,6 @@ type Node interface {
 	GetPriority() int
 	HasData() bool
 	Post(context.Context, string, string, Traceable) ([]byte, error)
-	// the returned ReadCloser is always non-nil and Close() must always be called on it, regardless of error state
 	PostRaw(ctx context.Context, name, path string, body Traceable) (io.ReadCloser, error)
 	GetName() string
 }

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -255,21 +255,6 @@ func (n *HTTPNode) SetPartitions(part []int32) {
 	n.Updated = time.Now()
 }
 
-type RawResp struct {
-	io.ReadCloser
-	span opentracing.Span
-}
-
-func (rr RawResp) Close() error {
-	rr.span.Finish()
-	if rr.ReadCloser != nil {
-		return rr.ReadCloser.Close()
-	}
-	return nil
-}
-
-// PostRaw executes a post request on the HTTPNode
-// Important: Close() must always be called on the returned ReadCloser, regardless of error state!
 func (n HTTPNode) PostRaw(ctx context.Context, name, path string, body Traceable) (io.ReadCloser, error) {
 	ctx, span := tracing.NewSpan(ctx, Tracer, name)
 	tags.SpanKindRPCClient.Set(span)
@@ -285,21 +270,18 @@ func (n HTTPNode) PostRaw(ctx context.Context, name, path string, body Traceable
 		if err != nil || time.Since(pre) > 10*time.Second {
 			body.TraceDebug(span)
 		}
+		span.Finish()
 	}(time.Now())
-
-	resp := RawResp{
-		span: span,
-	}
 
 	b, err := json.Marshal(body)
 	if err != nil {
-		return resp, NewError(http.StatusInternalServerError, err)
+		return nil, NewError(http.StatusInternalServerError, err)
 	}
 	reader := bytes.NewReader(b)
 	addr := n.RemoteURL() + path
 	req, err := http.NewRequest("POST", addr, reader)
 	if err != nil {
-		return resp, NewError(http.StatusInternalServerError, err)
+		return nil, NewError(http.StatusInternalServerError, err)
 	}
 	req = req.WithContext(ctx)
 	carrier := opentracing.HTTPHeadersCarrier(req.Header)
@@ -316,31 +298,30 @@ func (n HTTPNode) PostRaw(ctx context.Context, name, path string, body Traceable
 	case <-ctx.Done():
 		log.Debugf("CLU HTTPNode: context canceled on request to peer %s", n.Name)
 		err = nil
-		return resp, nil
+		return nil, nil
 	default:
 	}
 
 	if err != nil {
 		tags.Error.Set(span, true)
 		log.Errorf("CLU HTTPNode: error trying to talk to peer %s: %s", n.Name, err.Error())
-		return resp, NewError(http.StatusServiceUnavailable, errors.New("error trying to talk to peer"))
+		return nil, NewError(http.StatusServiceUnavailable, errors.New("error trying to talk to peer"))
 	}
 	if rsp.StatusCode != 200 {
 		// Read in body so that the connection can be reused
 		io.Copy(ioutil.Discard, rsp.Body)
 		rsp.Body.Close()
-		return resp, NewError(rsp.StatusCode, fmt.Errorf(rsp.Status))
+		return nil, NewError(rsp.StatusCode, fmt.Errorf(rsp.Status))
 	}
-	resp.ReadCloser = rsp.Body
-	return resp, nil
+	return rsp.Body, nil
 }
 
 func (n HTTPNode) Post(ctx context.Context, name, path string, body Traceable) (ret []byte, err error) {
 	bodyReader, err := n.PostRaw(ctx, name, path, body)
-	defer bodyReader.Close()
-	if err != nil {
+	if err != nil || bodyReader == nil {
 		return nil, err
 	}
+	defer bodyReader.Close()
 	return ioutil.ReadAll(bodyReader)
 }
 


### PR DESCRIPTION
This reverts commit d06a29f36a66faeee08c497618376936a1b40c43.
Fix #1721

I'm not seeing an elegant solution to the problem of "we want to keep the span open until we're done reading the body" which means the span has a lifetime beyond PostRaw (but would get initiated out of PostRaw since that's where the http request is created and we inject the headers)

I played with a few ideas, and ideally I'ld like something that appreciates that "PostRaw" is only half of the work (creating and initiating the request), whereas the remainder of the work would be done in the caller and in parrallel would stream the body over the network while processing it.
This would best be symbolized I think by a span that is conceputally `PostRaw+<whatever caller does>`, but that got too messy.

Further developing our composite io.ReadCloser also started to become too ugly.

So for now, let's just revert it and keep it a known limitation that the PostRaw span may finish before the work/network io is done.