### PR TITLE
mt-index-prune: error when there is an error parsing the flags

### DIFF
--- a/cmd/mt-index-prune/main.go
+++ b/cmd/mt-index-prune/main.go
@@ -95,7 +95,9 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	globalFlags.Parse(os.Args[1:cassI])
+
+	err := globalFlags.Parse(os.Args[1:cassI])
+	perror(err)
 
 	indexRules, err := conf.ReadIndexRules(indexRulesFile)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
when parsing returns an error then output it and exit