### PR TITLE
Mt-fakemetrics: configurable builders + "daily-sine" value policy

### DIFF
--- a/cmd/mt-fakemetrics/cmd/backfill.go
+++ b/cmd/mt-fakemetrics/cmd/backfill.go
@@ -50,7 +50,7 @@ var backfillCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(backfillCmd)
-	backfillCmd.Flags().StringVar(&metricName, "metricname", "some.id.of.a.metric", "the metric name to use")
+	backfillCmd.Flags().StringVar(&metricName, "metricname", "some.id.of.a.metric.%d", "the metric name to use")
 	backfillCmd.Flags().DurationVar(&offset, "offset", 0, "offset duration expression. (how far back in time to start. e.g. 1month, 6h, etc). must be a multiple of 1s")
 	backfillCmd.Flags().IntVar(&orgs, "orgs", 1, "how many orgs to simulate")
 	backfillCmd.Flags().IntVar(&mpo, "mpo", 100, "how many metrics per org to simulate")

--- a/cmd/mt-fakemetrics/cmd/backfill.go
+++ b/cmd/mt-fakemetrics/cmd/backfill.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"time"
 
+	builder "github.com/grafana/metrictank/cmd/mt-fakemetrics/metricbuilder"
 	"github.com/grafana/metrictank/cmd/mt-fakemetrics/policy"
 	"github.com/spf13/cobra"
 )
@@ -35,7 +36,15 @@ var backfillCmd = &cobra.Command{
 			panic(err)
 		}
 
-		dataFeed(out, orgs, mpo, period, flush, int(offset.Seconds()), speedup, true, TaggedBuilder{metricName}, vp)
+		builder := builder.Tagged{
+			MetricName:          metricName,
+			CustomTags:          customTags,
+			AddTags:             addTags,
+			NumUniqueCustomTags: numUniqueCustomTags,
+			NumUniqueTags:       numUniqueTags,
+		}
+
+		dataFeed(out, orgs, mpo, period, flush, int(offset.Seconds()), speedup, true, builder, vp)
 	},
 }
 

--- a/cmd/mt-fakemetrics/cmd/backfill.go
+++ b/cmd/mt-fakemetrics/cmd/backfill.go
@@ -49,5 +49,5 @@ func init() {
 	backfillCmd.Flags().IntVar(&speedup, "speedup", 1, "for each advancement of real time, how many advancements of fake data to simulate")
 	backfillCmd.Flags().DurationVar(&flushDur, "flush", time.Second, "how often to flush metrics")
 	backfillCmd.Flags().DurationVar(&periodDur, "period", time.Second, "period between metric points (must be a multiple of 1s)")
-	backfillCmd.Flags().StringVar(&valuePolicy, "value-policy", "", "a value policy (i.e. \"single:1\" \"multiple:1,2,3,4,5\" \"timestamp\")")
+	backfillCmd.Flags().StringVar(&valuePolicy, "value-policy", "", "a value policy (i.e. \"single:1\" \"multiple:1,2,3,4,5\" \"timestamp\" \"daily-sine:<peak>,<offset>,<stdev>\")")
 }

--- a/cmd/mt-fakemetrics/cmd/backfill.go
+++ b/cmd/mt-fakemetrics/cmd/backfill.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"time"
 
-	builder "github.com/grafana/metrictank/cmd/mt-fakemetrics/metricbuilder"
 	"github.com/grafana/metrictank/cmd/mt-fakemetrics/policy"
 	"github.com/spf13/cobra"
 )
@@ -36,21 +35,14 @@ var backfillCmd = &cobra.Command{
 			panic(err)
 		}
 
-		builder := builder.Tagged{
-			MetricName:          metricName,
-			CustomTags:          customTags,
-			AddTags:             addTags,
-			NumUniqueCustomTags: numUniqueCustomTags,
-			NumUniqueTags:       numUniqueTags,
-		}
-
-		dataFeed(out, orgs, mpo, period, flush, int(offset.Seconds()), speedup, true, builder, vp)
+		dataFeed(out, orgs, mpo, period, flush, int(offset.Seconds()), speedup, true, getBuilder(metricBuilder, metricName), vp)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(backfillCmd)
 	backfillCmd.Flags().StringVar(&metricName, "metricname", "some.id.of.a.metric.%d", "the metric name to use")
+	backfillCmd.Flags().StringVar(&metricBuilder, "metricbuilder", "simple", "the metric builder to use. (simple|tagged)")
 	backfillCmd.Flags().DurationVar(&offset, "offset", 0, "offset duration expression. (how far back in time to start. e.g. 1month, 6h, etc). must be a multiple of 1s")
 	backfillCmd.Flags().IntVar(&orgs, "orgs", 1, "how many orgs to simulate")
 	backfillCmd.Flags().IntVar(&mpo, "mpo", 100, "how many metrics per org to simulate")

