### PR TITLE
implement /metrics/expand endpoint

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/metrictank/idx/memory"
@@ -369,6 +370,84 @@ func (s *Server) metricsFind(ctx *middleware.Context, request models.GraphiteFin
 		response.Write(ctx, response.NewMsgpack(200, findPickle(nodes, request, fromUnix, toUnix)))
 	case "pickle":
 		response.Write(ctx, response.NewPickle(200, findPickle(nodes, request, fromUnix, toUnix)))
+	}
+}
+
+func (s *Server) metricsExpand(ctx *middleware.Context, request models.GraphiteExpand) {
+	var wg sync.WaitGroup
+	var errAtomic atomic.Value
+
+	reqCtx := ctx.Req.Context()
+	results := make([]map[string]struct{}, len(request.Query))
+	wg.Add(len(request.Query))
+	for queryIdx, query := range request.Query {
+		go func(queryIdx int, query string) {
+			defer wg.Done()
+
+			series, err := s.findSeries(reqCtx, ctx.OrgId, []string{query}, 0)
+			if err != nil {
+				errAtomic.Store(err)
+				return
+			}
+
+			results[queryIdx] = make(map[string]struct{})
+			for _, s := range series {
+				for _, n := range s.Series {
+					if request.LeavesOnly && !n.Leaf {
+						continue
+					}
+
+					results[queryIdx][n.Path] = struct{}{}
+				}
+			}
+		}(queryIdx, query)
+	}
+	wg.Wait()
+
+	// check to see if the request has been canceled, if so abort now.
+	select {
+	case <-reqCtx.Done():
+		//request canceled
+		response.Write(ctx, response.RequestCanceledErr)
+		return
+	default:
+	}
+
+	err := errAtomic.Load()
+	if err != nil {
+		response.Write(ctx, response.WrapError(err.(error)))
+		return
+	}
+
+	if request.GroupByExpr {
+		// keyed by query string
+		resultsGrouped := make(map[string][]string, len(results))
+		for resultIdx, queryResults := range results {
+			// query and results can be associated via their shared idx
+			query := request.Query[resultIdx]
+			resultsGrouped[query] = make([]string, 0, len(queryResults))
+			for queryResult := range queryResults {
+				resultsGrouped[query] = append(resultsGrouped[query], queryResult)
+			}
+			sort.StringSlice(resultsGrouped[query]).Sort()
+		}
+
+		response.Write(ctx, response.NewJson(200, resultsGrouped, request.Jsonp))
+	} else {
+		// all results in one flat list
+		resultsUngrouped := make(map[string]struct{})
+		for _, paths := range results {
+			for path := range paths {
+				resultsUngrouped[path] = struct{}{}
+			}
+		}
+		resultSlice := make([]string, 0, len(resultsUngrouped))
+		for result := range resultsUngrouped {
+			resultSlice = append(resultSlice, result)
+		}
+		sort.StringSlice(resultSlice).Sort()
+
+		response.Write(ctx, response.NewJson(200, resultSlice, request.Jsonp))
 	}
 }
 

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -182,6 +182,13 @@ type GraphiteFind struct {
 	Jsonp  string `json:"jsonp" form:"jsonp"`
 }
 
+type GraphiteExpand struct {
+	Query       []string `json:"query" form:"query" binding:"Required"`
+	GroupByExpr bool     `json:"groupByExpr" form:"groupByExpr"`
+	LeavesOnly  bool     `json:"leavesOnly" form:"leavesOnly"`
+	Jsonp       string   `json:"jsonp" form:"jsonp"`
+}
+
 type MetricsDelete struct {
 	Query string `json:"query" form:"query" binding:"Required"`
 }

