### PR TITLE
fix datafeed metrics loop

### DIFF
--- a/cmd/mt-fakemetrics/cmd/datafeed.go
+++ b/cmd/mt-fakemetrics/cmd/datafeed.go
@@ -123,7 +123,6 @@ times %4d orgs: each %s, flushing %d metrics so rate of %d Hz. (%d total unique 
 		}
 		flushDuration.Value(time.Since(preFlush))
 
-		log.ConsoleErrorf("ts: %v - now: %v - nowT: %v", ts, now, nowT)
 		if ts >= now && stopAtNow {
 			return
 		}


### PR DESCRIPTION
This PR fixes a problem in `mt-fakemetrics` tool inside the loop that sends data. In certain cases where the `--speedup` was set to a high value it would cause `mt-fakemetrics` to send data with future timestamps.