### PR TITLE
groupByNode[s]: implement ordering like graphite does

### DIFF
--- a/expr/func_groupbynodes_test.go
+++ b/expr/func_groupbynodes_test.go
@@ -2,7 +2,6 @@ package expr
 
 import (
 	"math"
-	"sort"
 	"strconv"
 	"testing"
 
@@ -240,13 +239,6 @@ func testGroupByNodes(name string, in []models.Series, expected []models.Series,
 	if len(got) != len(expected) {
 		t.Fatalf("case %q: output length expected to be %d but got %d", name, len(expected), len(got))
 	}
-
-	sort.Slice(got, func(i, j int) bool {
-		return got[i].Target < got[j].Target
-	})
-	sort.Slice(expected, func(i, j int) bool {
-		return expected[i].Target < expected[j].Target
-	})
 
 	for i, g := range got {
 		o := expected[i]


### PR DESCRIPTION
fix #1767 

## PRE
![pre](https://user-images.githubusercontent.com/20774/79384258-2eb60680-7f6f-11ea-83dc-f4b4712194d0.png)

## POST
![post](https://user-images.githubusercontent.com/20774/79384255-2d84d980-7f6f-11ea-8eb0-5febf4d66b21.png)