### PR TITLE
Fix Meta tag inverted filtering not working 

### DIFF
--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -266,12 +266,12 @@ func metaRecordFilterInverted(metaRecordFilters []tagquery.MetricDefinitionFilte
 				decision = defaultDecision
 			}
 
-			if decision == tagquery.Fail {
-				return tagquery.Pass
+			if decision == tagquery.Pass {
+				return tagquery.Fail
 			}
 		}
 
-		return tagquery.Fail
+		return tagquery.Pass
 	}
 }
 

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -202,12 +202,14 @@ func TestFilterByMetaTagOfMultipleExpressionsWithNotEqualAndWithNotHasTag(t *tes
 }
 
 func testFilterByMetaTagOfMultipleExpressionsWithNotEqualAndWithNotHasTag(t *testing.T) {
-	// matches ids 3, 5, 6
 	metaTagExpressions, err := tagquery.ParseExpressions([]string{"tag1=value3", "tag1=value4", "tag1=value5"})
 	if err != nil {
 		t.Fatalf("Unexpected error when parsing expressions: %s", err)
 	}
 
+	// one meta tag with 3 underlying meta records,
+	// it matches all metrics which satisfy one of these conditions:
+	// tag1=value3 or tag1=value4 or tag1=value5
 	metaRecords := []tagquery.MetaTagRecord{
 		{
 			MetaTags: []tagquery.Tag{


### PR DESCRIPTION
This first adds a unit test which fails due to issue #1765, then it fixes the issue and makes the unit test pass

Fixes #1765 