### PR TITLE
add utf8 validation checks to incoming metrics

### DIFF
--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -270,10 +270,10 @@ func main() {
 			continue
 		}
 		if tags == "valid" || tags == "invalid" {
-			valid := schema.ValidateTags(d.Tags)
+			err := schema.ValidateTags(d.Tags)
 
 			// skip the metric if the validation result is not what we want
-			if valid != (tags == "valid") {
+			if (err == nil) != (tags == "valid") {
 				continue
 			}
 		}

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -258,10 +258,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -260,6 +260,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -258,10 +258,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -260,6 +260,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -258,10 +258,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -260,6 +260,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -258,10 +258,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -260,6 +260,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]

--- a/docs/config.md
+++ b/docs/config.md
@@ -311,6 +311,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 ```
 
 ### carbon input (optional)

--- a/docs/config.md
+++ b/docs/config.md
@@ -309,10 +309,8 @@ log-headers = false
 
 ```
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 ```
 
 ### carbon input (optional)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -222,6 +222,10 @@ a count of times a metricdata was invalid by input plugin
 * `input.%s.metricdata.discarded.invalid_tags`:  
 a count of times a metricdata was considered invalid due to
 invalid tags in the metric definition. all rejected metrics counted here are also counted in the above "invalid" counter
+* `input.%s.metricdata.discarded.invalid_utf`:  
+a count of times a metricdata was considered invalid due to
+invalid utf8 in either the name or tags in the metric definition. all rejected metrics counted here are also counted in
+above "invalid" counter
 * `input.%s.metricdata.received`:  
 the count of metricdata datapoints received by input plugin
 * `input.%s.metricpoint.discarded.invalid`:  

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -219,13 +219,9 @@ the duration of (successful) update of a metric to the memory idx
 the number of currently known metrics in the index
 * `input.%s.metricdata.discarded.invalid`:  
 a count of times a metricdata was invalid by input plugin
-* `input.%s.metricdata.discarded.invalid_tags`:  
+* `input.%s.metricdata.discarded.invalid_input`:  
 a count of times a metricdata was considered invalid due to
-invalid tags in the metric definition. all rejected metrics counted here are also counted in the above "invalid" counter
-* `input.%s.metricdata.discarded.invalid_utf`:  
-a count of times a metricdata was considered invalid due to
-invalid utf8 in either the name or tags in the metric definition. all rejected metrics counted here are also counted in
-above "invalid" counter
+invalid input data in the metric definition. all rejected metrics counted here are also counted in the above "invalid" counter
 * `input.%s.metricdata.received`:  
 the count of metricdata datapoints received by input plugin
 * `input.%s.metricpoint.discarded.invalid`:  

--- a/input/input.go
+++ b/input/input.go
@@ -18,14 +18,12 @@ import (
 )
 
 var (
-	rejectInvalidTags bool
-	rejectInvalidUtf8 bool
+	rejectInvalidInput bool
 )
 
 func ConfigSetup() {
 	input := flag.NewFlagSet("input", flag.ExitOnError)
-	input.BoolVar(&rejectInvalidTags, "reject-invalid-tags", true, "reject received metrics that have invalid tags")
-	input.BoolVar(&rejectInvalidUtf8, "reject-invalid-utf8", false, "reject received metrics with invalid utf8 data")
+	input.BoolVar(&rejectInvalidInput, "reject-invalid-input", true, "reject received metrics that have invalid input data")
 	globalconf.Register("input", input, flag.ExitOnError)
 }
 
@@ -38,14 +36,13 @@ type Handler interface {
 
 // Default is a base handler for a metrics packet, aimed to be embedded by concrete implementations
 type DefaultHandler struct {
-	receivedMD   *stats.Counter32
-	receivedMP   *stats.Counter32
-	receivedMPNO *stats.Counter32
-	invalidMD    *stats.CounterRate32
-	invalidTagMD *stats.CounterRate32
-	invalidUtfMD *stats.CounterRate32
-	invalidMP    *stats.CounterRate32
-	unknownMP    *stats.Counter32
+	receivedMD     *stats.Counter32
+	receivedMP     *stats.Counter32
+	receivedMPNO   *stats.Counter32
+	invalidMD      *stats.CounterRate32
+	invalidInputMD *stats.CounterRate32
+	invalidMP      *stats.CounterRate32
+	unknownMP      *stats.Counter32
 
 	metrics     mdata.Metrics
 	metricIndex idx.MetricIndex
@@ -58,8 +55,7 @@ const (
 	invalidOrgId     = "invalid-orgID"
 	invalidName      = "invalid-name"
 	invalidMtype     = "invalid-mtype"
-	invalidTagFormat = "invalid-tag-format"
-	invalidUtf8      = "invalid-utf8-data"
+	invalidInput     = "invalid-input"
 	unknownPointId   = "unknown-point-id"
 )
 
@@ -73,13 +69,9 @@ func NewDefaultHandler(metrics mdata.Metrics, metricIndex idx.MetricIndex, input
 		receivedMPNO: stats.NewCounter32(fmt.Sprintf("input.%s.metricpoint_no_org.received", input)),
 		// metric input.%s.metricdata.discarded.invalid is a count of times a metricdata was invalid by input plugin
 		invalidMD: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricdata.discarded.invalid", input)),
-		// metric input.%s.metricdata.discarded.invalid_tags is a count of times a metricdata was considered invalid due to
-		// invalid tags in the metric definition. all rejected metrics counted here are also counted in the above "invalid" counter
-		invalidTagMD: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricdata.discarded.invalid_tag", input)),
-		// metric input.%s.metricdata.discarded.invalid_utf is a count of times a metricdata was considered invalid due to
-		// invalid utf8 in either the name or tags in the metric definition. all rejected metrics counted here are also counted in
-		// above "invalid" counter
-		invalidUtfMD: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricdata.discarded.invalid_utf", input)),
+		// metric input.%s.metricdata.discarded.invalid_input is a count of times a metricdata was considered invalid due to
+		// invalid input data in the metric definition. all rejected metrics counted here are also counted in the above "invalid" counter
+		invalidInputMD: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricdata.discarded.invalid_tag", input)),
 		// metric input.%s.metricpoint.discarded.invalid is a count of times a metricpoint was invalid by input plugin
 		invalidMP: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricpoint.discarded.invalid", input)),
 		// metric input.%s.metricpoint.discarded.unknown is the count of times the ID of a received metricpoint was not in the index, by input plugin
@@ -128,27 +120,13 @@ func (in DefaultHandler) ProcessMetricData(md *schema.MetricData, partition int3
 		in.invalidMD.Inc()
 
 		ignoreError := false
-		// assuming that the tag format was the only issue found by Validate()
-		// better make sure that the tag format is the last check which Validate() checks, to not accidentally ignore a potential following error
-		if err == schema.ErrInvalidTagFormat {
-			in.invalidTagMD.Inc()
-			if !rejectInvalidTags {
+		// assuming that invalid input was the only issue found by Validate()
+		// better make sure that invalid input is the last check which Validate() checks, to not accidentally ignore a potential following error
+		if err == schema.ErrInvalidInput {
+			in.invalidInputMD.Inc()
+			if !rejectInvalidInput {
 				if log.IsLevelEnabled(log.DebugLevel) {
-					log.Debugf("in: Invalid metric %v, not rejecting it because rejection due to invalid tags is disabled: %s", md, err)
-				}
-				ignoreError = true
-			}
-		}
-
-		// if a tag contains invalid UTF8 data and has other invalid tag problems, you will never see this error. We decided to optimize for the most
-		// common use case (no invalid UTF8 data) in order to keep this function fast. If you think you might have an issue with both invalid UTF8 data
-		// and invalid tags, then you should just turn on rejection for both.
-		// this is now the second to last check, just before the Invalid Tag check
-		if err == schema.ErrInvalidUtf8 {
-			in.invalidUtfMD.Inc()
-			if !rejectInvalidUtf8 {
-				if log.IsLevelEnabled(log.DebugLevel) {
-					log.Debugf("in: Invalid metric %v, not rejecting it because rejection due to invalid utf8 data is disabled: %s", md, err)
+					log.Debugf("in: Invalid metric %v, not rejecting it because rejection due to invalid input is disabled: %s", md, err)
 				}
 				ignoreError = true
 			}
@@ -167,10 +145,8 @@ func (in DefaultHandler) ProcessMetricData(md *schema.MetricData, partition int3
 				reason = invalidName
 			case schema.ErrInvalidMtype:
 				reason = invalidMtype
-			case schema.ErrInvalidUtf8:
-				reason = invalidUtf8
-			case schema.ErrInvalidTagFormat:
-				reason = invalidTagFormat
+			case schema.ErrInvalidInput:
+				reason = invalidInput
 			default:
 				reason = "unknown"
 			}

--- a/input/input.go
+++ b/input/input.go
@@ -71,7 +71,7 @@ func NewDefaultHandler(metrics mdata.Metrics, metricIndex idx.MetricIndex, input
 		invalidMD: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricdata.discarded.invalid", input)),
 		// metric input.%s.metricdata.discarded.invalid_input is a count of times a metricdata was considered invalid due to
 		// invalid input data in the metric definition. all rejected metrics counted here are also counted in the above "invalid" counter
-		invalidInputMD: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricdata.discarded.invalid_tag", input)),
+		invalidInputMD: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricdata.discarded.invalid_input", input)),
 		// metric input.%s.metricpoint.discarded.invalid is a count of times a metricpoint was invalid by input plugin
 		invalidMP: stats.NewCounterRate32(fmt.Sprintf("input.%s.metricpoint.discarded.invalid", input)),
 		// metric input.%s.metricpoint.discarded.unknown is the count of times the ID of a received metricpoint was not in the index, by input plugin

--- a/input/input.go
+++ b/input/input.go
@@ -140,6 +140,9 @@ func (in DefaultHandler) ProcessMetricData(md *schema.MetricData, partition int3
 			}
 		}
 
+		// if a tag contains invalid UTF8 data and has other invalid tag problems, you will never see this error. We decided to optimize for the most
+		// common use case (no invalid UTF8 data) in order to keep this function fast. If you think you might have an issue with both invalid UTF8 data
+		// and invalid tags, then you should just turn on rejection for both.
 		// this is now the second to last check, just before the Invalid Tag check
 		if err == schema.ErrInvalidUtf8 {
 			in.invalidUtfMD.Inc()

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -17,177 +17,135 @@ import (
 
 func TestIngestValidAndInvalidTagsAndValuesWithAndWithoutRejection(t *testing.T) {
 	type testCase struct {
-		name                    string
-		mdName                  string
-		rejectInvalidTags       bool
-		rejectInvalidUtf8       bool
-		tags                    []string
-		expectedInvalidMdInc    uint32
-		expectedInvalidTagMdInc uint32
-		expectedInvalidUtf8Inc  uint32
-		expectedIndexSizeInc    uint32
+		name                      string
+		mdName                    string
+		rejectInvalidInput        bool
+		tags                      []string
+		expectedInvalidMdInc      uint32
+		expectedInvalidInputMdInc uint32
+		expectedIndexSizeInc      uint32
 	}
 
 	testCases := []testCase{
 		{
-			name:                    "valid_utf8_with_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       true,
-			tags:                    []string{"valid=tag"},
-			expectedInvalidMdInc:    0,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    1,
+			name:                      "valid_utf8_with_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        true,
+			tags:                      []string{"valid=tag"},
+			expectedInvalidMdInc:      0,
+			expectedInvalidInputMdInc: 0,
+			expectedIndexSizeInc:      1,
 		}, {
-			name:                    "valid_utf8_without_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       false,
-			tags:                    []string{"valid=tag"},
-			expectedInvalidMdInc:    0,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    1,
+			name:                      "valid_utf8_without_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        false,
+			tags:                      []string{"valid=tag"},
+			expectedInvalidMdInc:      0,
+			expectedInvalidInputMdInc: 0,
+			expectedIndexSizeInc:      1,
 		}, {
-			name:                    "invalid_utf8_name_with_rejection",
-			mdName:                  "abc\xc5",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       true,
-			tags:                    []string{"valid=tag"},
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  1,
-			expectedIndexSizeInc:    0,
+			name:                      "invalid_utf8_name_with_rejection",
+			mdName:                    "abc\xc5",
+			rejectInvalidInput:        true,
+			tags:                      []string{"valid=tag"},
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      0,
 		}, {
-			name:                    "invalid_utf8_name_without_rejection",
-			mdName:                  "abc\xc5",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       false,
-			tags:                    []string{"valid=tag"},
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  1,
-			expectedIndexSizeInc:    1,
+			name:                      "invalid_utf8_name_without_rejection",
+			mdName:                    "abc\xc5",
+			rejectInvalidInput:        false,
+			tags:                      []string{"valid=tag"},
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      1,
 		}, {
-			name:                    "invalid_utf8_tag_values_with_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       true,
-			tags:                    []string{"invalid=bb\xc5"},
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  1,
-			expectedIndexSizeInc:    0,
+			name:                      "invalid_utf8_tag_values_with_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        true,
+			tags:                      []string{"invalid=bb\xc5"},
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      0,
 		}, {
-			name:                    "invalid_utf8_tag_values_without_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       false,
-			tags:                    []string{"invalid=bb\xc5"},
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  1,
-			expectedIndexSizeInc:    1,
+			name:                      "invalid_utf8_tag_values_without_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        false,
+			tags:                      []string{"invalid=bb\xc5"},
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      1,
 		}, {
-			name:                    "invalid_utf8_tag_values_and_invalid_tags_with_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       true,
-			rejectInvalidUtf8:       false,
-			tags:                    []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 1,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    0,
+			name:                      "invalid_utf8_tag_values_and_invalid_tags_with_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        true,
+			tags:                      []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      0,
 		}, {
-			name:                    "invalid_utf8_tag_values_and_invalid_tags_with_utf8_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       true,
-			tags:                    []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 1,
-			expectedInvalidUtf8Inc:  0, // since the tag is invalid we won't ever see invalid UTF8 error
-			expectedIndexSizeInc:    1, // index still increases because we are not rejecting invalid tags
+			name:                      "invalid_utf8_tag_values_and_invalid_tags_with_utf8_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        true,
+			tags:                      []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      0,
 		},
 		{
-			name:                    "invalid_utf8_tag_values_and_invalid_tags_with_utf8_rejection_and_tag_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       true,
-			rejectInvalidUtf8:       true,
-			tags:                    []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 1,
-			expectedInvalidUtf8Inc:  0, // since the tag is invalid we won't ever see invalid UTF8 error
-			expectedIndexSizeInc:    0,
-		},
-		{
-			name:                    "valid_with_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       true,
-			rejectInvalidUtf8:       false,
-			tags:                    []string{"valid=tag"},
-			expectedInvalidMdInc:    0,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    1,
+			name:                      "valid_with_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        true,
+			tags:                      []string{"valid=tag"},
+			expectedInvalidMdInc:      0,
+			expectedInvalidInputMdInc: 0,
+			expectedIndexSizeInc:      1,
 		}, {
-			name:                    "valid_without_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       false,
-			tags:                    []string{"valid=tag"},
-			expectedInvalidMdInc:    0,
-			expectedInvalidTagMdInc: 0,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    1,
+			name:                      "valid_without_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        false,
+			tags:                      []string{"valid=tag"},
+			expectedInvalidMdInc:      0,
+			expectedInvalidInputMdInc: 0,
+			expectedIndexSizeInc:      1,
 		}, {
-			name:                    "invalid_tags_with_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       true,
-			rejectInvalidUtf8:       false,
-			tags:                    generateInvalidTags(t),
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 1,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    0,
+			name:                      "invalid_tags_with_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        true,
+			tags:                      generateInvalidTags(t),
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      0,
 		}, {
-			name:                    "invalid_tags_without_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       false,
-			tags:                    generateInvalidTags(t),
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 1,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    1,
+			name:                      "invalid_tags_without_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        false,
+			tags:                      generateInvalidTags(t),
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      1,
 		}, {
-			name:                    "invalid_tag_values_with_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       true,
-			rejectInvalidUtf8:       false,
-			tags:                    generateInvalidTagValues(t),
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 1,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    0,
+			name:                      "invalid_tag_values_with_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        true,
+			tags:                      generateInvalidTagValues(t),
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      0,
 		}, {
-			name:                    "invalid_tag_values_without_rejection",
-			mdName:                  "abc",
-			rejectInvalidTags:       false,
-			rejectInvalidUtf8:       false,
-			tags:                    generateInvalidTagValues(t),
-			expectedInvalidMdInc:    1,
-			expectedInvalidTagMdInc: 1,
-			expectedInvalidUtf8Inc:  0,
-			expectedIndexSizeInc:    1,
+			name:                      "invalid_tag_values_without_rejection",
+			mdName:                    "abc",
+			rejectInvalidInput:        false,
+			tags:                      generateInvalidTagValues(t),
+			expectedInvalidMdInc:      1,
+			expectedInvalidInputMdInc: 1,
+			expectedIndexSizeInc:      1,
 		},
 	}
 
 	for _, tc := range testCases {
 		handler, index, reset := getDefaultHandler(t)
-		rejectInvalidTags = tc.rejectInvalidTags
-		rejectInvalidUtf8 = tc.rejectInvalidUtf8
+		rejectInvalidInput = tc.rejectInvalidInput
 		for i, tag := range tc.tags {
 			data := getTestMetricData()
 			data.Tags = []string{tag}
@@ -199,8 +157,7 @@ func TestIngestValidAndInvalidTagsAndValuesWithAndWithoutRejection(t *testing.T)
 				handler,
 				index,
 				tc.expectedInvalidMdInc,
-				tc.expectedInvalidTagMdInc,
-				tc.expectedInvalidUtf8Inc,
+				tc.expectedInvalidInputMdInc,
 				tc.expectedIndexSizeInc,
 			)
 		}
@@ -271,10 +228,9 @@ func getTestMetricData() schema.MetricData {
 	}
 }
 
-func testIngestMetricData(t *testing.T, tc string, data schema.MetricData, handler DefaultHandler, index idx.MetricIndex, expectedInvalidMdInc, expectedInvalidTagMdInc, expectedInvalidUtf8MdInc, expectedIndexSizeInc uint32) {
+func testIngestMetricData(t *testing.T, tc string, data schema.MetricData, handler DefaultHandler, index idx.MetricIndex, expectedInvalidMdInc, expectedInvalidInputMdInc, expectedIndexSizeInc uint32) {
 	originalInvalidCnt := handler.invalidMD.Peek()
-	originalInvalidTagCnt := handler.invalidTagMD.Peek()
-	originalInvalidUtf8Cnt := handler.invalidUtfMD.Peek()
+	originalInvalidInputCnt := handler.invalidInputMD.Peek()
 	originalIndexSize := uint32(len(index.List(1)))
 	data.SetId()
 	handler.ProcessMetricData(&data, 0)
@@ -283,16 +239,10 @@ func testIngestMetricData(t *testing.T, tc string, data schema.MetricData, handl
 	if invalidCnt != originalInvalidCnt+expectedInvalidMdInc {
 		t.Fatalf("TC %s: Invalid metric counter has not been updated correctly, expected %d, got %d", tc, originalInvalidCnt+expectedInvalidMdInc, invalidCnt)
 	}
-	invalidTagCnt := handler.invalidTagMD.Peek()
+	invalidInputCnt := handler.invalidInputMD.Peek()
 
-	if invalidTagCnt != originalInvalidTagCnt+expectedInvalidTagMdInc {
-		t.Fatalf("TC %s: Invalid tag counter has not been updated correctly, expected %d, got %d", tc, originalInvalidTagCnt+expectedInvalidTagMdInc, invalidTagCnt)
-	}
-
-	invalidUtf8Cnt := handler.invalidUtfMD.Peek()
-
-	if invalidUtf8Cnt != originalInvalidUtf8Cnt+expectedInvalidUtf8MdInc {
-		t.Fatalf("TC %s: Invalid utf8 counter has not been updated correctly, expected %d, got %d", tc, originalInvalidUtf8Cnt+expectedInvalidUtf8MdInc, invalidUtf8Cnt)
+	if invalidInputCnt != originalInvalidInputCnt+expectedInvalidInputMdInc {
+		t.Fatalf("TC %s: Invalid input counter has not been updated correctly, expected %d, got %d", tc, originalInvalidInputCnt+expectedInvalidInputMdInc, invalidInputCnt)
 	}
 
 	indexSize := uint32(len(index.List(1)))
@@ -304,14 +254,14 @@ func testIngestMetricData(t *testing.T, tc string, data schema.MetricData, handl
 func getDefaultHandler(t *testing.T) (DefaultHandler, idx.MetricIndex, func()) {
 	t.Helper()
 
-	oldRejectInvalidTags := rejectInvalidTags
+	oldrejectInvalidInput := rejectInvalidInput
 	oldSchemas := mdata.Schemas
 	oldTagSupport := memory.TagSupport
 	memory.TagSupport = true
 	index := memory.New()
 
 	reset := func() {
-		rejectInvalidTags = oldRejectInvalidTags
+		rejectInvalidInput = oldrejectInvalidInput
 		mdata.Schemas = oldSchemas
 		memory.TagSupport = oldTagSupport
 		index.Stop()

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -18,55 +18,168 @@ import (
 func TestIngestValidAndInvalidTagsAndValuesWithAndWithoutRejection(t *testing.T) {
 	type testCase struct {
 		name                    string
+		mdName                  string
 		rejectInvalidTags       bool
+		rejectInvalidUtf8       bool
 		tags                    []string
 		expectedInvalidMdInc    uint32
 		expectedInvalidTagMdInc uint32
+		expectedInvalidUtf8Inc  uint32
 		expectedIndexSizeInc    uint32
 	}
 
 	testCases := []testCase{
 		{
-			name:                    "valid_with_rejection",
-			rejectInvalidTags:       true,
+			name:                    "valid_utf8_with_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       true,
 			tags:                    []string{"valid=tag"},
 			expectedInvalidMdInc:    0,
 			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  0,
+			expectedIndexSizeInc:    1,
+		}, {
+			name:                    "valid_utf8_without_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       false,
+			tags:                    []string{"valid=tag"},
+			expectedInvalidMdInc:    0,
+			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  0,
+			expectedIndexSizeInc:    1,
+		}, {
+			name:                    "invalid_utf8_name_with_rejection",
+			mdName:                  "abc\xc5",
+			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       true,
+			tags:                    []string{"valid=tag"},
+			expectedInvalidMdInc:    1,
+			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  1,
+			expectedIndexSizeInc:    0,
+		}, {
+			name:                    "invalid_utf8_name_without_rejection",
+			mdName:                  "abc\xc5",
+			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       false,
+			tags:                    []string{"valid=tag"},
+			expectedInvalidMdInc:    1,
+			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  1,
+			expectedIndexSizeInc:    1,
+		}, {
+			name:                    "invalid_utf8_tag_values_with_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       true,
+			tags:                    []string{"invalid=bb\xc5"},
+			expectedInvalidMdInc:    1,
+			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  1,
+			expectedIndexSizeInc:    0,
+		}, {
+			name:                    "invalid_utf8_tag_values_without_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       false,
+			tags:                    []string{"invalid=bb\xc5"},
+			expectedInvalidMdInc:    1,
+			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  1,
+			expectedIndexSizeInc:    1,
+		}, {
+			name:                    "invalid_utf8_tag_values_and_invalid_tags_with_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       true,
+			rejectInvalidUtf8:       false,
+			tags:                    []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
+			expectedInvalidMdInc:    1,
+			expectedInvalidTagMdInc: 1,
+			expectedInvalidUtf8Inc:  0,
+			expectedIndexSizeInc:    0,
+		}, {
+			name:                    "invalid_utf8_tag_values_and_invalid_tags_with_utf8_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       true,
+			tags:                    []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
+			expectedInvalidMdInc:    1,
+			expectedInvalidTagMdInc: 1,
+			expectedInvalidUtf8Inc:  0, // since the tag is invalid we won't ever see invalid UTF8 error
+			expectedIndexSizeInc:    1, // index still increases because we are not rejecting invalid tags
+		},
+		{
+			name:                    "invalid_utf8_tag_values_and_invalid_tags_with_utf8_rejection_and_tag_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       true,
+			rejectInvalidUtf8:       true,
+			tags:                    []string{"invalid!!!;;;=bb\xc5@#;;;!@#"},
+			expectedInvalidMdInc:    1,
+			expectedInvalidTagMdInc: 1,
+			expectedInvalidUtf8Inc:  0, // since the tag is invalid we won't ever see invalid UTF8 error
+			expectedIndexSizeInc:    0,
+		},
+		{
+			name:                    "valid_with_rejection",
+			mdName:                  "abc",
+			rejectInvalidTags:       true,
+			rejectInvalidUtf8:       false,
+			tags:                    []string{"valid=tag"},
+			expectedInvalidMdInc:    0,
+			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  0,
 			expectedIndexSizeInc:    1,
 		}, {
 			name:                    "valid_without_rejection",
+			mdName:                  "abc",
 			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       false,
 			tags:                    []string{"valid=tag"},
 			expectedInvalidMdInc:    0,
 			expectedInvalidTagMdInc: 0,
+			expectedInvalidUtf8Inc:  0,
 			expectedIndexSizeInc:    1,
 		}, {
 			name:                    "invalid_tags_with_rejection",
+			mdName:                  "abc",
 			rejectInvalidTags:       true,
+			rejectInvalidUtf8:       false,
 			tags:                    generateInvalidTags(t),
 			expectedInvalidMdInc:    1,
 			expectedInvalidTagMdInc: 1,
+			expectedInvalidUtf8Inc:  0,
 			expectedIndexSizeInc:    0,
 		}, {
 			name:                    "invalid_tags_without_rejection",
+			mdName:                  "abc",
 			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       false,
 			tags:                    generateInvalidTags(t),
 			expectedInvalidMdInc:    1,
 			expectedInvalidTagMdInc: 1,
+			expectedInvalidUtf8Inc:  0,
 			expectedIndexSizeInc:    1,
 		}, {
 			name:                    "invalid_tag_values_with_rejection",
+			mdName:                  "abc",
 			rejectInvalidTags:       true,
+			rejectInvalidUtf8:       false,
 			tags:                    generateInvalidTagValues(t),
 			expectedInvalidMdInc:    1,
 			expectedInvalidTagMdInc: 1,
+			expectedInvalidUtf8Inc:  0,
 			expectedIndexSizeInc:    0,
 		}, {
 			name:                    "invalid_tag_values_without_rejection",
+			mdName:                  "abc",
 			rejectInvalidTags:       false,
+			rejectInvalidUtf8:       false,
 			tags:                    generateInvalidTagValues(t),
 			expectedInvalidMdInc:    1,
 			expectedInvalidTagMdInc: 1,
+			expectedInvalidUtf8Inc:  0,
 			expectedIndexSizeInc:    1,
 		},
 	}
@@ -74,9 +187,11 @@ func TestIngestValidAndInvalidTagsAndValuesWithAndWithoutRejection(t *testing.T)
 	for _, tc := range testCases {
 		handler, index, reset := getDefaultHandler(t)
 		rejectInvalidTags = tc.rejectInvalidTags
+		rejectInvalidUtf8 = tc.rejectInvalidUtf8
 		for i, tag := range tc.tags {
 			data := getTestMetricData()
 			data.Tags = []string{tag}
+			data.Name = tc.mdName
 			testIngestMetricData(
 				t,
 				fmt.Sprintf("%s_%d", tc.name, i),
@@ -85,6 +200,7 @@ func TestIngestValidAndInvalidTagsAndValuesWithAndWithoutRejection(t *testing.T)
 				index,
 				tc.expectedInvalidMdInc,
 				tc.expectedInvalidTagMdInc,
+				tc.expectedInvalidUtf8Inc,
 				tc.expectedIndexSizeInc,
 			)
 		}
@@ -155,9 +271,10 @@ func getTestMetricData() schema.MetricData {
 	}
 }
 
-func testIngestMetricData(t *testing.T, tc string, data schema.MetricData, handler DefaultHandler, index idx.MetricIndex, expectedInvalidMdInc, expectedInvalidTagMdInc, expectedIndexSizeInc uint32) {
+func testIngestMetricData(t *testing.T, tc string, data schema.MetricData, handler DefaultHandler, index idx.MetricIndex, expectedInvalidMdInc, expectedInvalidTagMdInc, expectedInvalidUtf8MdInc, expectedIndexSizeInc uint32) {
 	originalInvalidCnt := handler.invalidMD.Peek()
 	originalInvalidTagCnt := handler.invalidTagMD.Peek()
+	originalInvalidUtf8Cnt := handler.invalidUtfMD.Peek()
 	originalIndexSize := uint32(len(index.List(1)))
 	data.SetId()
 	handler.ProcessMetricData(&data, 0)
@@ -170,6 +287,12 @@ func testIngestMetricData(t *testing.T, tc string, data schema.MetricData, handl
 
 	if invalidTagCnt != originalInvalidTagCnt+expectedInvalidTagMdInc {
 		t.Fatalf("TC %s: Invalid tag counter has not been updated correctly, expected %d, got %d", tc, originalInvalidTagCnt+expectedInvalidTagMdInc, invalidTagCnt)
+	}
+
+	invalidUtf8Cnt := handler.invalidUtfMD.Peek()
+
+	if invalidUtf8Cnt != originalInvalidUtf8Cnt+expectedInvalidUtf8MdInc {
+		t.Fatalf("TC %s: Invalid utf8 counter has not been updated correctly, expected %d, got %d", tc, originalInvalidUtf8Cnt+expectedInvalidUtf8MdInc, invalidUtf8Cnt)
 	}
 
 	indexSize := uint32(len(index.List(1)))

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -263,6 +263,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -261,10 +261,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -56,14 +56,15 @@ func (m *MetricData) Validate() error {
 	if m.Mtype == "" || (m.Mtype != "gauge" && m.Mtype != "rate" && m.Mtype != "count" && m.Mtype != "counter" && m.Mtype != "timestamp") {
 		return ErrInvalidMtype
 	}
+	var err error
 	if !utf8.ValidString(m.Name) {
-		return ErrInvalidUtf8
+		err = ErrInvalidUtf8
 	}
-	if err := ValidateTags(m.Tags); err != nil {
+	if e := ValidateTags(m.Tags); e != nil {
 		// this will return either ErrInvalidUtf8 or ErrInvalidTagFormat
-		return err
+		err = e
 	}
-	return nil
+	return err
 }
 
 // returns a id (hash key) in the format OrgId.md5Sum
@@ -349,7 +350,8 @@ func ValidateTag(tag string) error {
 
 	// this now checks for both invalid utf8 and an invalid tag format. If the utf8 check fails, it still goes on to validate the tags.
 	// if both checks fail, the last one will set the error to invalid tag format. Now we know that if this function returns ErrInvalidUtf8 that
-	// all of the other checks passed and can handle further processing accordingly.
+	// all of the other checks passed and can handle further processing accordingly. This also means that if the tag contains invalid UTF8 and it
+	// also fails to validate as a tag, then it will still only return ErrInvalidTagFormat.
 	//
 	// if all checks pass, it still returns nil
 	var err error

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -9,12 +9,14 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"unicode/utf8"
 )
 
 var ErrInvalidIntervalzero = errors.New("interval cannot be 0")
 var ErrInvalidOrgIdzero = errors.New("org-id cannot be 0")
 var ErrInvalidEmptyName = errors.New("name cannot be empty")
 var ErrInvalidMtype = errors.New("invalid mtype")
+var ErrInvalidUtf8 = errors.New("invalid utf8 data")
 var ErrInvalidTagFormat = errors.New("invalid tag format")
 var ErrUnknownPartitionMethod = errors.New("unknown partition method")
 
@@ -53,6 +55,9 @@ func (m *MetricData) Validate() error {
 	}
 	if m.Mtype == "" || (m.Mtype != "gauge" && m.Mtype != "rate" && m.Mtype != "count" && m.Mtype != "counter" && m.Mtype != "timestamp") {
 		return ErrInvalidMtype
+	}
+	if !utf8.ValidString(m.Name) {
+		return ErrInvalidUtf8
 	}
 	if !ValidateTags(m.Tags) {
 		return ErrInvalidTagFormat

--- a/schema/metric_test.go
+++ b/schema/metric_test.go
@@ -68,9 +68,9 @@ func TestValidate(t *testing.T) {
 		{mdZeroInterval, ErrInvalidIntervalzero},
 		{mdEmptyName, ErrInvalidEmptyName},
 		{mdInvalidMType, ErrInvalidMtype},
-		{mdInvalidUtf8Name, ErrInvalidUtf8},
-		{mdInvalidUtf8InTag, ErrInvalidUtf8},
-		{mdInvalidUtf8InTagAndInvalidTag, ErrInvalidTagFormat},
+		{mdInvalidUtf8Name, ErrInvalidInput},
+		{mdInvalidUtf8InTag, ErrInvalidInput},
+		{mdInvalidUtf8InTagAndInvalidTag, ErrInvalidInput},
 	}
 
 	for _, tc := range testCases {
@@ -89,21 +89,21 @@ func TestTagValidation(t *testing.T) {
 
 	testCases := []testCase{
 		{[]string{"abc=cba"}, nil},
-		{[]string{"a="}, ErrInvalidTagFormat},
-		{[]string{"a!="}, ErrInvalidTagFormat},
-		{[]string{"=abc"}, ErrInvalidTagFormat},
-		{[]string{"@#$%!=(*&"}, ErrInvalidTagFormat},
-		{[]string{"!@#$%=(*&"}, ErrInvalidTagFormat},
-		{[]string{"@#;$%=(*&"}, ErrInvalidTagFormat},
-		{[]string{"@#$%=(;*&"}, ErrInvalidTagFormat},
+		{[]string{"a="}, ErrInvalidInput},
+		{[]string{"a!="}, ErrInvalidInput},
+		{[]string{"=abc"}, ErrInvalidInput},
+		{[]string{"@#$%!=(*&"}, ErrInvalidInput},
+		{[]string{"!@#$%=(*&"}, ErrInvalidInput},
+		{[]string{"@#;$%=(*&"}, ErrInvalidInput},
+		{[]string{"@#$%=(;*&"}, ErrInvalidInput},
 		{[]string{"@#$%=(*&"}, nil},
 		{[]string{"@#$%=(*&", "abc=!fd", "a===="}, nil},
-		{[]string{"@#$%=(*&", "abc=!fd", "a===;="}, ErrInvalidTagFormat},
-		{[]string{"a=~a"}, ErrInvalidTagFormat},
+		{[]string{"@#$%=(*&", "abc=!fd", "a===;="}, ErrInvalidInput},
+		{[]string{"a=~a"}, ErrInvalidInput},
 		{[]string{"a=a~"}, nil},
-		{[]string{"aaa"}, ErrInvalidTagFormat},
-		{[]string{"aaa=b\xc3"}, ErrInvalidUtf8},
-		{[]string{"a\xc3=bb\x28\xc5"}, ErrInvalidUtf8},
+		{[]string{"aaa"}, ErrInvalidInput},
+		{[]string{"aaa=b\xc3"}, ErrInvalidInput},
+		{[]string{"a\xc3=bb\x28\xc5"}, ErrInvalidInput},
 	}
 
 	for _, tc := range testCases {

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -258,10 +258,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -260,6 +260,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -258,10 +258,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -260,6 +260,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -258,10 +258,8 @@ log-headers = false
 ## metric data inputs ##
 
 [input]
-# reject received metrics that have invalid tags
-reject-invalid-tags = true
-# reject received metrics that have invalid utf8 data
-reject-invalid-utf8 = false
+# reject received metrics that have invalid input data (invalid utf8 or invalid tags)
+reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -260,6 +260,8 @@ log-headers = false
 [input]
 # reject received metrics that have invalid tags
 reject-invalid-tags = true
+# reject received metrics that have invalid utf8 data
+reject-invalid-utf8 = false
 
 ### carbon input (optional)
 [carbon-in]


### PR DESCRIPTION
We decided to consolidate both UTF8 and Invalid Tag validation into one. It is now called InvalidInput. This will break a few things, including deployments that use `reject-invalid-tags`. That option no longer exists, now it is just called `reject-invalid-input`, with a default of `true`.

For dashboards, the old metric `...metricdata.discarded.invalid_tag` no longer exists. It is now called `...metricdata.discarded.invalid_input`. Dashboards will need to be updated.

Closes: #1728