### PR TITLE
Add spans for spec-exec and queryPeers

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -247,7 +247,7 @@ func (s *Server) getTargetsRemote(ctx context.Context, ss *models.StorageStats, 
 	rCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	resultChan, errorChan := queryPeers(rCtx, requiredPeers, func(ctx context.Context, node cluster.Node) (interface{}, error) {
+	resultChan, errorChan := queryPeers(rCtx, requiredPeers, "getTargetsRemote", func(ctx context.Context, node cluster.Node) (interface{}, error) {
 		var resp models.GetDataRespV1
 		reqs, ok := shardReqs[node.GetPartitions()[0]]
 		if !ok {
@@ -255,7 +255,7 @@ func (s *Server) getTargetsRemote(ctx context.Context, ss *models.StorageStats, 
 			// Return empty response, no error
 			return resp, nil
 		}
-		body, err := node.PostRaw(rCtx, "getTargetsRemote", "/getdata", models.GetData{Requests: reqs})
+		body, err := node.PostRaw(ctx, "getTargetsRemote", "/getdata", models.GetData{Requests: reqs})
 		if body == nil || err != nil {
 			return nil, err
 		}

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -286,6 +286,7 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 	for _, o := range out {
 		if len(o.Datapoints) != 0 {
 			noDataPoints = false
+			break
 		}
 	}
 	if noDataPoints {
@@ -746,7 +747,6 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 			}
 		}
 	}
-
 	meta.RenderStats.ResolveSeriesDuration = time.Since(pre)
 
 	select {
@@ -818,12 +818,17 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) 
 		sort.Sort(models.SeriesByTarget(dataMap[k]))
 	}
 	meta.RenderStats.PrepareSeriesDuration = time.Since(b)
+	durToMillis := func(dur time.Duration) float64 {
+		return float64(dur.Nanoseconds()) / float64(time.Millisecond.Nanoseconds())
+	}
+	span.LogFields(traceLog.Float64("PrepareSeriesMillis", durToMillis(meta.RenderStats.PrepareSeriesDuration)))
 
 	preRun := time.Now()
 	out, err = plan.Run(dataMap)
 
 	meta.RenderStats.PlanRunDuration = time.Since(preRun)
 	planRunDuration.Value(meta.RenderStats.PlanRunDuration)
+	span.LogFields(traceLog.Float64("PlanRunMillis", durToMillis(meta.RenderStats.PlanRunDuration)))
 	return out, meta, err
 }
 
@@ -1027,7 +1032,7 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 	data := models.IndexFindByTag{OrgId: orgId, Expr: expressions.Strings(), From: from}
 	newCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	responseChan, errorChan := s.queryAllShardsGeneric(newCtx,
+	responseChan, errorChan := s.queryAllShardsGeneric(newCtx, "clusterFindByTag",
 		func(reqCtx context.Context, peer cluster.Node) (interface{}, error) {
 			resp := models.IndexFindByTagResp{}
 			body, err := peer.PostRaw(reqCtx, "clusterFindByTag", "/index/find_by_tag", data)


### PR DESCRIPTION
Adds some spans to encapsulate shard requests and includes speculative requests (and logs speculative wins).

The driver for this change in our deployment is that with a large number of peers the spans get hard to traverse (especially for multi-`target` requests). This allows `find_by_tag` and `get_targets` operations to be folded in jaeger and we can optionally unfold sections that seem slow. 