--- a/api/models/graphite_gen.go
+++ b/api/models/graphite_gen.go
@@ -7,6 +7,224 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *GraphiteExpand) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Query":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Query")
+				return
+			}
+			if cap(z.Query) >= int(zb0002) {
+				z.Query = (z.Query)[:zb0002]
+			} else {
+				z.Query = make([]string, zb0002)
+			}
+			for za0001 := range z.Query {
+				z.Query[za0001], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Query", za0001)
+					return
+				}
+			}
+		case "GroupByExpr":
+			z.GroupByExpr, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "GroupByExpr")
+				return
+			}
+		case "LeavesOnly":
+			z.LeavesOnly, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "LeavesOnly")
+				return
+			}
+		case "Jsonp":
+			z.Jsonp, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Jsonp")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GraphiteExpand) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 4
+	// write "Query"
+	err = en.Append(0x84, 0xa5, 0x51, 0x75, 0x65, 0x72, 0x79)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Query)))
+	if err != nil {
+		err = msgp.WrapError(err, "Query")
+		return
+	}
+	for za0001 := range z.Query {
+		err = en.WriteString(z.Query[za0001])
+		if err != nil {
+			err = msgp.WrapError(err, "Query", za0001)
+			return
+		}
+	}
+	// write "GroupByExpr"
+	err = en.Append(0xab, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x42, 0x79, 0x45, 0x78, 0x70, 0x72)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.GroupByExpr)
+	if err != nil {
+		err = msgp.WrapError(err, "GroupByExpr")
+		return
+	}
+	// write "LeavesOnly"
+	err = en.Append(0xaa, 0x4c, 0x65, 0x61, 0x76, 0x65, 0x73, 0x4f, 0x6e, 0x6c, 0x79)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.LeavesOnly)
+	if err != nil {
+		err = msgp.WrapError(err, "LeavesOnly")
+		return
+	}
+	// write "Jsonp"
+	err = en.Append(0xa5, 0x4a, 0x73, 0x6f, 0x6e, 0x70)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Jsonp)
+	if err != nil {
+		err = msgp.WrapError(err, "Jsonp")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GraphiteExpand) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "Query"
+	o = append(o, 0x84, 0xa5, 0x51, 0x75, 0x65, 0x72, 0x79)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Query)))
+	for za0001 := range z.Query {
+		o = msgp.AppendString(o, z.Query[za0001])
+	}
+	// string "GroupByExpr"
+	o = append(o, 0xab, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x42, 0x79, 0x45, 0x78, 0x70, 0x72)
+	o = msgp.AppendBool(o, z.GroupByExpr)
+	// string "LeavesOnly"
+	o = append(o, 0xaa, 0x4c, 0x65, 0x61, 0x76, 0x65, 0x73, 0x4f, 0x6e, 0x6c, 0x79)
+	o = msgp.AppendBool(o, z.LeavesOnly)
+	// string "Jsonp"
+	o = append(o, 0xa5, 0x4a, 0x73, 0x6f, 0x6e, 0x70)
+	o = msgp.AppendString(o, z.Jsonp)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GraphiteExpand) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Query":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Query")
+				return
+			}
+			if cap(z.Query) >= int(zb0002) {
+				z.Query = (z.Query)[:zb0002]
+			} else {
+				z.Query = make([]string, zb0002)
+			}
+			for za0001 := range z.Query {
+				z.Query[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Query", za0001)
+					return
+				}
+			}
+		case "GroupByExpr":
+			z.GroupByExpr, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "GroupByExpr")
+				return
+			}
+		case "LeavesOnly":
+			z.LeavesOnly, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LeavesOnly")
+				return
+			}
+		case "Jsonp":
+			z.Jsonp, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Jsonp")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *GraphiteExpand) Msgsize() (s int) {
+	s = 1 + 6 + msgp.ArrayHeaderSize
+	for za0001 := range z.Query {
+		s += msgp.StringPrefixSize + len(z.Query[za0001])
+	}
+	s += 12 + msgp.BoolSize + 11 + msgp.BoolSize + 6 + msgp.StringPrefixSize + len(z.Jsonp)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *GraphiteTagDelSeries) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/api/models/graphite_gen_test.go
+++ b/api/models/graphite_gen_test.go
@@ -9,6 +9,119 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+func TestMarshalUnmarshalGraphiteExpand(t *testing.T) {
+	v := GraphiteExpand{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGraphiteExpand(b *testing.B) {
+	v := GraphiteExpand{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGraphiteExpand(b *testing.B) {
+	v := GraphiteExpand{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGraphiteExpand(b *testing.B) {
+	v := GraphiteExpand{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGraphiteExpand(t *testing.T) {
+	v := GraphiteExpand{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GraphiteExpand{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGraphiteExpand(b *testing.B) {
+	v := GraphiteExpand{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGraphiteExpand(b *testing.B) {
+	v := GraphiteExpand{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalGraphiteTagDelSeries(t *testing.T) {
 	v := GraphiteTagDelSeries{}
 	bts, err := v.MarshalMsg(nil)

--- a/api/routes.go
+++ b/api/routes.go
@@ -64,6 +64,7 @@ func (s *Server) RegisterRoutes() {
 	// Graphite endpoints
 	r.Combo("/render", cBody, withOrg, ready, bind(models.GraphiteRender{})).Get(s.renderMetrics).Post(s.renderMetrics)
 	r.Combo("/metrics/find", withOrg, ready, bind(models.GraphiteFind{})).Get(s.metricsFind).Post(s.metricsFind)
+	r.Combo("/metrics/expand", withOrg, ready, bind(models.GraphiteExpand{})).Get(s.metricsExpand).Post(s.metricsExpand)
 	r.Get("/metrics/index.json", withOrg, ready, s.metricsIndex)
 	r.Post("/metrics/delete", withOrg, ready, bind(models.MetricsDelete{}), s.metricsDelete)
 	r.Combo("/tags/findSeries", withOrg, ready, bind(models.GraphiteTagFindSeries{})).Get(s.graphiteTagFindSeries).Post(s.graphiteTagFindSeries)

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -66,6 +66,30 @@ json and treejson are the same.
 curl -H "X-Org-Id: 12345" "http://localhost:6060/metrics/find?query=statsd.fakesite.counters.session_start.*.count"
 ```
 
+## Expand metric name patterns into all names matching it
+
+```
+GET /metrics/expand
+POST /metrics/expand
+```
+
+Returns metrics which match the given query/queries and are stored under the given org or are public data (see [multi-tenancy](https://github.com/grafana/metrictank/blob/master/docs/multi-tenancy.md)).
+Very similar to `/metrics/find`, the main difference is that it does not deduplicate the results by the last name node and it returns them in a more simple format.
+
+##### Parameters
+
+* header `X-Org-Id` required
+* query (required): a metric name, and can use all graphite glob patterns (`*`, `{}`, `[]`, `?`). can be specified multiple times
+* groupByExpr: if true, then the results get grouped by the query which yielded them, otherwise all results are in a flat list. (defaults to false)
+* leavesOnly: if true, only leaf nodes get returned, if false branch nodes also get returned. (defaults to false)
+* jsonp
+
+#### Example
+
+```bash
+curl 'http://localhost:6061/metrics/expand?groupByExpr=true&query=some.id.of.a.metric.*&query=other.metric.*.*'
+```
+
 ## Find tagged metrics
 
 ```


### PR DESCRIPTION
Implements the API endpoint `/metrics/expand` as documented [here](https://graphite-api.readthedocs.io/en/latest/api.html#metrics-expand).

Without it we can't claim to be API compatible with Graphite