### PR TITLE
Support multiple targets that act on different time windows

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -28,7 +27,6 @@ import (
 	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/stats"
 	"github.com/grafana/metrictank/tracing"
-	"github.com/grafana/metrictank/util"
 	opentracing "github.com/opentracing/opentracing-go"
 	tags "github.com/opentracing/opentracing-go/ext"
 	traceLog "github.com/opentracing/opentracing-go/log"
@@ -690,8 +688,6 @@ func (s *Server) metricsDeleteRemote(ctx context.Context, orgId uint32, query st
 func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan) ([]models.Series, models.RenderMeta, error) {
 	var meta models.RenderMeta
 
-	minFrom := uint32(math.MaxUint32)
-	var maxTo uint32
 	reqs := NewReqMap()
 	metaTagEnrichmentData := make(map[string]tagquery.Tags)
 
@@ -733,9 +729,6 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan)
 		if err != nil {
 			return nil, meta, err
 		}
-
-		minFrom = util.Min(minFrom, r.From)
-		maxTo = util.Max(maxTo, r.To)
 
 		for _, s := range series {
 			for _, metric := range s.Series {

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -792,7 +792,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan)
 	// note: if 1 series has a movingAvg that requires a long time range extension, it may push other reqs into another archive. can be optimized later
 	var err error
 	var rp *ReqsPlan
-	rp, err = planRequests(uint32(time.Now().Unix()), minFrom, maxTo, reqs, plan.MaxDataPoints, maxPointsPerReqSoft, maxPointsPerReqHard)
+	rp, err = planRequests(uint32(time.Now().Unix()), reqs, plan.MaxDataPoints, maxPointsPerReqSoft, maxPointsPerReqHard)
 	if err != nil {
 		return nil, meta, err
 	}

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -199,13 +199,13 @@ HonoredSoft:
 
 	// 4) send out some metrics and we're done!
 	for _, reqs := range rp.single.mdpyes {
-		if len(reqs) != 0 {
-			reqRenderChosenArchive.Values(int(reqs[0].Archive), len(reqs))
+		for _, req := range reqs {
+			reqRenderChosenArchive.Value(int(req.Archive))
 		}
 	}
 	for _, reqs := range rp.single.mdpno {
-		if len(reqs) != 0 {
-			reqRenderChosenArchive.Values(int(reqs[0].Archive), len(reqs))
+		for _, req := range reqs {
+			reqRenderChosenArchive.Value(int(req.Archive))
 		}
 	}
 	for _, data := range rp.pngroups {

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -60,26 +60,41 @@ var (
 //    For "fairness" across series, and because we used to simply reduce any series without regard for how it would be used, we pick the latter. better would be both
 // 3) subject to max-points-per-req-hard: reject the query if it can't be met
 //
-// note: it is assumed that all requests have the same from & to.
 // also takes a "now" value which we compare the TTL against
 
 // Note: MDP-yes code path may not take into account that archive 0 may have a different raw interval.
 // see https://github.com/grafana/metrictank/issues/1679
-func planRequests(now, from, to uint32, reqs *ReqMap, planMDP uint32, mpprSoft, mpprHard int) (*ReqsPlan, error) {
-
+func planRequests(now uint32, reqs *ReqMap, planMDP uint32, mpprSoft, mpprHard int) (*ReqsPlan, error) {
 	ok, rp := false, NewReqsPlan(*reqs)
 
 	// 1) Initial parameters
+	getTimeWindowSuperSet := func(rba ReqsByArchives) (uint32, uint32) {
+		minFrom := uint32(math.MaxUint32)
+		maxTo := uint32(0)
+		for _, reqs := range rba {
+			if len(reqs) == 0 {
+				continue
+			}
+			for _, r := range reqs {
+				minFrom = util.Min(minFrom, r.From)
+				maxTo = util.Max(maxTo, r.To)
+			}
+		}
+		return minFrom, maxTo
+	}
 	for group, split := range rp.pngroups {
+		// Find the minFrom and maxTo of reqs in the same split
 		if split.mdpyes.HasData() {
-			ok = planLowestResForMDPMulti(now, from, to, planMDP, split.mdpyes, rp.archives)
+			groupFrom, groupTo := getTimeWindowSuperSet(split.mdpyes)
+			ok = planLowestResForMDPMulti(now, groupFrom, groupTo, planMDP, split.mdpyes, rp.archives)
 			if !ok {
 				return nil, errUnSatisfiable
 			}
 			rp.pngroups[group] = split
 		}
 		if split.mdpno.HasData() {
-			ok = planHighestResMulti(now, from, to, split.mdpno, rp.archives)
+			groupFrom, groupTo := getTimeWindowSuperSet(split.mdpno)
+			ok = planHighestResMulti(now, groupFrom, groupTo, split.mdpno, rp.archives)
 			if !ok {
 				return nil, errUnSatisfiable
 			}
@@ -89,18 +104,24 @@ func planRequests(now, from, to uint32, reqs *ReqMap, planMDP uint32, mpprSoft, 
 		if len(reqs) == 0 {
 			continue
 		}
-		ok = planLowestResForMDPSingles(now, from, to, planMDP, archivesID, reqs, rp.archives)
-		if !ok {
-			return nil, errUnSatisfiable
+		// Singles should be planned independently
+		for i := range reqs {
+			ok = planLowestResForMDPSingles(now, planMDP, archivesID, &reqs[i], rp.archives)
+			if !ok {
+				return nil, errUnSatisfiable
+			}
 		}
 	}
 	for archivesID, reqs := range rp.single.mdpno {
 		if len(reqs) == 0 {
 			continue
 		}
-		ok = planHighestResSingles(now, from, to, archivesID, reqs, rp.archives)
-		if !ok {
-			return nil, errUnSatisfiable
+		// Singles should be planned independently
+		for i := range reqs {
+			ok = planHighestResSingles(now, archivesID, &reqs[i], rp.archives)
+			if !ok {
+				return nil, errUnSatisfiable
+			}
 		}
 	}
 
@@ -143,7 +164,8 @@ func planRequests(now, from, to uint32, reqs *ReqMap, planMDP uint32, mpprSoft, 
 			for _, groupID := range pngroupsByLen {
 				data := rp.pngroups[groupID]
 				if len(data.mdpno) > 0 {
-					ok := reduceResMulti(now, from, to, data.mdpno, rp.archives)
+					groupFrom, groupTo := getTimeWindowSuperSet(data.mdpno)
+					ok := reduceResMulti(now, groupFrom, groupTo, data.mdpno, rp.archives)
 					if ok {
 						progress = true
 						if rp.PointsFetch() <= uint32(mpprSoft) {
@@ -153,14 +175,14 @@ func planRequests(now, from, to uint32, reqs *ReqMap, planMDP uint32, mpprSoft, 
 				}
 			}
 			for archivesID, reqs := range rp.single.mdpno {
-				if len(reqs) > 0 {
-					ok := reduceResSingles(now, from, to, archivesID, reqs, rp.archives)
-					if ok {
-						progress = true
-						if rp.PointsFetch() <= uint32(mpprSoft) {
-							goto HonoredSoft
-						}
-					}
+				// Singles should be reduced independently (possibly different from/to)
+				for i := range reqs {
+					ok = reduceResSingle(now, archivesID, &reqs[i], rp.archives)
+					progress = progress || ok
+				}
+				if progress && rp.PointsFetch() <= uint32(mpprSoft) {
+					goto HonoredSoft
+
 				}
 			}
 		}
@@ -203,47 +225,30 @@ HonoredSoft:
 }
 
 // planHighestResSingles plans all requests of the given retention to their most precise resolution (which may be different for different retentions).
-func planHighestResSingles(now, from, to uint32, archivesID int, reqs []models.Req, index archives.Index) bool {
+func planHighestResSingles(now uint32, archivesID int, req *models.Req, index archives.Index) bool {
 	as := index.Get(archivesID)
-	minTTL := now - from
-	archive, a, ok := findHighestResRet(as, from, minTTL)
+	minTTL := now - req.From
+	archive, a, ok := findHighestResRet(as, req.From, minTTL)
 	if ok {
-		for i := range reqs {
-			req := &reqs[i]
-			req.Plan(archive, a)
-		}
+		req.Plan(archive, a)
 	}
 	return ok
 }
 
 // planLowestResForMDPSingles plans all requests of the given retention to an interval such that requests still return >=mdp/2 points (interval may be different for different retentions)
-func planLowestResForMDPSingles(now, from, to, mdp uint32, archivesID int, reqs []models.Req, index archives.Index) bool {
-	if len(reqs) == 0 {
-		return true
-	}
+func planLowestResForMDPSingles(now, mdp uint32, archivesID int, req *models.Req, index archives.Index) bool {
 	as := index.Get(archivesID)
-	var archive int
-	var a archives.Archive
-	var ok bool
 	for i := len(as) - 1; i >= 0; i-- {
 		// skip non-ready option.
-		if as[i].Ready > from {
+		if as[i].Ready > req.From {
 			continue
 		}
-		archive, a, ok = i, as[i], true
-		(&reqs[0]).Plan(i, as[i])
-		if reqs[0].PointsFetch() >= mdp/2 {
-			break
+		req.Plan(i, as[i])
+		if req.PointsFetch() >= mdp/2 {
+			return true
 		}
 	}
-	if !ok {
-		return false
-	}
-	for i := range reqs {
-		req := &reqs[i]
-		req.Plan(archive, a)
-	}
-	return true
+	return false
 }
 
 // planHighestResMulti plans all requests of all retentions to the most precise, common, resolution.
@@ -315,46 +320,25 @@ func planLowestResForMDPMulti(now, from, to, mdp uint32, rba ReqsByArchives, ind
 	return true
 }
 
-// reduceResSingles reduces the resolution of all requests of the given retention
-// to the next more coarse, common, interval (which may be different for different retentions)
-// we already assume that each request is setup to request as little as data as possible to yield
+// reduceResSingle reduces the resolution of a given request to the next more coarse, common,
+// interval (which may be different for different retentions)
+// we already assume that the request is setup to request as little as data as possible to yield
 // the desired output interval. Thus the only way to fetch fewer points is to increase the output
 // interval
 // returns whether we were able to reduce
-func reduceResSingles(now, from, to uint32, archivesID int, reqs []models.Req, index archives.Index) bool {
-	if len(reqs) == 0 {
-		return true
-	}
-
-	curOut := reqs[0].OutInterval
-	minTTL := now - from
-
-	var ok bool
-
-	var archive int
-	var a archives.Archive
+func reduceResSingle(now uint32, archivesID int, req *models.Req, index archives.Index) bool {
+	curOut := req.OutInterval
+	minTTL := now - req.From
 
 	as := index.Get(archivesID)
 	for i, aMaybe := range as {
-		if aMaybe.Valid(from, minTTL) && aMaybe.Interval > curOut {
-			ok = true
-			archive = i
-			a = aMaybe
-			break
+		if aMaybe.Valid(req.From, minTTL) && aMaybe.Interval > curOut {
+			req.Plan(i, aMaybe)
+			return true
 		}
 	}
 
-	if !ok {
-		return false
-	}
-
-	for i := range reqs {
-		req := &reqs[i]
-		req.Plan(archive, a)
-	}
-
-	return true
-
+	return false
 }
 
 // reduceResMulti reduces the resolution of all requests to the next more coarse, common, interval
@@ -518,7 +502,6 @@ func planToMulti(now, from, to, interval uint32, rba ReqsByArchives, index archi
 // * is ready for long enough to accommodate `from`
 // * has a long enough TTL, or otherwise the longest TTL
 func findHighestResRet(as archives.Archives, from, ttl uint32) (int, archives.Archive, bool) {
-
 	var archive int
 	var a archives.Archive
 	var ok bool

--- a/api/query_engine_test.go
+++ b/api/query_engine_test.go
@@ -49,7 +49,7 @@ func testPlan(reqs []models.Req, retentions []conf.Retentions, outReqs []models.
 	// thus SchemasID must accommodate for this!
 	mdata.Schemas = conf.NewSchemas(schemas)
 	//spew.Dump(mdata.Schemas)
-	out, err := planRequests(now, reqs[0].From, reqs[0].To, getReqMap(reqs), 0, maxPointsPerReqSoft, maxPointsPerReqHard)
+	out, err := planRequests(now, getReqMap(reqs), 0, maxPointsPerReqSoft, maxPointsPerReqHard)
 	if err != outErr {
 		t.Errorf("different err value expected: %v, got: %v", outErr, err)
 	}
@@ -315,7 +315,7 @@ func TestPlanRequests_Singles_DifferentTimeRanges(t *testing.T) {
 
 // TestPlanRequestsMaxPointsPerReqSoft tests how maxPointsPerReqSoft gets applied.
 // we validate that:
-// * requests are coarsened, PNGroup by PNGroup (we can predict PNGroup map iteration order, so we only test with 1 PNGroup),
+// * requests are coarsened, PNGroup by PNGroup (we cannot predict PNGroup map iteration order, so we only test with 1 PNGroup),
 //   and singles in groups by retention (in schemaID order)
 // * PNGroups obviously will need a common interval, which gets interesting when using multiple schemas
 // * coarsening continues until all data is fetched at its coarsest. At that point we may breach soft, but never hard
@@ -663,7 +663,7 @@ func BenchmarkPlanRequestsSamePNGroupNoLimits(b *testing.B) {
 	})
 
 	for n := 0; n < b.N; n++ {
-		res, _ = planRequests(14*24*3600, 0, 3600*24*7, reqs, 0, 0, 0)
+		res, _ = planRequests(14*24*3600, reqs, 0, 0, 0)
 	}
 	result = res
 }

--- a/api/query_engine_test.go
+++ b/api/query_engine_test.go
@@ -293,6 +293,8 @@ func TestPlanRequestsMultiIntervalsUseRaw(t *testing.T) {
 // 2 identical singles, one requesting older data (> raw TTL).
 // They should be independently planned
 func TestPlanRequests_Singles_DifferentTimeRanges(t *testing.T) {
+	// req0 400-800
+	// req1 0-400 // with a now at 1200, archive 0 doesn't have long enough retention
 	in, out := generate(400, 800, []reqProp{
 		NewReqProp(10, 0, 0),
 		NewReqProp(10, 0, 0),
@@ -307,6 +309,7 @@ func TestPlanRequests_Singles_DifferentTimeRanges(t *testing.T) {
 	testPlan(in, rets, out, nil, 1200, 0, 0, t)
 
 	// If soft is slightly breached, only the high res data should be reduced
+	// (800-400)/10 + (400-0)/60 = 46 points
 	t.Run("WithMaxPointsPerReqSoftJustBreached", func(t *testing.T) {
 		adjust(&out[0], 1, 60, 60, 1200)
 		testPlan(in, rets, out, nil, 1200, 45, 0, t)


### PR DESCRIPTION
To support functions like timeShift and movingWindow, we need to support functions that can adjust the `from` and `to` at a per context level. The archive chosen for unrelated requests should not be influenced by time ranges that were adjusted by other functions.  