### PR TITLE
fix bug in "proxy to graphite upon bad request"

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -259,6 +259,7 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 		if err.HTTPStatusCode() == http.StatusBadRequest && !request.NoProxy && proxyBadRequests {
 			log.Infof("Proxying to Graphite because of error: %s", err.Error())
 			s.proxyToGraphite(ctx)
+			return
 		}
 		ctx.Error(err.HTTPStatusCode(), err.Error())
 		return


### PR DESCRIPTION
This bug was introduced in v0.13.1-577-g07eed80f / PR #1761

When a response is considered to be a 400 Bad Request by this particular code section,
it would proxy to Graphite, but still try to run
`ctx.Error(err.HTTPStatusCode(), err.Error())`

which would partially succeed.

The ramifications are:
* we tried to set http 400 bad request header (which failed, headers
  already set from proxied response), so response would get 200 OK
  (but body invalid, see below)
* we added content to the body (after graphite's response), both in plaintext and gzip case.
  - in plaintext case, this results in invalid json, so client would typically not be able to decode our response
  - in gzip case, the response would similarly get extraneous content and be invalid.

Additionally in the gzip body case, our logging and tracing middle ware was failing to decompress the gzip body,
resulting in empty error messages in the log and jaeger traces.
Note that macaron has this:
```
func (rw *responseWriter) WriteHeader(s int) {
	rw.callBefore()
	rw.ResponseWriter.WriteHeader(s)
	rw.status = s
}
```
if WriteHeader fails (e.g. we already set a header with a code of 200) the status field will still be updated.
Hence the tracing/logging middleware still executing this branch:
```
if rw.Status() < 200 || rw.Status() >= 300 {
	var errBody string
	if rw.Header().Get("Content-Encoding") == "gzip" {
		errBody, err = util.DecompressGzip(rw.errBody)
		if err != nil {
			log.Errorf("Decompressing gzip body failed: %s", err.Error())
		}
		...
```

## Behavior before
### Without compression
```
curl -v 'http://localhost:6060/render' -d 'target=groupByNode(metrictank.stats.docker-env.default.*.metrics_active.gauge32, 4,"sumSeries")' -d format=json -d maxDataPoints=1
*   Trying ::1:6060...
* Connected to localhost (::1) port 6060 (#0)
> POST /render HTTP/1.1
> Host: localhost:6060
> User-Agent: curl/7.69.1
> Accept: */*
> Content-Length: 123
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 123 out of 123 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Cache-Control: no-cache, no-store, must-revalidate, max-age=0
< Content-Type: application/json
< Date: Wed, 15 Apr 2020 10:57:26 GMT
< Expires: Wed, 15 Apr 2020 10:57:26 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Trace-Id: bac4fcb32699784
< Vary: Origin
< Vary: Accept-Encoding
< X-Graphite-Hostname: graphite
< X-Graphite-Timing: D=281935 t=1586948246658708
< Content-Length: 352
<
* Connection #0 to host localhost left intact
[{"datapoints": [[262.0, 1586861847]], "target": "idx", "tags": {"aggregatedBy": "sum", "name": "metrictank.stats.docker-env.default.idx.metrics_active.gauge32"}}, {"datapoints": [[262.0, 1586861847]], "target": "tank", "tags": {"aggregatedBy": "sum", "name": "metrictank.stats.docker-env.default.tank.metrics_active.gauge32"}}]Invalid aggregation func
```
metrictank logs:
```
2020-04-15 11:10:18.693 [INFO] Proxying to Graphite because of error: Invalid aggregation func
2020-04-15 11:10:18.788 [INFO] ts=2020-04-15T11:10:18.788968675Z traceID=4a8e2e2b738fe745, sampled=true msg="POST /render/?format=pickle&from=1586862618&local=1&noCache=1&now=1586949018&target=metrictank.stats.docker-env.default.%2A.metrics_active.gauge32&until=1586949018 (200) 13.749768ms" orgID=1 sourceIP="172.19.0.4"
2020/04/15 11:10:18 http: superfluous response.WriteHeader call from github.com/grafana/metrictank/vendor/gopkg.in/macaron%2ev1.(*responseWriter).WriteHeader (response_writer.go:59)
2020-04-15 11:10:18.979 [INFO] ts=2020-04-15T11:10:18.97961121Z traceID=317975bbb0d5eaaa, sampled=true msg="POST /render?format=json&maxDataPoints=1&target=groupByNode%28metrictank.stats.docker-env.default.%2A.metrics_active.gauge32%2C+4%2C%22sumSeries%22%29 (400) 286.53617ms" orgID=1 sourceIP="172.19.0.1" error="Invalid%20aggregation%20func"
```
### With compression
```
curl -v -H "Accept-Encoding: gzip" 'http://localhost:6060/render' -d 'target=groupByNode(metrictank.stats.docker-env.default.*.metrics_active.gauge32, 4,"sumSeries")' -d format=json -d maxDataPoints=1 --output file.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1:6060...
* Connected to localhost (::1) port 6060 (#0)
> POST /render HTTP/1.1
> Host: localhost:6060
> User-Agent: curl/7.69.1
> Accept: */*
> Accept-Encoding: gzip
> Content-Length: 123
> Content-Type: application/x-www-form-urlencoded
>
} [123 bytes data]
* upload completely sent off: 123 out of 123 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Cache-Control: no-cache, no-store, must-revalidate, max-age=0
< Content-Encoding: gzip
< Content-Type: application/json
< Date: Wed, 15 Apr 2020 11:14:06 GMT
< Expires: Wed, 15 Apr 2020 11:14:06 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Trace-Id: 55ff4564600f8ce
< Vary: Origin
< Vary: Accept-Encoding
< X-Graphite-Hostname: graphite
< X-Graphite-Timing: D=329972 t=1586949246270026
< Content-Length: 210
<
{ [210 bytes data]
100   333  100   210  100   123    632    370 --:--:-- --:--:-- --:--:--  1003
* Connection #0 to host localhost left intact
$ strings file.txt
UW.g
yt@h
Invalid aggregation func
```
metrictank logs:
```
2020-04-15 11:14:06.269 [INFO] Proxying to Graphite because of error: Invalid aggregation func
2020-04-15 11:14:06.366 [INFO] ts=2020-04-15T11:14:06.36659784Z traceID=5937a317897d1d, sampled=true msg="POST /render/?format=pickle&from=1586862846&local=1&noCache=1&now=1586949246&target=metrictank.stats.docker-env.default.%2A.metrics_active.gauge32&until=1586949246 (200) 16.613027ms" orgID=1 sourceIP="172.19.0.4"
2020/04/15 11:14:06 http: superfluous response.WriteHeader call from github.com/grafana/metrictank/vendor/gopkg.in/macaron%2ev1.(*responseWriter).WriteHeader (response_writer.go:59)
2020-04-15 11:14:06.600 [ERROR] Decompressing gzip body failed: gzip: invalid header
2020-04-15 11:14:06.600 [INFO] ts=2020-04-15T11:14:06.600212377Z traceID=55ff4564600f8ce, sampled=true msg="POST /render?format=json&maxDataPoints=1&target=groupByNode%28metrictank.stats.docker-env.default.%2A.metrics_active.gauge32%2C+4%2C%22sumSeries%22%29 (400) 331.014237ms" orgID=1 sourceIP="172.19.0.1" error=""
2020-04-15 11:14:06.600 [ERROR] Decompressing gzip body failed: gzip: invalid header
```

## Behavior after
### Without compression
```
curl -v 'http://localhost:6060/render' -d 'target=groupByNode(metrictank.stats.docker-env.default.*.metrics_active.gauge32, 4,"sumSeries")' -d format=json -d maxDataPoints=1
*   Trying ::1:6060...
* Connected to localhost (::1) port 6060 (#0)
> POST /render HTTP/1.1
> Host: localhost:6060
> User-Agent: curl/7.69.1
> Accept: */*
> Content-Length: 123
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 123 out of 123 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Cache-Control: no-cache, no-store, must-revalidate, max-age=0
< Content-Type: application/json
< Date: Wed, 15 Apr 2020 11:31:52 GMT
< Expires: Wed, 15 Apr 2020 11:31:52 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Trace-Id: 7ab109480a919f0d
< Vary: Origin
< Vary: Accept-Encoding
< X-Graphite-Hostname: graphite
< X-Graphite-Timing: D=246776 t=1586950312168191
< Content-Length: 351
<
* Connection #0 to host localhost left intact
[{"datapoints": [[525.5255813953488, 1586863913]], "target": "idx", "tags": {"aggregatedBy": "sum", "name": "metrictank.stats.docker-env.default.idx.metrics_active.gauge32"}}, {"datapoints": [[525.553488372093, 1586863913]], "target": "tank", "tags": {"aggregatedBy": "sum", "name": "metrictank.stats.docker-env.default.tank.metrics_active.gauge32"}}]
```
metrictank logs:
```
2020-04-15 11:30:33.964 [INFO] Proxying to Graphite because of error: Invalid aggregation func
2020-04-15 11:30:33.984 [INFO] ts=2020-04-15T11:30:33.984560431Z traceID=1b9d32fb4beec2f5, sampled=true msg="POST /render/?format=pickle&from=1586863833&local=1&noCache=1&now=1586950233&target=metrictank.stats.docker-env.default.%2A.metrics_active.gauge32&until=1586950233 (200) 13.886857ms" orgID=1 sourceIP="172.19.0.5"
2020-04-15 11:30:34.158 [INFO] ts=2020-04-15T11:30:34.15877782Z traceID=11cfcc070fd1d001, sampled=true msg="POST /render?format=json&maxDataPoints=1&target=groupByNode%28metrictank.stats.docker-env.default.%2A.metrics_active.gauge32%2C+4%2C%22sumSeries%22%29 (200) 194.87944ms" orgID=1 sourceIP="172.19.0.1"
```
## With compression
```
curl -v -H "Accept-Encoding: gzip" 'http://localhost:6060/render' -d 'target=groupByNode(metrictank.stats.docker-env.default.*.metrics_active.gauge32, 4,"sumSeries")' -d format=json -d maxDataPoints=1 --output file.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1:6060...
* Connected to localhost (::1) port 6060 (#0)
> POST /render HTTP/1.1
> Host: localhost:6060
> User-Agent: curl/7.69.1
> Accept: */*
> Accept-Encoding: gzip
> Content-Length: 123
> Content-Type: application/x-www-form-urlencoded
>
} [123 bytes data]
* upload completely sent off: 123 out of 123 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Cache-Control: no-cache, no-store, must-revalidate, max-age=0
< Content-Encoding: gzip
< Content-Type: application/json
< Date: Wed, 15 Apr 2020 11:29:22 GMT
< Expires: Wed, 15 Apr 2020 11:29:22 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Trace-Id: 1b6ceac7d6ffca3a
< Vary: Origin
< Vary: Accept-Encoding
< X-Graphite-Hostname: graphite
< X-Graphite-Timing: D=210107 t=1586950162575803
< Content-Length: 177
<
{ [177 bytes data]
100   300  100   177  100   123    834    580 --:--:-- --:--:-- --:--:--  1415
* Connection #0 to host localhost left intact
~ ❯❯❯ strings file.txt
exUO^
+Udb
Letit
L|V<
>0#T
```
metrictank logs:
```
2020-04-15 11:29:22.575 [INFO] Proxying to Graphite because of error: Invalid aggregation func
2020-04-15 11:29:22.595 [INFO] ts=2020-04-15T11:29:22.594989246Z traceID=3a3ed024ef958f0e, sampled=true msg="POST /render/?format=pickle&from=1586863762&local=1&noCache=1&now=1586950162&target=metrictank.stats.docker-env.default.%2A.metrics_active.gauge32&until=1586950162 (200) 13.470897ms" orgID=1 sourceIP="172.19.0.5"
2020-04-15 11:29:22.786 [INFO] ts=2020-04-15T11:29:22.786109647Z traceID=1b6ceac7d6ffca3a, sampled=true msg="POST /render?format=json&maxDataPoints=1&target=groupByNode%28metrictank.stats.docker-env.default.%2A.metrics_active.gauge32%2C+4%2C%22sumSeries%22%29 (200) 210.993056ms" orgID=1 sourceIP="172.19.0.1"
```



### Sidenote
For the record, I also confirmed disabling the proxy works as expected:

```
-proxy-bad-requests = true
+proxy-bad-requests = false
```
```
http "localhost:6060/render?target=groupByNode(metrictank.stats.docker-env.default.*.metrics_active.gauge32, 4, 'sumSeries')&format=json&from=-1s"
HTTP/1.1 400 Bad Request
Content-Encoding: gzip
Content-Length: 49
Date: Wed, 15 Apr 2020 10:46:53 GMT
Trace-Id: 1378eedbeea323b3
Vary: Accept-Encoding

Invalid aggregation func
```