### PR TITLE
add details format to /metrics/find endpoint and update docs

### DIFF
--- a/docs/cloud/http-api.md
+++ b/docs/cloud/http-api.md
@@ -221,7 +221,7 @@ Returns metrics which match the `query` and have received an update since `from`
 ##### Parameters
 
 * query (required): [Graphite pattern](#graphite-patterns)
-* format: json, treejson, completer, pickle, or msgpack. (defaults to json)
+* format: json, treejson, completer, pickle, msgpack, or details. (defaults to json)
 * jsonp: true/false: enables jsonp
 * from: Graphite from time specification (defaults to now-24hours)
 
@@ -231,6 +231,7 @@ Returns metrics which match the `query` and have received an update since `from`
 * completer: used for graphite-web's completer UI
 * msgpack: optimized transfer format
 * pickle: deprecated
+* details: returns a json of any found series and their archives (including MKey and Interval)
 
 
 ##### Example

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -53,7 +53,7 @@ POST /metrics/find
 
 * header `X-Org-Id` required
 * query (required): can be an id, and use all graphite glob patterns (`*`, `{}`, `[]`, `?`)
-* format: json, treejson, completer, pickle, or msgpack. (defaults to json)
+* format: json, treejson, completer, pickle, msgpack, or details. (defaults to json)
 * jsonp
 
 Returns metrics which match the query and are stored under the given org or are public data (see [multi-tenancy](https://github.com/grafana/metrictank/blob/master/docs/multi-tenancy.md))


### PR DESCRIPTION
This PR adds a new format called `details` to the `/metrics/find` endpoint. You can use this to return detailed information on a series, including all of its archives (along with their MKeys and Intervals, etc..). This partly addresses some of the comments in #1115. Will need another PR to add retrieval (in Json format) by MKey.

See also: #1527, #1565 