### PR TITLE
Use pointers so plan.Clean() works

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -267,7 +267,7 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 
 	execCtx, execSpan := tracing.NewSpan(ctx.Req.Context(), s.Tracer, "executePlan")
 	defer execSpan.Finish()
-	out, meta, err := s.executePlan(execCtx, ctx.OrgId, plan)
+	out, meta, err := s.executePlan(execCtx, ctx.OrgId, &plan)
 	if err != nil {
 		err := response.WrapError(err)
 		if err.HTTPStatusCode() == http.StatusBadRequest && !request.NoProxy && proxyBadRequests {
@@ -687,7 +687,7 @@ func (s *Server) metricsDeleteRemote(ctx context.Context, orgId uint32, query st
 // executePlan looks up the needed data, retrieves it, and then invokes the processing
 // note if you do something like sum(foo.*) and all of those metrics happen to be on another node,
 // we will collect all the individual series from the peer, and then sum here. that could be optimized
-func (s *Server) executePlan(ctx context.Context, orgId uint32, plan expr.Plan) ([]models.Series, models.RenderMeta, error) {
+func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan) ([]models.Series, models.RenderMeta, error) {
 	var meta models.RenderMeta
 
 	minFrom := uint32(math.MaxUint32)

--- a/expr/plan.go
+++ b/expr/plan.go
@@ -302,7 +302,7 @@ func newplanFunc(e *expr, fn GraphiteFunc, context Context, stable bool, reqs []
 }
 
 // Run invokes all processing as specified in the plan (expressions, from/to) against the given datamap
-func (p Plan) Run(dataMap DataMap) ([]models.Series, error) {
+func (p *Plan) Run(dataMap DataMap) ([]models.Series, error) {
 	var out []models.Series
 	p.dataMap = dataMap
 	for _, fn := range p.funcs {


### PR DESCRIPTION
Verified locally. Results in a moderate reduction in alloc rate for query nodes.