### PR TITLE
Use new archive type for cleaner non-standard archinterval handling

### DIFF
--- a/api/graphite_req.go
+++ b/api/graphite_req.go
@@ -80,7 +80,7 @@ func (rbr ReqsByRet) Len() int {
 	return cnt
 }
 
-// GroupData embodies a PNGroup broken down by whether requests are MDP-optimizable, and by retention
+// GroupData embodies a set of requests broken down by whether requests are MDP-optimizable, and by retention
 type GroupData struct {
 	mdpyes ReqsByRet // MDP-optimizable requests
 	mdpno  ReqsByRet // not MDP-optimizable reqs

--- a/api/graphite_req.go
+++ b/api/graphite_req.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/metrictank/api/models"
-	"github.com/grafana/metrictank/mdata"
+	"github.com/grafana/metrictank/archives"
 )
 
 // ReqMap is a map of requests of data,
@@ -49,13 +49,20 @@ func (r ReqMap) Dump() string {
 	return out
 }
 
-// Requests indexed by their retention ID
-type ReqsByRet [][]models.Req
+// Requests indexed by their ArchivesID
+type ReqsByArchives [][]models.Req
 
-// OutInterval returns the outinterval of the ReqsByRet
+func (rba *ReqsByArchives) Add(idx int, r models.Req) {
+	for len(*rba) <= idx {
+		*rba = append(*rba, nil)
+	}
+	(*rba)[idx] = append((*rba)[idx], r)
+}
+
+// OutInterval returns the outinterval of the ReqsByArchives
 // this assumes that all requests have been planned to a consistent out interval, of course.
