### PR TITLE
fix panic on shutdown: stop double closing the index

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -142,7 +142,6 @@ func (s *Server) Run() {
 
 func (s *Server) Stop() {
 	close(s.shutdown)
-	s.MetricIndex.Stop()
 }
 
 func (s *Server) handleShutdown(l net.Listener) {

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -542,6 +542,8 @@ func shutdown() {
 	if cluster.Mode != cluster.ModeQuery {
 		log.Info("closing store")
 		store.Stop()
+		log.Info("closing index")
+		metricIndex.Stop()
 
 		if memory.MetaTagSupport {
 			switch concrete := metaRecords.(type) {

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -542,8 +542,6 @@ func shutdown() {
 	if cluster.Mode != cluster.ModeQuery {
 		log.Info("closing store")
 		store.Stop()
-		log.Info("closing index")
-		metricIndex.Stop()
 
 		if memory.MetaTagSupport {
 			switch concrete := metaRecords.(type) {


### PR DESCRIPTION
I decided to remove the `Stop()` call on the index from `apiServer` instead of from the main. Main performs checks to determine whether or not it is a query pod, and it makes more sense to stop it here.