### PR TITLE
add options to use custom values with fakemetrics

### DIFF
--- a/cmd/mt-fakemetrics/cmd/datafeed.go
+++ b/cmd/mt-fakemetrics/cmd/datafeed.go
@@ -167,6 +167,10 @@ func dataFeed(outs []out.Out, orgs, mpo, period, flush, offset, speedup int, sto
 		panic("can only use one value option (use-fixed-value, use-fixed-values, use-ts-value)")
 	}
 
+	if useFixedValues && len(fixedValues) < 2 {
+		panic("you must specify at least 2 values when using fixed-values")
+	}
+
 	if useFixedValue {
 		metricValue = fixedValue
 	}

--- a/cmd/mt-fakemetrics/cmd/root.go
+++ b/cmd/mt-fakemetrics/cmd/root.go
@@ -68,6 +68,12 @@ var (
 	customTags          []string
 	numUniqueCustomTags int
 
+	useFixedValue  bool
+	fixedValue     float64
+	useFixedValues bool
+	fixedValues    []float64
+	useTsValue     bool
+
 	kafkaMdmAddr     string
 	kafkaMdmTopic    string
 	kafkaMdmV2       bool
@@ -106,6 +112,12 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&numUniqueTags, "num-unique-tags", 1, "a number between 0 and 10. when using add-tags this will add a unique number to some built-in tags")
 	rootCmd.PersistentFlags().StringSliceVar(&customTags, "custom-tags", []string{}, "A list of comma separated tags (i.e. \"tag1=value1,tag2=value2\")(default empty) conflicts with add-tags")
 	rootCmd.PersistentFlags().IntVar(&numUniqueCustomTags, "num-unique-custom-tags", 0, "a number between 0 and the length of custom-tags. when using custom-tags this will make the tags unique (default 0)")
+
+	rootCmd.PersistentFlags().BoolVar(&useFixedValue, "use-fixed-value", false, "use a single value for all metrics")
+	rootCmd.PersistentFlags().Float64Var(&fixedValue, "fixed-value", 1, "the value to use for all metrics")
+	rootCmd.PersistentFlags().BoolVar(&useFixedValues, "use-fixed-values", false, "use repeating values for all metrics")
+	rootCmd.PersistentFlags().Float64SliceVar(&fixedValues, "fixed-values", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}, "the repeating values to use for all metrics")
+	rootCmd.PersistentFlags().BoolVar(&useTsValue, "use-ts-value", false, "use timestamp as value for metrics")
 
 	rootCmd.PersistentFlags().StringVar(&kafkaMdmAddr, "kafka-mdm-addr", "", "kafka TCP address for MetricData-Msgp messages. e.g. localhost:9092")
 	rootCmd.PersistentFlags().StringVar(&kafkaMdmTopic, "kafka-mdm-topic", "mdm", "kafka topic for MetricData-Msgp messages")

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -83,6 +83,8 @@ Flags:
       --carbon-addr string           carbon TCP address. e.g. localhost:2003
       --config string                config file (default is $HOME/.mt-fakemetrics.yaml)
       --custom-tags strings          A list of comma separated tags (i.e. "tag1=value1,tag2=value2")(default empty) conflicts with add-tags
+      --fixed-value float            the value to use for all metrics (default 1)
+      --fixed-values float64Slice    the repeating values to use for all metrics (default [1.000000,2.000000,3.000000,4.000000,5.000000,6.000000,7.000000,8.000000,9.000000])
       --gnet-addr string             gnet address. e.g. http://localhost:8081
       --gnet-key string              gnet api key
   -h, --help                         help for mt-fakemetrics
@@ -98,6 +100,9 @@ Flags:
       --statsd-addr string           statsd TCP address. e.g. 'localhost:8125'
       --statsd-type string           statsd type: standard or datadog (default "standard")
       --stdout                       enable emitting metrics to stdout
+      --use-fixed-value              use a single value for all metrics
+      --use-fixed-values             use repeating values for all metrics
+      --use-ts-value                 use timestamp as value for metrics
 
 Use "mt-fakemetrics [command] --help" for more information about a command.
 ```


### PR DESCRIPTION
This PR adds the ability to use fixed custom values to the fakemetrics tool. This should make it easier to run certain types of tests.