### PR TITLE
treat bad Regex argument as a "bad request"

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -186,7 +186,7 @@ func (e expr) consumeBasicArg(pos int, exp Arg) (int, error) {
 		}
 		re, err := regexp.Compile(got.str)
 		if err != nil {
-			return 0, err
+			return 0, ErrBadRegex{err}
 		}
 		*v.val = re
 	case ArgSeries, ArgSeriesList:

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -51,6 +51,14 @@ func (e ErrBadArgumentStr) HTTPStatusCode() int {
 	return http.StatusBadRequest
 }
 
+type ErrBadRegex struct {
+	error
+}
+
+func (e ErrBadRegex) HTTPStatusCode() int {
+	return http.StatusBadRequest
+}
+
 type ErrUnknownFunction string
 
 func (e ErrUnknownFunction) Error() string {


### PR DESCRIPTION
fix #1777

Before:
* a query like `aliasSub(metrictank.stats.docker-env.default.api.request.*.latency.median.gauge32,'(?!-[0-9]*-)-[0-9]','')` results in http 500 `error parsing regexp: invalid or unsupported Perl syntax: '(?!'......`

After
We trigger an internal http 400, which invokes the graphite proxy, and the request succeeds.

```
2020-04-16 09:29:39.919 [INFO] Proxying to Graphite because of error: error parsing regexp: invalid or unsupported Perl syntax: `(?!`
2020-04-16 09:29:39.942 [INFO] ts=2020-04-16T09:29:39.94250757Z msg="POST /render/?format=pickle&from=1587007779&local=1&noCache=1&now=1587029379&target=metrictank.stats.docker-env.default.api.request.%2A.latency.median.gauge32&until=1587029379 (200) 17.505297ms" orgID=1 sourceIP="172.19.0.5"
2020-04-16 09:29:40.081 [INFO] ts=2020-04-16T09:29:40.081842051Z msg="POST /render?format=json&from=-6h&maxDataPoints=1870&meta=true&target=aliasSub%28metrictank.stats.docker-env.default.api.request.%2A.latency.median.gauge32%2C%27%28%3F%21-%5B0-9%5D%2A-%29-%5B0-9%5D%27%2C%27%27%29&until=now (200) 162.298473ms" orgID=1 sourceIP="172.19.0.1, 172.19.0.1"
```