### PR TITLE
Return 499 http code instead of 502 when client disconnect during a render query with graphite proxying

### DIFF
--- a/api/response/error.go
+++ b/api/response/error.go
@@ -96,4 +96,6 @@ func (r *ErrorResp) Headers() (headers map[string]string) {
 	return headers
 }
 
-var RequestCanceledErr = NewError(499, "request canceled")
+const HttpClientClosedRequest = 499
+
+var RequestCanceledErr = NewError(HttpClientClosedRequest, "request canceled")


### PR DESCRIPTION
If the client disconnects while processing a query that needs to be forwarded to graphite, return http code 499 instead of default 502 by implementing a custom proxy error handler.

Fix #1820