--- a/cmd/mt-fakemetrics/cmd/feed.go
+++ b/cmd/mt-fakemetrics/cmd/feed.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"time"
 
+	builder "github.com/grafana/metrictank/cmd/mt-fakemetrics/metricbuilder"
 	"github.com/grafana/metrictank/cmd/mt-fakemetrics/policy"
 	"github.com/spf13/cobra"
 )
@@ -35,7 +36,15 @@ var feedCmd = &cobra.Command{
 			panic(err)
 		}
 
-		dataFeed(out, orgs, mpo, period, flush, 0, 1, false, TaggedBuilder{metricName}, vp)
+		builder := builder.Tagged{
+			MetricName:          metricName,
+			CustomTags:          customTags,
+			AddTags:             addTags,
+			NumUniqueCustomTags: numUniqueCustomTags,
+			NumUniqueTags:       numUniqueTags,
+		}
+
+		dataFeed(out, orgs, mpo, period, flush, 0, 1, false, builder, vp)
 
 	},
 }

--- a/cmd/mt-fakemetrics/cmd/feed.go
+++ b/cmd/mt-fakemetrics/cmd/feed.go
@@ -48,5 +48,5 @@ func init() {
 	feedCmd.Flags().IntVar(&mpo, "mpo", 100, "how many metrics per org to simulate")
 	feedCmd.Flags().DurationVar(&flushDur, "flush", time.Second, "how often to flush metrics")
 	feedCmd.Flags().DurationVar(&periodDur, "period", time.Second, "period between metric points (must be a multiple of 1s)")
-	feedCmd.Flags().StringVar(&valuePolicy, "value-policy", "", "a value policy (i.e. \"single:1\" \"multiple:1,2,3,4,5\" \"timestamp\")")
+	feedCmd.Flags().StringVar(&valuePolicy, "value-policy", "", "a value policy (i.e. \"single:1\" \"multiple:1,2,3,4,5\" \"timestamp\" \"daily-sine:<peak>,<offset>,<stdev>\")")
 }

--- a/cmd/mt-fakemetrics/cmd/feed.go
+++ b/cmd/mt-fakemetrics/cmd/feed.go
@@ -51,7 +51,7 @@ var feedCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(feedCmd)
-	feedCmd.Flags().StringVar(&metricName, "metricname", "some.id.of.a.metric", "the metric name to use")
+	feedCmd.Flags().StringVar(&metricName, "metricname", "some.id.of.a.metric.%d", "the metric name to use")
 	feedCmd.Flags().IntVar(&orgs, "orgs", 1, "how many orgs to simulate")
 	feedCmd.Flags().IntVar(&mpo, "mpo", 100, "how many metrics per org to simulate")
 	feedCmd.Flags().DurationVar(&flushDur, "flush", time.Second, "how often to flush metrics")

--- a/cmd/mt-fakemetrics/cmd/feed.go
+++ b/cmd/mt-fakemetrics/cmd/feed.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"time"
 
-	builder "github.com/grafana/metrictank/cmd/mt-fakemetrics/metricbuilder"
 	"github.com/grafana/metrictank/cmd/mt-fakemetrics/policy"
 	"github.com/spf13/cobra"
 )
@@ -36,15 +35,7 @@ var feedCmd = &cobra.Command{
 			panic(err)
 		}
 
-		builder := builder.Tagged{
-			MetricName:          metricName,
-			CustomTags:          customTags,
-			AddTags:             addTags,
-			NumUniqueCustomTags: numUniqueCustomTags,
-			NumUniqueTags:       numUniqueTags,
-		}
-
-		dataFeed(out, orgs, mpo, period, flush, 0, 1, false, builder, vp)
+		dataFeed(out, orgs, mpo, period, flush, 0, 1, false, getBuilder(metricBuilder, metricName), vp)
 
 	},
 }
@@ -52,6 +43,7 @@ var feedCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(feedCmd)
 	feedCmd.Flags().StringVar(&metricName, "metricname", "some.id.of.a.metric.%d", "the metric name to use")
+	feedCmd.Flags().StringVar(&metricBuilder, "metricbuilder", "simple", "the metric builder to use. (simple|tagged)")
 	feedCmd.Flags().IntVar(&orgs, "orgs", 1, "how many orgs to simulate")
 	feedCmd.Flags().IntVar(&mpo, "mpo", 100, "how many metrics per org to simulate")
 	feedCmd.Flags().DurationVar(&flushDur, "flush", time.Second, "how often to flush metrics")

