### PR TITLE
configurable "proxy bad requests to graphite" behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@
      upgrade query or shard nodes.
   B) do a colored deployment: create a new gossip cluster that has the optimization enabled from the get-go,
      then delete the older deployment.
+* as of v0.13.1-433-g4c801819, metrictank proxies bad requests to graphite.
+  though as of <TODO> this is configurable via the `http.proxy-bad-requests` flag.
+  Leave enabled if your queries are in the grey zone (rejected by MT, tolerated by graphite),
+  disable if you don't like the additional latency.
+  The aspiration is to remove this entire feature once we work out any more kinks in metrictank's request validation.
 
 ## other
 

--- a/api/config.go
+++ b/api/config.go
@@ -25,6 +25,7 @@ var (
 	keyFile          string
 	multiTenant      bool
 	fallbackGraphite string
+	proxyBadRequests bool
 	timeZoneStr      string
 
 	getTargetsConcurrency int
@@ -48,6 +49,7 @@ func ConfigSetup() {
 	apiCfg.StringVar(&keyFile, "key-file", "", "SSL key file")
 	apiCfg.BoolVar(&multiTenant, "multi-tenant", true, "require x-org-id authentication to auth as a specific org. otherwise orgId 1 is assumed")
 	apiCfg.StringVar(&fallbackGraphite, "fallback-graphite-addr", "http://localhost:8080", "in case our /render endpoint does not support the requested processing, proxy the request to this graphite")
+	apiCfg.BoolVar(&proxyBadRequests, "proxy-bad-requests", true, "proxy to graphite when metrictank considers the request bad")
 	apiCfg.StringVar(&timeZoneStr, "time-zone", "local", "timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone")
 	apiCfg.IntVar(&getTargetsConcurrency, "get-targets-concurrency", 20, "maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.")
 	apiCfg.UintVar(&tagdbDefaultLimit, "tagdb-default-limit", 100, "default limit for tagdb query results, can be overridden with query parameter \"limit\"")

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -236,6 +236,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -236,6 +236,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -236,6 +236,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -236,6 +236,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/docs/config.md
+++ b/docs/config.md
@@ -285,6 +285,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://localhost:8080
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -192,7 +192,6 @@ enforce-future-tolerance = true
 # defines until how far in the future we accept datapoints. defined as a percentage fraction of the raw ttl of the matching retention storage schema
 future-tolerance-ratio = 10
 
-
 ## instrumentation stats ##
 [stats]
 # enable sending graphite messages for instrumentation
@@ -240,6 +239,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://localhost:8080
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -236,6 +236,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://graphite
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -236,6 +236,8 @@ max-series-per-req = 250000
 multi-tenant = true
 # in case our /render endpoint does not support the requested processing, proxy the request to this graphite
 fallback-graphite-addr = http://localhost:8080
+# proxy to graphite when metrictank considers the request bad
+proxy-bad-requests = true
 # timezone for interpreting from/until values when needed, specified using [zoneinfo name](https://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) e.g. 'America/New_York', 'UTC' or 'local' to use local server timezone.
 time-zone = local
 # maximum number of concurrent threads for fetching data on the local node. Each thread handles a single series.


### PR DESCRIPTION
the behavior introduced in #1690 should be configurable

While I was at it, i made the logic a bit more verbose but easier to
follow.

Fix #592