### PR TITLE
Docs: Align naming with Grafana.com

### DIFF
--- a/docs/cloud/_index.md
+++ b/docs/cloud/_index.md
@@ -3,9 +3,9 @@ title: Grafana Cloud Graphite
 header: false
 ---
 
-# Hosted Metrics - Graphite
+# Metrics - Graphite
 
-Grafana Labs' Hosted metrics Graphite service offers a graphite-compatible monitoring backend as a service.
+Grafana Labs' metrics Graphite service offers a graphite-compatible monitoring backend as a service.
 It acts and behaves as a regular graphite datasource within Grafana (or other tools), but behind the scenes, it is a sophisticated platform run by a team of dedicated engineers.
 
 * [data ingestion]({{< relref "data-ingestion" >}})
@@ -16,15 +16,15 @@ It acts and behaves as a regular graphite datasource within Grafana (or other to
 
 Several examples below have a `<instance URL>` placeholder.
 To identify your instance URL, login at grafana.com and
-navigate to your Hosted Metrics instance details.
+navigate to your Metrics instance details.
 
 
-## Using Grafana with Hosted Metrics
+## Using Grafana with Metrics
 
-Configuring Grafana for Hosted Metrics works the same way,
-whether you’re using your own Grafana or Hosted Grafana.
+Configuring Grafana for Metrics works the same way,
+whether or not you’re using Grafana Cloud.
 
-Once logged into your Grafana, you need to add a data source for Hosted Metrics
+Once logged into your Grafana, you need to add a data source for Metrics
 with the following details:
 
 **Grafana Data Source settings**
@@ -42,13 +42,13 @@ Field          | Value
 
 ## Sending Data with Carbon-Relay-NG
 
-There are a variety of ways that you can send your data to Hosted Metrics.
+There are a variety of ways that you can send your data to Metrics.
 
 In most situations, you should install a carbon-relay-ng service
 in each of the datacenter or regions that you will be sending metrics from.
 
 This will accept plain-text carbon (Graphite) input,
-and stream your encrypted metrics to the Hosted Metrics.
+and stream your encrypted data to Metrics.
 Since carbon-relay-ng can buffer metric streams in memory,
 this also provides increased resiliency to connectivity issues.
 

--- a/docs/cloud/data-ingestion.md
+++ b/docs/cloud/data-ingestion.md
@@ -19,14 +19,14 @@ Customers typically deploy using either of these 2 options:
 
 If your Graphite stack does not currently contain any relay, then you can simply add carbon-relay-ng, have your clients (statsd, collectd, diamond, etc) send data to the relay, which in turn can send data to your existing graphite server *and* to our platform.
 
-When creating a Hosted Metrics Graphite instance, we provide a carbon-relay-ng config file that you can plug in and be ready to use out of the box.
+When creating a Metrics Graphite instance, we provide a carbon-relay-ng config file that you can plug in and be ready to use out of the box.
 We also have Grafana Labs engineers ready to advise further on set up, if needed.
 
 ## Using carbon-relay-ng as a replacement for carbon-relay or carbon-cache
 
 The most simple way to send your carbon traffic to GrafanaCloud is to use carbon-relay-ng as a replacement for your current carbon-relay or carbon-cache. Carbon-relay-ng has a carbon input which supports the plain text and the pickle protocols, just like carbon-relay and carbon-cache. Note that the consistent-hashing implementation in carbon-relay-ng is different from the one in carbon-relay, so if you're using consistent-hashing then switching from carbon-relay to carbon-relay-ng would re-distribute the metrics among the destinations.
 
-An example configuration to do that can be downloaded from your Hosted Metrics instance's "Details" page. It contains a `grafanaNet` route pointing at your instance.
+An example configuration to do that can be downloaded from your Metrics instance's "Details" page. It contains a `grafanaNet` route pointing at your instance.
 
 ## Sending a copy of your carbon traffic to GrafanaCloud
 
@@ -107,8 +107,8 @@ When distributing traffic among multiple instances of carbon-relay-ng it is impo
 
 ```table
 |-------------------| |-------------------| |-------------------| |-------------------| |-------------------| |-------------------|
-| metric producer 1 | | metric producer 2 | | metric producer 3 | | metric producer 4 | | metric producer 5 | | metric producer 6 | 
-|-------------------| |-------------------| |-------------------| |-------------------| |-------------------| |-------------------| 
+| metric producer 1 | | metric producer 2 | | metric producer 3 | | metric producer 4 | | metric producer 5 | | metric producer 6 |
+|-------------------| |-------------------| |-------------------| |-------------------| |-------------------| |-------------------|
                     \                     \           |                      |          /                     /
                      \                     \          |                      |         /                     /
                       \                     \         |                      |        /                     /
@@ -132,8 +132,8 @@ This setup gives you failure tolerance and scalability:
 
 ```table
 |-------------------| |-------------------| |-------------------| |-------------------| |-------------------| |-------------------|
-| metric producer 1 | | metric producer 2 | | metric producer 3 | | metric producer 4 | | metric producer 5 | | metric producer 6 | 
-|-------------------| |-------------------| |-------------------| |-------------------| |-------------------| |-------------------| 
+| metric producer 1 | | metric producer 2 | | metric producer 3 | | metric producer 4 | | metric producer 5 | | metric producer 6 |
+|-------------------| |-------------------| |-------------------| |-------------------| |-------------------| |-------------------|
           \                     /                   /                        \                    /                    /
            \                   /                   /                          \                  /                    /
             \                 / /-----------------/                            \                / /------------------/

--- a/docs/cloud/faq.md
+++ b/docs/cloud/faq.md
@@ -10,9 +10,9 @@ Yes, our platform supports graphite tags as well as [meta tags](https://grafana.
 
 ### Can I import my existing data?
 
-You can import pre-existing data into the hosted platform, from either a Graphite or metrictank installation.
+You can import pre-existing data, from either a Graphite or metrictank installation.
 We either provide you with the tools and instructions, or if provided access, we offer this service for a hands-off experience.
-Grafana dashboards can also be imported if you choose to use a hosted Grafana instance.
+Dashboards can also be imported if you choose to use Grafana Cloud.
 
 ### How do I send data to the service?
 
@@ -20,11 +20,11 @@ See [data ingestion]({{< relref "data-ingestion" >}}).
 
 ### How does this compare to stock graphite?
 
-The hosted platform is built on top of [metrictank](/oss/metrictank) and [graphite](/oss/graphite)
+Grafana Cloud is built on top of [metrictank](/oss/metrictank) and [graphite](/oss/graphite)
 Important differences with stock Graphite to be aware of:
 
 * support for meta tags
-* the platform is optimized for append-only workloads. While historical data can be imported, and we can allow for some out-of-orderness in the recent window (e.g. last 10 or 60 points), we currently don't support out of order writes (overwriting old data)
+* Grafana Cloud is optimized for append-only workloads. While historical data can be imported, and we can allow for some out-of-orderness in the recent window (e.g. last 10 or 60 points), we currently don't support out of order writes (overwriting old data)
 * timeseries can change resolution (interval) over time, they will be merged automatically.
 * Response metadata: performance statistics, series lineage information and rollup indicator (all visualized through grafana)
 * Index pruning (hide inactive/stale series)
@@ -43,6 +43,6 @@ so we will pick the minutely data instead. This way you typically still get high
 
 Note that on custom plans, these settings can be adjusted. You can also [pre-aggregate data in carbon-relay-ng](https://github.com/grafana/carbon-relay-ng/blob/master/docs/aggregation.md) to load fewer series.
 
-## Do I have to use hosted grafana or exclusively the hosted platform?
+## Do I have to exclusively use Grafana Cloud?
 
-No, the hosted platform is a datasource that you can use however you like. E.g. in combination with other datasources, and queried from any Grafana instance or other client.
+No, Grafana Cloud contains a datasource that you can use however you like. E.g. in combination with other datasources, and queried from any Grafana instance or other client.

--- a/docs/cloud/http-api.md
+++ b/docs/cloud/http-api.md
@@ -7,7 +7,7 @@ weight: 2
 
 The HTTP API is the same as that of Graphite, with the addition of ingestion, authentication and meta tags.
 
-First of all, there are two endpoints you will be talking to. They are provided on your grafana.com Hosted Metrics instance details page.
+First of all, there are two endpoints you will be talking to. They are provided on your Metrics instance details page.
 
 They will look something like:
 
@@ -62,7 +62,7 @@ Authorization: Basic base64(<instance id>:<api key>)
 Authorization: Bearer <instance id>:<api key>
 ```
 
-Note that you can find the instance ID as the username in the "Using Grafana with Hosted Metrics" section of your Grafana.com instance details page
+Note that you can find the instance ID as the username in the "Using Grafana with Metrics" section of your Grafana.com instance details page
 
 So essentially you can use basic auth with username "api_key" (for dedicated clusters) or your instance ID (for shared clusters) and password the api key that you provisoned
 


### PR DESCRIPTION
Purpose is to move away from "Hosted X" and toward "Grafana Cloud X" or just "X".

Here are the related PRs for renaming on grafana-com: grafana/grafana-com#1561, grafana/grafana-com#1553.