--- a/cmd/mt-fakemetrics/cmd/getbuilder.go
+++ b/cmd/mt-fakemetrics/cmd/getbuilder.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/grafana/metrictank/cmd/mt-fakemetrics/metricbuilder"
+)
+
+func getBuilder(metricBuilder, metricName string) metricbuilder.Builder {
+	switch metricBuilder {
+	case "tagged":
+		return metricbuilder.Tagged{
+			MetricName:          metricName,
+			CustomTags:          customTags,
+			AddTags:             addTags,
+			NumUniqueCustomTags: numUniqueCustomTags,
+			NumUniqueTags:       numUniqueTags,
+		}
+	case "simple":
+		return metricbuilder.Simple{metricName}
+	}
+	panic("unknown metricbuilder :" + metricBuilder)
+}

--- a/cmd/mt-fakemetrics/cmd/root.go
+++ b/cmd/mt-fakemetrics/cmd/root.go
@@ -69,6 +69,7 @@ var (
 	numUniqueCustomTags int
 
 	filterStrings []string
+	metricBuilder string
 	valuePolicy   string
 
 	kafkaMdmAddr     string

--- a/cmd/mt-fakemetrics/cmd/schemasbackfill.go
+++ b/cmd/mt-fakemetrics/cmd/schemasbackfill.go
@@ -20,7 +20,6 @@ import (
 
 	"time"
 
-	"github.com/grafana/metrictank/cmd/mt-fakemetrics/metricbuilder"
 	"github.com/grafana/metrictank/cmd/mt-fakemetrics/policy"
 	"github.com/grafana/metrictank/conf"
 	log "github.com/sirupsen/logrus"
@@ -34,6 +33,7 @@ var schemasFile = "/etc/metrictank/storage-schemas.conf"
 func init() {
 	rootCmd.AddCommand(schemasbackfillCmd)
 	schemasbackfillCmd.Flags().IntVar(&mpr, "mpr", 10, "how many metrics so simulate per rule")
+	schemasbackfillCmd.Flags().StringVar(&metricBuilder, "metricbuilder", "simple", "the metric builder to use. (simple|tagged)")
 	schemasbackfillCmd.Flags().StringVar(&schemasFile, "schemas-file", "/etc/metrictank/storage-schemas.conf", "path to storage-schemas.conf file")
 	schemasbackfillCmd.Flags().StringVar(&ignore, "ignore", "default", "comma separated list of section names to exclude")
 	schemasbackfillCmd.Flags().DurationVar(&offset, "offset", 0, "offset duration expression. (how far back in time to start. e.g. 1month, 6h, etc). must be a multiple of 1s")
@@ -81,7 +81,7 @@ var schemasbackfillCmd = &cobra.Command{
 				if err != nil {
 					panic(err)
 				}
-				dataFeed(out, 1, mpr, period, flush, int(offset.Seconds()), speedup, true, metricbuilder.Simple{name}, vp)
+				dataFeed(out, 1, mpr, period, flush, int(offset.Seconds()), speedup, true, getBuilder(metricBuilder, name), vp)
 				wg.Done()
 			}(name, schema.Retentions.Rets[0].SecondsPerPoint)
 		}

--- a/cmd/mt-fakemetrics/cmd/schemasbackfill.go
+++ b/cmd/mt-fakemetrics/cmd/schemasbackfill.go
@@ -20,6 +20,7 @@ import (
 
 	"time"
 
+	"github.com/grafana/metrictank/cmd/mt-fakemetrics/metricbuilder"
 	"github.com/grafana/metrictank/cmd/mt-fakemetrics/policy"
 	"github.com/grafana/metrictank/conf"
 	log "github.com/sirupsen/logrus"
@@ -80,7 +81,7 @@ var schemasbackfillCmd = &cobra.Command{
 				if err != nil {
 					panic(err)
 				}
-				dataFeed(out, 1, mpr, period, flush, int(offset.Seconds()), speedup, true, SimpleBuilder{name}, vp)
+				dataFeed(out, 1, mpr, period, flush, int(offset.Seconds()), speedup, true, metricbuilder.Simple{name}, vp)
 				wg.Done()
 			}(name, schema.Retentions.Rets[0].SecondsPerPoint)
 		}

--- a/cmd/mt-fakemetrics/cmd/schemasbackfill.go
+++ b/cmd/mt-fakemetrics/cmd/schemasbackfill.go
@@ -40,7 +40,7 @@ func init() {
 	schemasbackfillCmd.Flags().IntVar(&speedup, "speedup", 1, "for each advancement of real time, how many advancements of fake data to simulate")
 	schemasbackfillCmd.Flags().DurationVar(&flushDur, "flush", time.Second, "how often to flush metrics")
 	schemasbackfillCmd.Flags().DurationVar(&periodDur, "period", time.Second, "period between metric points (must be a multiple of 1s)")
-	schemasbackfillCmd.Flags().StringVar(&valuePolicy, "value-policy", "", "a value policy (i.e. \"single:1\" \"multiple:1,2,3,4,5\" \"timestamp\")")
+	schemasbackfillCmd.Flags().StringVar(&valuePolicy, "value-policy", "", "a value policy (i.e. \"single:1\" \"multiple:1,2,3,4,5\" \"timestamp\" \"daily-sine:<peak>,<offset>,<stdev>\")")
 }
 
 // schemasbackfillCmd represents the schemasbackfill command

--- a/cmd/mt-fakemetrics/metricbuilder/builder.go
+++ b/cmd/mt-fakemetrics/metricbuilder/builder.go
@@ -1,0 +1,122 @@
+package metricbuilder
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/grafana/metrictank/schema"
+)
+
+type Builder interface {
+	Info() string
+	// Build builds a slice of slices of MetricData's( per orgid), with time and value not set yet.
+	Build(orgs, mpo, period int) [][]schema.MetricData
+}
+
+// uses no tags
+type Simple struct {
+	MetricName string
+}
+
+func (s Simple) Info() string {
+	return "metricName=" + s.MetricName
+}
+
+func (s Simple) Build(orgs, mpo, period int) [][]schema.MetricData {
+	out := make([][]schema.MetricData, orgs)
+	for o := 0; o < orgs; o++ {
+		metrics := make([]schema.MetricData, mpo)
+		for m := 0; m < mpo; m++ {
+			name := fmt.Sprintf("%s.%d", s.MetricName, m+1)
+			metrics[m] = schema.MetricData{
+				Name:     name,
+				OrgId:    o + 1,
+				Interval: period,
+				Unit:     "ms",
+				Mtype:    "gauge",
+			}
+			metrics[m].SetId()
+		}
+		out[o] = metrics
+	}
+	return out
+}
+
+// uses tags
+type Tagged struct {
+	MetricName          string
+	CustomTags          []string
+	AddTags             bool
+	NumUniqueCustomTags int
+	NumUniqueTags       int
+}
+
+func (tb Tagged) Info() string {
+	return "metricName=" + tb.MetricName
+}
+
+func (tb Tagged) Build(orgs, mpo, period int) [][]schema.MetricData {
+	out := make([][]schema.MetricData, orgs)
+	for o := 0; o < orgs; o++ {
+		metrics := make([]schema.MetricData, mpo)
+		for m := 0; m < mpo; m++ {
+			var tags []string
+			name := fmt.Sprintf("%s.%d", tb.MetricName, m+1)
+
+			localTags := []string{
+				"secondkey=anothervalue",
+				"thirdkey=onemorevalue",
+				"region=west",
+				"os=ubuntu",
+				"anothertag=somelongervalue",
+				"manymoreother=lotsoftagstointern",
+				"afewmoretags=forgoodmeasure",
+				"onetwothreefourfivesix=seveneightnineten",
+				"lotsandlotsoftags=morefunforeveryone",
+				"goodforpeoplewhojustusetags=forbasicallyeverything",
+			}
+
+			if len(tb.CustomTags) > 0 {
+				if tb.NumUniqueCustomTags > 0 {
+					var j int
+					for j = 0; j < tb.NumUniqueCustomTags; j++ {
+						tags = append(tags, tb.CustomTags[j]+strconv.Itoa(m+1))
+					}
+					for j < len(tb.CustomTags) {
+						tags = append(tags, tb.CustomTags[j])
+						j++
+					}
+
+				} else {
+					tags = tb.CustomTags
+				}
+			}
+
+			if tb.AddTags {
+				if tb.NumUniqueTags > 0 {
+					var j int
+					for j = 0; j < tb.NumUniqueTags; j++ {
+						tags = append(tags, localTags[j]+strconv.Itoa(m+1))
+					}
+					for j < len(localTags) {
+						tags = append(tags, localTags[j])
+						j++
+					}
+				} else {
+					tags = localTags
+				}
+			}
+			metrics[m] = schema.MetricData{
+				Name:     name,
+				OrgId:    o + 1,
+				Interval: period,
+				Unit:     "ms",
+				Mtype:    "gauge",
+				Tags:     tags,
+			}
+			metrics[m].SetId()
+		}
+		out[o] = metrics
+	}
+	return out
+}

--- a/cmd/mt-fakemetrics/metricbuilder/builder.go
+++ b/cmd/mt-fakemetrics/metricbuilder/builder.go
@@ -13,7 +13,7 @@ type Builder interface {
 	Build(orgs, mpo, period int) [][]schema.MetricData
 }
 
-// uses no tags
+// Simple builds simple metrics by name
 type Simple struct {
 	MetricName string
 }
@@ -42,7 +42,7 @@ func (s Simple) Build(orgs, mpo, period int) [][]schema.MetricData {
 	return out
 }
 
-// uses tags
+// Tagged builds metrics with a name and various tag related options
 type Tagged struct {
 	MetricName          string
 	CustomTags          []string

--- a/cmd/mt-fakemetrics/policy/policy.go
+++ b/cmd/mt-fakemetrics/policy/policy.go
@@ -1,10 +1,14 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"strconv"
 	"strings"
+
+	"github.com/raintank/dur"
 )
 
 type ValuePolicy interface {
@@ -23,6 +27,61 @@ type ValuePolicyTimestamp struct {
 
 func (v *ValuePolicyTimestamp) Value(ts int64) float64 {
 	return float64(ts)
+}
+
+/*
+	if you ever wanted a triangular pattern with configurable peak and stdev, that peaks at noon, this code worked:
+	remainder := ts % (24 * 3600)
+	num := math.Abs(float64((12 * 3600) - remainder)) // number between 0 (if ts was around noon) and 12*3600 (if ts was around midnight)
+	val := rand.NormFloat64()*1000 + (v.peak * (1 - (num / float64(12*3600))))
+	if val < 0 {
+		val = 0
+	}
+	return val
+*/
+
+// ValuePolicyDailySine mimics a daily sinus-shaped trend e.g. traffic to a website
+type ValuePolicyDailySine struct {
+	peak   float64 // average peak values
+	offset uint32  // time in seconds into the day where we should peak (0<= x <24h)
+	stdev  float64 // standard deviation. typically you want 0 < x < peak
+
+}
+
+func NewDailySine(args string) (ValuePolicyDailySine, error) {
+	argsv := strings.Split(args, ",")
+	if len(argsv) != 3 {
+		return ValuePolicyDailySine{}, errors.New("DailySine needs 3 comma separated options")
+	}
+	peak, err := strconv.ParseFloat(argsv[0], 64)
+	if err != nil {
+		return ValuePolicyDailySine{}, fmt.Errorf("could not parse peak value: %s", argsv[0])
+	}
+	offset, err := dur.ParseDuration(argsv[1])
+	if err != nil {
+		return ValuePolicyDailySine{}, fmt.Errorf("could not parse offset value: %s", argsv[1])
+	}
+	stdev, err := strconv.ParseFloat(argsv[2], 64)
+	if err != nil {
+		return ValuePolicyDailySine{}, fmt.Errorf("could not parse stdev value: %s", argsv[2])
+	}
+
+	return ValuePolicyDailySine{
+		peak:   peak,
+		offset: offset,
+		stdev:  stdev,
+	}, nil
+}
+
+func (v ValuePolicyDailySine) Value(ts int64) float64 {
+	// a sine does a full cycle every every time we increase x by 2*Pi
+	// we change this to a daily cycle
+	// also, a sine normally has its peak at 1/4 into its cycle, so we adjust for that
+	offset := (6 * 3600) - int64(v.offset)
+	sineValue := (1 + math.Sin(2*math.Pi*float64(ts+offset)/(24*3600))) * v.peak / 2 // this value is the daily cycle, between 0 and v.peak, peaking at offset
+
+	return math.Abs(rand.NormFloat64()*v.stdev + sineValue)
+
 }
 
 type ValuePolicySingle struct {
@@ -71,6 +130,8 @@ func ParseValuePolicy(p string) (ValuePolicy, error) {
 	}
 
 	switch strings.TrimSpace(p[:split]) {
+	case "daily-sine":
+		return NewDailySine(p[split+1:])
 	case "single":
 		val, err := strconv.ParseFloat(strings.TrimSpace(p[split+1:]), 64)
 		if err != nil {


### PR DESCRIPTION
Mainly this makes it so that you can choose a metric builder (simple, tagged) orthogonally to a mode (backfill, feed, etc)
Also, better options to generate metricname, and a value policy that generates sine waves with configurable amount of noise and peak time. I used this for my Lineage metadata blog post that uses a fake statsd counter (where i didn't want a number appended to the metric)
