### PR TITLE
don't conflate dev docker with prod docker!

### DIFF
--- a/docker/docker-cosmosdb/docker-compose.yml
+++ b/docker/docker-cosmosdb/docker-compose.yml
@@ -9,7 +9,7 @@ services:
      - "2003:2003"
     volumes:
       - ../../build/metrictank:/usr/bin/metrictank
-      - ../../scripts/config/metrictank-docker.ini:/etc/metrictank/metrictank.ini
+      - ../../scripts/config/metrictank-docker-dev.ini:/etc/metrictank/metrictank.ini
       - ./storage-schemas.conf:/etc/metrictank/storage-schemas.conf
       - ./storage-aggregation.conf:/etc/metrictank/storage-aggregation.conf
     environment:

--- a/docker/docker-dev-bigtable/docker-compose.yml
+++ b/docker/docker-dev-bigtable/docker-compose.yml
@@ -9,7 +9,7 @@ services:
      - "2003:2003"
     volumes:
       - ../../build/metrictank:/usr/bin/metrictank
-      - ../../scripts/config/metrictank-docker.ini:/etc/metrictank/metrictank.ini
+      - ../../scripts/config/metrictank-docker-dev.ini:/etc/metrictank/metrictank.ini
       - ../../scripts/config/storage-schemas.conf:/etc/metrictank/storage-schemas.conf
       - ../../scripts/config/storage-aggregation.conf:/etc/metrictank/storage-aggregation.conf
       - ../../scripts/config/schema-store-cassandra.toml:/etc/metrictank/schema-store-cassandra.toml

--- a/docker/docker-dev-debug/docker-compose.yml
+++ b/docker/docker-dev-debug/docker-compose.yml
@@ -13,7 +13,7 @@ services:
      - "40000:40000"
     volumes:
       - ../../build/metrictank:/usr/bin/metrictank
-      - ../../scripts/config/metrictank-docker.ini:/etc/metrictank/metrictank.ini
+      - ../../scripts/config/metrictank-docker-dev.ini:/etc/metrictank/metrictank.ini
       - ../../scripts/config/index-rules.conf:/etc/metrictank/index-rules.conf
       - ../../scripts/config/storage-aggregation.conf:/etc/metrictank/storage-aggregation.conf
       - ../../scripts/config/storage-schemas.conf:/etc/metrictank/storage-schemas.conf

--- a/docker/docker-dev-scylla/docker-compose.yml
+++ b/docker/docker-dev-scylla/docker-compose.yml
@@ -9,7 +9,7 @@ services:
      - "2003:2003"
     volumes:
       - ../../build/metrictank:/usr/bin/metrictank
-      - ../../scripts/config/metrictank-docker.ini:/etc/metrictank/metrictank.ini
+      - ../../scripts/config/metrictank-docker-dev.ini:/etc/metrictank/metrictank.ini
       - ../../scripts/config/index-rules.conf:/etc/metrictank/index-rules.conf
       - ../../scripts/config/storage-aggregation.conf:/etc/metrictank/storage-aggregation.conf
       - ../../scripts/config/storage-schemas.conf:/etc/metrictank/storage-schemas.conf

--- a/docker/docker-dev/docker-compose.yml
+++ b/docker/docker-dev/docker-compose.yml
@@ -9,7 +9,7 @@ services:
      - "2003:2003"
     volumes:
       - ../../build/metrictank:/usr/bin/metrictank
-      - ../../scripts/config/metrictank-docker.ini:/etc/metrictank/metrictank.ini
+      - ../../scripts/config/metrictank-docker-dev.ini:/etc/metrictank/metrictank.ini
       - ../../scripts/config/index-rules.conf:/etc/metrictank/index-rules.conf
       - ../../scripts/config/storage-aggregation.conf:/etc/metrictank/storage-aggregation.conf
       - ../../scripts/config/storage-schemas.conf:/etc/metrictank/storage-schemas.conf

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -52,7 +52,7 @@ log-level = info
 ## request tracing via jaeger ##
 [jaeger]
 # Whether the tracer is enabled or not
-enabled = false
+enabled = true
 # A comma separated list of name = value tracer level tags, which get added to all reported spans.
 # The value can also refer to an environment variable using the format ${envVarName:default},
 # where the :default is optional, and identifies a value to be used if the environment variable cannot be found
@@ -88,7 +88,7 @@ collector-user =
 # Password to send as part of "Basic" authentication to the collector endpoint
 collector-password =
 # UDP address of the agent to send spans to. (only used if collector-addr is empty)
-agent-addr = localhost:6831
+agent-addr = jaeger:6831
 
 ## metric data storage in cassandra ##
 [cassandra]


### PR DESCRIPTION
jaeger settings are specific to docker-dev, so let's keep a separate
config after all. If we keep this in the prod image, it may cause
metrictank to fail to start. So move the current metrictank-docker.ini to metrictank-docker-dev.ini and restore the original metrictank-docker.ini.

```
$ diff metrictank-docker.ini metrictank-docker-dev.ini
55c55
< enabled = false
---
> enabled = true
91c91
< agent-addr = localhost:6831
---
> agent-addr = jaeger:6831
```