-func (rbr ReqsByRet) OutInterval() uint32 {
-	for _, reqs := range rbr {
+func (rba ReqsByArchives) OutInterval() uint32 {
+	for _, reqs := range rba {
 		if len(reqs) != 0 {
 			return reqs[0].OutInterval
 		}
@@ -63,8 +70,8 @@ func (rbr ReqsByRet) OutInterval() uint32 {
 	return 0
 }
 
-func (rbr ReqsByRet) HasData() bool {
-	for _, reqs := range rbr {
+func (rba ReqsByArchives) HasData() bool {
+	for _, reqs := range rba {
 		if len(reqs) != 0 {
 			return true
 		}
@@ -72,25 +79,22 @@ func (rbr ReqsByRet) HasData() bool {
 	return false
 }
 
-func (rbr ReqsByRet) Len() int {
+func (rba ReqsByArchives) Len() int {
 	var cnt int
-	for _, reqs := range rbr {
+	for _, reqs := range rba {
 		cnt += len(reqs)
 	}
 	return cnt
 }
 
-// GroupData embodies a set of requests broken down by whether requests are MDP-optimizable, and by retention
+// GroupData embodies a set of requests broken down by whether requests are MDP-optimizable, and by archivesID
 type GroupData struct {
-	mdpyes ReqsByRet // MDP-optimizable requests
-	mdpno  ReqsByRet // not MDP-optimizable reqs
+	mdpyes ReqsByArchives // MDP-optimizable requests
+	mdpno  ReqsByArchives // not MDP-optimizable reqs
 }
 
 func NewGroupData() GroupData {
-	return GroupData{
-		mdpyes: make([][]models.Req, mdata.Schemas.Len()),
-		mdpno:  make([][]models.Req, mdata.Schemas.Len()),
-	}
+	return GroupData{}
 }
 
 func (gd GroupData) Len() int {
@@ -102,6 +106,7 @@ type ReqsPlan struct {
 	pngroups map[models.PNGroup]GroupData
 	single   GroupData
 	cnt      uint32
+	archives archives.Index
 }
 
 // NewReqsPlan generates a ReqsPlan based on the provided ReqMap.
@@ -110,49 +115,55 @@ func NewReqsPlan(reqs ReqMap) ReqsPlan {
 		pngroups: make(map[models.PNGroup]GroupData),
 		single:   NewGroupData(),
 		cnt:      reqs.cnt,
+		archives: archives.NewIndex(),
 	}
+
 	for group, groupReqs := range reqs.pngroups {
 		data := NewGroupData()
 		for _, req := range groupReqs {
+			archivesID := rp.archives.ArchivesID(req.RawInterval, req.SchemaId)
 			if req.MaxPoints > 0 {
-				data.mdpyes[req.SchemaId] = append(data.mdpyes[req.SchemaId], req)
+				data.mdpyes.Add(archivesID, req)
 			} else {
-				data.mdpno[req.SchemaId] = append(data.mdpno[req.SchemaId], req)
+				data.mdpno.Add(archivesID, req)
 			}
 		}
 		rp.pngroups[group] = data
 	}
+
 	for _, req := range reqs.single {
+		archivesID := rp.archives.ArchivesID(req.RawInterval, req.SchemaId)
 		if req.MaxPoints > 0 {
-			rp.single.mdpyes[req.SchemaId] = append(rp.single.mdpyes[req.SchemaId], req)
+			rp.single.mdpyes.Add(archivesID, req)
 		} else {
-			rp.single.mdpno[req.SchemaId] = append(rp.single.mdpno[req.SchemaId], req)
+			rp.single.mdpno.Add(archivesID, req)
 		}
 	}
+
 	return rp
 }
 
 // PointsFetch returns how many points this plan will fetch when executed
 func (rp ReqsPlan) PointsFetch() uint32 {
 	var cnt uint32
-	for _, rbr := range rp.single.mdpyes {
-		for _, req := range rbr {
+	for _, rba := range rp.single.mdpyes {
+		for _, req := range rba {
 			cnt += req.PointsFetch()
 		}
 	}
-	for _, rbr := range rp.single.mdpno {
-		for _, req := range rbr {
+	for _, rba := range rp.single.mdpno {
+		for _, req := range rba {
 			cnt += req.PointsFetch()
 		}
 	}
 	for _, data := range rp.pngroups {
-		for _, rbr := range data.mdpyes {
-			for _, req := range rbr {
+		for _, rba := range data.mdpyes {
+			for _, req := range rba {
 				cnt += req.PointsFetch()
 			}
 		}
-		for _, rbr := range data.mdpno {
-			for _, req := range rbr {
+		for _, rba := range data.mdpno {
+			for _, req := range rba {
 				cnt += req.PointsFetch()
 			}
 		}
@@ -167,29 +178,29 @@ func (rp ReqsPlan) Dump() string {
 	for i, data := range rp.pngroups {
 		out += fmt.Sprintf("    ## group %d\n", i)
 		out += "      ### MDP-yes:\n"
-		for schemaID, reqs := range data.mdpyes {
+		for archivesID, reqs := range data.mdpyes {
 			for _, req := range reqs {
-				out += fmt.Sprintf("        [%d] %s\n", schemaID, req.DebugString())
+				out += fmt.Sprintf("        [%v] %s\n", rp.archives.Get(archivesID), req.DebugString())
 			}
 		}
 		out += "      ### MDP-no:\n"
-		for schemaID, reqs := range data.mdpno {
+		for archivesID, reqs := range data.mdpno {
 			for _, req := range reqs {
-				out += fmt.Sprintf("        [%d] %s\n", schemaID, req.DebugString())
+				out += fmt.Sprintf("        [%v] %s\n", rp.archives.Get(archivesID), req.DebugString())
 			}
 		}
 	}
 	out += "  # Single\n"
 	out += "   ## MDP-yes:\n"
-	for schemaID, reqs := range rp.single.mdpyes {
+	for archivesID, reqs := range rp.single.mdpyes {
 		for _, req := range reqs {
-			out += fmt.Sprintf("    [%d] %s\n", schemaID, req.DebugString())
+			out += fmt.Sprintf("    [%v] %s\n", rp.archives.Get(archivesID), req.DebugString())
 		}
 	}
 	out += "    ## MDP-no:\n"
-	for schemaID, reqs := range rp.single.mdpno {
+	for archivesID, reqs := range rp.single.mdpno {
 		for _, req := range reqs {
-			out += fmt.Sprintf("    [%d] %s\n", schemaID, req.DebugString())
+			out += fmt.Sprintf("    [%v] %s\n", rp.archives.Get(archivesID), req.DebugString())
 		}
 	}
 	return out
@@ -199,24 +210,24 @@ func (rp ReqsPlan) Dump() string {
 // best effort: not aware of summarize(), aggregation functions, runtime normalization. but does account for runtime consolidation
 func (rp ReqsPlan) PointsReturn(planMDP uint32) uint32 {
 	var cnt uint32
-	for _, rbr := range rp.single.mdpyes {
-		for _, req := range rbr {
+	for _, rba := range rp.single.mdpyes {
+		for _, req := range rba {
 			cnt += req.PointsReturn(planMDP)
 		}
 	}
-	for _, rbr := range rp.single.mdpno {
-		for _, req := range rbr {
+	for _, rba := range rp.single.mdpno {
+		for _, req := range rba {
 			cnt += req.PointsReturn(planMDP)
 		}
 	}
 	for _, data := range rp.pngroups {
-		for _, rbr := range data.mdpyes {
-			for _, req := range rbr {
+		for _, rba := range data.mdpyes {
+			for _, req := range rba {
 				cnt += req.PointsReturn(planMDP)
 			}
 		}
-		for _, rbr := range data.mdpno {
-			for _, req := range rbr {
+		for _, rba := range data.mdpno {
+			for _, req := range rba {
 				cnt += req.PointsReturn(planMDP)
 			}
 		}

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -128,7 +128,8 @@ func planRequests(now, from, to uint32, reqs *ReqMap, planMDP uint32, mpprSoft, 
 		//   Though, is that any more fair? for some series it's more desirable to have them at lower resolutions than others.
 		// * In particular, our logic to do PNGroups in ascending size order, then singles in archivesID order, is made up.
 		// * Because PNGroups may be comprised of multiple schemas, we typically don't have to adjust all of the comprising requests
-		//   to achieve an overall point reduction for the entire group. This means that singles may reduce faster than PNGroups
+		//   to achieve an overall point reduction for the entire group. This means that singles may reduce faster
+		//   (grow their intervals faster per iteration) than PNGroups
 		progress := true
 
 		pngroupsByLen := make([]models.PNGroup, 0, len(rp.pngroups))

--- a/archives/archives.go
+++ b/archives/archives.go
@@ -1,0 +1,43 @@
+package archives
+
+import (
+	"github.com/grafana/metrictank/conf"
+	"github.com/grafana/metrictank/mdata"
+)
+
+// Archive is like conf.Retention except:
+// * for archive 0, the "interval" is the raw interval of the metric, if it differs from what the retention specifies
+// * only contains relevant fields for planning purposes
+type Archive struct {
+	Interval uint32
+	TTL      uint32
+	Ready    uint32 // ready for reads for data as of this timestamp (or as of now-TTL, whichever is highest)
+}
+
+// Valid returns whether the given Archive has been ready long enough (wrt from), and has a sufficient retention (wrt ttl)
+func (a Archive) Valid(from, ttl uint32) bool {
+	return a.Ready <= from && a.TTL >= ttl
+}
+
+func NewArchive(ret conf.Retention) Archive {
+	return Archive{
+		Interval: uint32(ret.SecondsPerPoint),
+		TTL:      uint32(ret.MaxRetention()),
+		Ready:    ret.Ready,
+	}
+}
+
+type Archives []Archive
+
+func NewArchives(rawInterval uint32, schemaID uint16) Archives {
+
+	rets := mdata.Schemas.Get(uint16(schemaID)).Retentions.Rets
+
+	archives := make(Archives, len(rets))
+	for i, ret := range rets {
+		archives[i] = NewArchive(ret)
+	}
+	archives[0].Interval = rawInterval
+
+	return archives
+}

--- a/archives/index.go
+++ b/archives/index.go
@@ -1,0 +1,38 @@
+package archives
+
+type key struct {
+	schemaID    uint16
+	rawInterval uint32
+}
+
+// Index tracks all seen lists of archives
+type Index struct {
+	seen map[key]int
+	list []Archives
+}
+
+func NewIndex() Index {
+	return Index{
+		seen: make(map[key]int),
+	}
+}
+
+// ArchivesID returns the archivesId for the given request,
+// and adds it to the index if it is new
+func (a *Index) ArchivesID(rawInterval uint32, schemaID uint16) int {
+	key := key{
+		schemaID:    schemaID,
+		rawInterval: rawInterval,
+	}
+	idx, ok := a.seen[key]
+	if !ok {
+		idx = len(a.list)
+		a.seen[key] = idx
+		a.list = append(a.list, NewArchives(rawInterval, schemaID))
+	}
+	return idx
+}
+
+func (a Index) Get(index int) Archives {
+	return a.list[index]
+}

--- a/conf/retention.go
+++ b/conf/retention.go
@@ -97,11 +97,6 @@ func (r Retention) MaxRetention() int {
 	return r.SecondsPerPoint * r.NumberOfPoints
 }
 
-// Valid returns whether the given retention has been ready long enough (wrt from), and has a sufficient retention (wrt ttl)
-func (r Retention) Valid(from, ttl uint32) bool {
-	return r.Ready <= from && uint32(r.MaxRetention()) >= ttl
-}
-
 func (r Retention) String() string {
 	s := dur.FormatDuration(uint32(r.SecondsPerPoint))
 	s += ":" + dur.FormatDuration(uint32(r.NumberOfPoints*r.SecondsPerPoint))


### PR DESCRIPTION
This resumes where #1709 left off.
In particular, this fixes #1679 for the case where we hit max-points-per-req-soft.

While solving this issue, it turns out there's many places in request planning where we have to keep in mind the custom raw intervals - as described in #1709, and it would be really nice if during all planning the retentions for each request were correct straight out of the box (without having to deal with the exception each time)

There's basically 2 ways to approach this problem:
1) in conf.Schemas track all "custom" schemas (creating new schema rules when metrics come in that declare a custom raw interval). In a way, this would be nice as we would have then a central place to reflect the "messy reality", and each schema rule would have a correct raw interval. This would mean that in the index, in idx.Archive the SchemaId field would now change.
This would in turn mean that during an upgrade from master to this code, nodes would have incompatible interpretations of this field, and this would require a blue/green deployment. There may be more ramifications as well, as this change would affect many things across the code base.

2) We keep conf.Schemas as-is: a reflection of our expanded version of the storage-schemas config (as it currently already does). But to deal with cases of using a schema rule but with a custom raw interval, we create a new type. We now have the choice to impact as much or as little of the code base as we want. E.g. we can only use it within planRequests. For simplicity, @robert-milan and I have chosen to pursue this path.

An additional optimization we can do is the new abstraction type can use fields and types that are more useful during request planning (e.g. whereas conf.Retention has a `MaxRetention() int` method, archive.Archive has a `TTL uint32` field)

As we introduce this approach to basically categorize requests by archivesID rather than schemaID, we are again guaranteed to have the exact same "schema" (including raw interval) for each group), which means we can bring back the cleaner code from before #1709, and rely on the fact that all requests in the same group have the same retentions in general, and the same rawInterval in particular.