### PR TITLE
Fix NormalizeTo bug: prepend correct amount of points to pre-canonicalize series

### DIFF
--- a/expr/normalize.go
+++ b/expr/normalize.go
@@ -79,7 +79,8 @@ func NormalizeTo(dataMap DataMap, in models.Series, interval uint32) models.Seri
 	// (it breaches `to`, and may have more points than other series it needs to be combined with)
 	// thus, we also need to potentially trim points from the back until the last point has the same Ts as a canonical series would
 
-	for ts := align.ForwardIfNotAligned(in.Datapoints[0].Ts, interval) - interval + in.Interval; ts < in.Datapoints[0].Ts; ts += interval {
+	canonicalStart := align.ForwardIfNotAligned(in.Datapoints[0].Ts, interval) - interval + in.Interval
+	for ts := canonicalStart; ts < in.Datapoints[0].Ts; ts += in.Interval {
 		datapoints = append(datapoints, schema.Point{Val: math.NaN(), Ts: ts})
 	}
 

--- a/expr/normalize_test.go
+++ b/expr/normalize_test.go
@@ -147,3 +147,37 @@ func TestNormalizeMultiLCMSeriesAdjustWithPreCanonicalize(t *testing.T) {
 		t.Errorf("TestNormalize() mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestNormalizeToWithMissingBeginning(t *testing.T) {
+	in := models.Series{
+		Interval:     15,
+		QueryFrom:    35,
+		QueryTo:      136,
+		Consolidator: consolidation.Sum,
+		Datapoints: []schema.Point{
+			{Ts: 45, Val: 45},
+			{Ts: 60, Val: 60},
+			{Ts: 75, Val: 75},
+			{Ts: 90, Val: 90},
+			{Ts: 105, Val: 105},
+			{Ts: 120, Val: 120},
+			{Ts: 135, Val: 135},
+		},
+	}
+	// 135 gets dropped
+	want := models.Series{
+		Interval:     60,
+		QueryFrom:    35,
+		QueryTo:      136,
+		Consolidator: consolidation.Sum,
+		Datapoints: []schema.Point{
+			{Ts: 60, Val: 45 + 60},
+			{Ts: 120, Val: 75 + 90 + 105 + 120},
+		},
+	}
+	dataMap := NewDataMap()
+	got := NormalizeTo(dataMap, in, 60)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("TestNormalize() mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
fixes #1812 

The basic issue here is that we weren't prepending enough NaN to fill out a series before calling consolidate. For the example in the test we had timestamps:

`[ 45, 60, 75, 90, 105, 135 ]` that we want to normalize to 60 second data. This means turning 4 points into 1. For consolidate to act on the proper time boundaries 15-60 and 75-105, we need to pad extra timestamps in the front to make `[ 15, 30, 45, 60, 75, 90, 105, 135 ]`

Unfortunately, the current code uses the output interval (60) not the input interval (15) as the step, so it would only ever prepend 0 or 1 timestamps. 