### PR TITLE
Fix issue 1740

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -563,6 +563,12 @@ func queryPeers(ctx context.Context, peerGroups map[int32][]cluster.Node, name s
 		}
 
 		for group, peers := range peerGroups {
+			if len(peers) == 0 {
+				errorChan <- fmt.Errorf("peer group %d has no peers", group)
+				delete(peerGroups, group)
+				continue
+			}
+
 			nextPeer := peers[0]
 			// shift nextPeer from the group
 			peerGroups[group] = peers[1:]

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -564,7 +564,7 @@ func queryPeers(ctx context.Context, peerGroups map[int32][]cluster.Node, name s
 
 		for group, peers := range peerGroups {
 			if len(peers) == 0 {
-				errorChan <- fmt.Errorf("peer group %d has no peers", group)
+				log.Warningf("Peer group %d has no peers", group)
 				delete(peerGroups, group)
 				continue
 			}

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -564,7 +564,7 @@ func queryPeers(ctx context.Context, peerGroups map[int32][]cluster.Node, name s
 
 		for group, peers := range peerGroups {
 			if len(peers) == 0 {
-				log.Warningf("Peer group %d has no peers", group)
+				log.Warningf("HTTP Peer group %d has no peers", group)
 				delete(peerGroups, group)
 				continue
 			}

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -240,10 +240,12 @@ func (s *Server) getTargetsRemote(ctx context.Context, ss *models.StorageStats, 
 	shardReqs := make(map[int32][]models.Req)
 	for _, nodeReqs := range remoteReqs {
 		shardID := nodeReqs[0].Node.GetPartitions()[0]
-		if peers := allPeers[shardID]; len(peers) > 0 {
-			requiredPeers[shardID] = peers
-			shardReqs[shardID] = append(shardReqs[shardID], nodeReqs...)
+		peers := allPeers[shardID]
+		if len(peers) == 0 {
+			return nil, fmt.Errorf("Shard %d has gone unavailable before /getdata", shardID)
 		}
+		requiredPeers[shardID] = peers
+		shardReqs[shardID] = append(shardReqs[shardID], nodeReqs...)
 	}
 
 	rCtx, cancel := context.WithCancel(ctx)

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -240,8 +240,10 @@ func (s *Server) getTargetsRemote(ctx context.Context, ss *models.StorageStats, 
 	shardReqs := make(map[int32][]models.Req)
 	for _, nodeReqs := range remoteReqs {
 		shardID := nodeReqs[0].Node.GetPartitions()[0]
-		requiredPeers[shardID] = allPeers[shardID]
-		shardReqs[shardID] = append(shardReqs[shardID], nodeReqs...)
+		if peers := allPeers[shardID]; len(peers) > 0 {
+			requiredPeers[shardID] = peers
+			shardReqs[shardID] = append(shardReqs[shardID], nodeReqs...)
+		}
 	}
 
 	rCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
this changes 2 things:
1) it prevents that an empty slice of peers gets passed into `queryPeers()`
2) it makes `queryPeers()` handle an empty slice of peers better, if for an unknown reason this still happens

fixes #1740 