### PR TITLE
Fix deadlock 1833

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -294,22 +294,7 @@ func NewUnpartitionedMemoryIdx() *UnpartitionedMemoryIdx {
 	}
 
 	if MetaTagSupport {
-		m.metaTagIdx = newMetaTagIndex(
-			// used by the meta tag enricher to lookup ids from query
-			// expressions on the main tag index
-			func(orgId uint32, query tagquery.Query, idCh chan schema.MKey) {
-				m.RLock()
-				defer m.RUnlock()
-				defer close(idCh)
-
-				tags, ok := m.tags[orgId]
-				if !ok {
-					return
-				}
-
-				queryCtx := NewTagQueryContext(query)
-				queryCtx.Run(tags, m.defById, nil, nil, idCh)
-			})
+		m.metaTagIdx = newMetaTagIndex(m.idsByTagQueryIntoCallback)
 	}
 
 	return m
@@ -1214,6 +1199,27 @@ func (m *UnpartitionedMemoryIdx) idsByTagQuery(orgId uint32, query tagquery.Quer
 		}
 		close(idCh)
 	}()
+}
+
+// idsByTagQueryIntoCallback executes the given query on the tag index and collects
+// the resulting metric ids in a slice. Once the query completed it submits the slice
+// of metric ids to the given callback function before releasing the read lock.
+// It does not use the meta tag index.
+func (m *UnpartitionedMemoryIdx) idsByTagQueryIntoCallback(orgId uint32, query tagquery.Query, resultCb func([]schema.MKey)) {
+	idCh := make(chan schema.MKey, 100)
+
+	m.RLock()
+	defer m.RUnlock()
+
+	// we never use the meta tag index in this function
+	m.idsByTagQuery(orgId, query, idCh, false)
+
+	var metricIds []schema.MKey
+	for metricId := range idCh {
+		metricIds = append(metricIds, metricId)
+	}
+
+	resultCb(metricIds)
 }
 
 // finalizeResult prepares a result to return it to the caller

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -493,10 +493,6 @@ func (m *UnpartitionedMemoryIdx) indexTags(def *schema.MetricDefinition) {
 	m.defByTagSet.add(def)
 
 	if MetaTagSupport {
-		// it is important to release the lock for a short time, otherwise
-		// it's possible that the enricher can't process its queue because
-		// it could be blocked on waiting for the read lock on the index
-		// which would lead to deadlock.
 		m.Unlock()
 		m.getOrgMetaTagIndex(def.OrgId).enricher.addMetric(*def)
 		m.Lock()
@@ -529,10 +525,6 @@ func (m *UnpartitionedMemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDe
 	m.defByTagSet.del(def)
 
 	if MetaTagSupport {
-		// it is important to release the lock for a short time, otherwise
-		// it's possible that the enricher can't process its queue because
-		// it could be blocked on waiting for the read lock on the index
-		// which would lead to deadlock.
 		m.Unlock()
 		m.getOrgMetaTagIndex(def.OrgId).enricher.delMetric(def)
 		m.Lock()

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -795,9 +795,7 @@ func (e *metaTagEnricher) _delMetaRecord(payload interface{}) {
 			delete(e.recordsByMetric, id.Key)
 		}
 	}
-	e.Unlock()
 
-	e.Lock()
 	delete(e.queriesByRecord, data.recordId)
 	enricherKnownMetaRecords.SetUint32(uint32(len(e.queriesByRecord)))
 	e.Unlock()

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -154,7 +154,9 @@ func (m *metaTagIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.Met
 	// check if the upsert has replaced a previously existing record
 	if oldId > 0 {
 		// if so we remove all references to it from the enricher
-		// and from the meta tag index
+		// and from the meta tag index. we can reuse the already existing query
+		// because the identity of a meta record is its query expressions,
+		// so the new and the old record must have the same expressions
 		idx.enricher.delMetaRecord(oldId, query)
 		idx.hierarchy.deleteRecord(oldRecord.MetaTags, oldId)
 	}
@@ -220,6 +222,10 @@ func (m *metaTagIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaT
 			// record exists, but its meta tags need to be updated,
 			// we first delete it and then re-add it
 			recordsModified++
+			// we can use the query which has been instantiated from the new
+			// record because the identity of a meta record is defined by its
+			// expressions, so the old and the new record both must have the
+			// same expressions.
 			idx.enricher.delMetaRecord(status.currentId, query)
 			idx.hierarchy.deleteRecord(status.currentMetaTags, status.currentId)
 		} else {

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -51,10 +51,10 @@ var (
 type metaTagIdx struct {
 	sync.RWMutex
 	byOrg    map[uint32]*orgMetaTagIdx
-	idLookup func(uint32, tagquery.Query, chan schema.MKey)
+	idLookup func(uint32, tagquery.Query, func([]schema.MKey))
 }
 
-func newMetaTagIndex(idLookup func(uint32, tagquery.Query, chan schema.MKey)) *metaTagIdx {
+func newMetaTagIndex(idLookup func(uint32, tagquery.Query, func([]schema.MKey))) *metaTagIdx {
 	return &metaTagIdx{
 		byOrg:    make(map[uint32]*orgMetaTagIdx),
 		idLookup: idLookup,
@@ -86,10 +86,7 @@ func (m *metaTagIdx) getOrgMetaTagIndex(orgId uint32) *orgMetaTagIdx {
 		return idx
 	}
 
-	idx = newOrgMetaTagIndex(func(query tagquery.Query, idCh chan schema.MKey) {
-		// bind orgId to function call
-		m.idLookup(orgId, query, idCh)
-	})
+	idx = newOrgMetaTagIndex()
 
 	m.byOrg[orgId] = idx
 
@@ -105,13 +102,11 @@ type orgMetaTagIdx struct {
 	enricher  *metaTagEnricher
 }
 
-type idLookup func(tagquery.Query, chan schema.MKey)
-
-func newOrgMetaTagIndex(idLookup idLookup) *orgMetaTagIdx {
+func newOrgMetaTagIndex() *orgMetaTagIdx {
 	return &orgMetaTagIdx{
 		hierarchy: newMetaTagHierarchy(),
 		records:   newMetaTagRecords(),
-		enricher:  newEnricher(idLookup),
+		enricher:  newEnricher(),
 	}
 }
 
@@ -146,25 +141,31 @@ func (m *metaTagIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.Met
 	idx.swapMutex.Lock()
 	defer idx.swapMutex.Unlock()
 
-	id, oldId, oldRecord, err := idx.records.upsert(upsertRecord)
+	newRecordId, oldRecordId, oldRecord, err := idx.records.upsert(upsertRecord)
 	if err != nil {
 		return err
 	}
 
 	// check if the upsert has replaced a previously existing record
-	if oldId > 0 {
+	if oldRecordId > 0 {
 		// if so we remove all references to it from the enricher
 		// and from the meta tag index. we can reuse the already existing query
 		// because the identity of a meta record is its query expressions,
 		// so the new and the old record must have the same expressions
-		idx.enricher.delMetaRecord(oldId, query)
-		idx.hierarchy.deleteRecord(oldRecord.MetaTags, oldId)
+		m.idLookup(orgId, query, func(metricIds []schema.MKey) {
+			idx.enricher.delMetaRecord(oldRecordId, query, metricIds)
+		})
+		idx.hierarchy.deleteRecord(oldRecord.MetaTags, oldRecordId)
 	}
 
-	// add the newly inserted meta record into the enricher and the
-	// meta tag index
-	idx.enricher.addMetaRecord(id, query)
-	idx.hierarchy.insertRecord(upsertRecord.MetaTags, id)
+	// lookup metrics from main index by the given query, then update the
+	// enricher with the new record id and the associated metrics
+	m.idLookup(orgId, query, func(metricIds []schema.MKey) {
+		idx.enricher.addMetaRecord(newRecordId, query, metricIds)
+	})
+
+	// add the newly inserted meta record to the meta tag index
+	idx.hierarchy.insertRecord(upsertRecord.MetaTags, newRecordId)
 
 	return nil
 }
@@ -226,7 +227,9 @@ func (m *metaTagIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaT
 			// record because the identity of a meta record is defined by its
 			// expressions, so the old and the new record both must have the
 			// same expressions.
-			idx.enricher.delMetaRecord(status.currentId, query)
+			m.idLookup(orgId, query, func(metricIds []schema.MKey) {
+				idx.enricher.delMetaRecord(status.currentId, query, metricIds)
+			})
 			idx.hierarchy.deleteRecord(status.currentMetaTags, status.currentId)
 		} else {
 			// record does not exist, so it will be added
@@ -239,7 +242,9 @@ func (m *metaTagIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaT
 			continue
 		}
 
-		idx.enricher.addMetaRecord(newRecordId, query)
+		m.idLookup(orgId, query, func(metricIds []schema.MKey) {
+			idx.enricher.addMetaRecord(newRecordId, query, metricIds)
+		})
 		idx.hierarchy.insertRecord(newRecords[i].MetaTags, newRecordId)
 
 		// adding the new record id to recordIdsToKeep to prevent that
@@ -271,7 +276,9 @@ func (m *metaTagIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaT
 				log.Errorf("Invalid record to prune, cannot instantiate query for (%q/%q): %s", record.Expressions.Strings(), record.MetaTags.Strings(), err)
 				continue
 			}
-			idx.enricher.delMetaRecord(recordId, query)
+			m.idLookup(orgId, query, func(metricIds []schema.MKey) {
+				idx.enricher.delMetaRecord(recordId, query, metricIds)
+			})
 			idx.hierarchy.deleteRecord(record.MetaTags, recordId)
 		}
 	}
@@ -508,8 +515,6 @@ type metaTagEnricher struct {
 	addMetricBuffer []schema.MetricDefinition
 	// pool of idx.Archive structs that we use when processing add metric events
 	archivePool sync.Pool
-
-	idLookup idLookup
 }
 
 type enricherEventType uint8
@@ -528,14 +533,13 @@ type enricherEvent struct {
 	payload   interface{}
 }
 
-func newEnricher(idLookup idLookup) *metaTagEnricher {
+func newEnricher() *metaTagEnricher {
 	res := &metaTagEnricher{
 		queriesByRecord: make(map[recordId]tagquery.Query),
 		recordsByMetric: make(map[schema.Key]map[recordId]struct{}),
 		archivePool: sync.Pool{
 			New: func() interface{} { return &idx.Archive{} },
 		},
-		idLookup: idLookup,
 	}
 
 	res.start()
@@ -730,14 +734,7 @@ func (e *metaTagEnricher) _delMetric(payload interface{}) {
 	enricherMetricsWithMetaRecords.SetUint32(uint32(len(e.recordsByMetric)))
 }
 
-func (e *metaTagEnricher) addMetaRecord(id recordId, query tagquery.Query) {
-	idCh := make(chan schema.MKey)
-	go e.idLookup(query, idCh)
-	var metricIds []schema.MKey
-	for metricId := range idCh {
-		metricIds = append(metricIds, metricId)
-	}
-
+func (e *metaTagEnricher) addMetaRecord(id recordId, query tagquery.Query, metricIds []schema.MKey) {
 	e.eventQueue <- enricherEvent{
 		eventType: addMetaRecord,
 		payload: struct {
@@ -775,14 +772,7 @@ func (e *metaTagEnricher) _addMetaRecord(payload interface{}) {
 	enricherMetricsAddedByQuery.AddUint32(added)
 }
 
-func (e *metaTagEnricher) delMetaRecord(id recordId, query tagquery.Query) {
-	idCh := make(chan schema.MKey)
-	go e.idLookup(query, idCh)
-	var metricIds []schema.MKey
-	for metricId := range idCh {
-		metricIds = append(metricIds, metricId)
-	}
-
+func (e *metaTagEnricher) delMetaRecord(id recordId, query tagquery.Query, metricIds []schema.MKey) {
 	e.eventQueue <- enricherEvent{
 		eventType: delMetaRecord,
 		payload: struct {

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -434,8 +434,8 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 	})
 	compareExpectedMetricCount(5)
 
-	enricher.delMetaRecord(recordId(2))
-	enricher.delMetaRecord(recordId(4))
+	enricher.delMetaRecord(recordId(2), acceptAll)
+	enricher.delMetaRecord(recordId(4), acceptEveryOdd)
 
 	compareResultToExpected(t, []map[recordId]struct{}{
 		{recordId(1): {}},
@@ -457,8 +457,8 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 	})
 	compareExpectedMetricCount(2)
 
-	enricher.delMetaRecord(recordId(1))
-	enricher.delMetaRecord(recordId(3))
+	enricher.delMetaRecord(recordId(1), acceptEveryEven)
+	enricher.delMetaRecord(recordId(3), acceptNone)
 
 	compareResultToExpected(t, []map[recordId]struct{}{
 		nil,

--- a/idx/memory/meta_tags_test.go
+++ b/idx/memory/meta_tags_test.go
@@ -300,8 +300,7 @@ func TestDeletingMetaRecord(t *testing.T) {
 }
 
 func TestAddingMetricsToEmptyEnricher(t *testing.T) {
-	var mockLookup func(tagquery.Query, chan schema.MKey)
-	enricher := newEnricher(mockLookup)
+	enricher := newEnricher()
 
 	mds := []schema.MetricDefinition{
 		{
@@ -346,34 +345,7 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 		allKeys[i] = testMetrics[i].Id.Key
 	}
 
-	// mocks a lookup function which would execute the given query on the tag index
-	// and then call the callback to pass it a channel of resulting metric ids
-	mockLookup := func(query tagquery.Query, resCh chan schema.MKey) {
-
-		switch query.Expressions[0].GetValue() {
-		case "everyEven":
-			for i := range testMetrics {
-				if i%2 == 0 {
-					resCh <- testMetrics[i].Id
-				}
-			}
-		case "everyOdd":
-			for i := range testMetrics {
-				if i%2 == 1 {
-					resCh <- testMetrics[i].Id
-				}
-			}
-		case "all":
-			for i := range testMetrics {
-				resCh <- testMetrics[i].Id
-			}
-		case "none":
-		}
-
-		close(resCh)
-	}
-
-	enricher := newEnricher(mockLookup)
+	enricher := newEnricher()
 	for i := range testMetrics {
 		enricher.addMetric(testMetrics[i])
 	}
@@ -382,9 +354,23 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 	acceptAll := parseQueryMustCompile(t, []string{"accept=all"})
 	acceptNone := parseQueryMustCompile(t, []string{"accept=none"})
 	acceptEveryOdd := parseQueryMustCompile(t, []string{"accept=everyOdd"})
-	enricher.addMetaRecord(recordId(1), acceptEveryEven)
-	enricher.addMetaRecord(recordId(2), acceptAll)
-	enricher.addMetaRecord(recordId(3), acceptNone)
+	var evenMetricIds []schema.MKey
+	var oddMetricIds []schema.MKey
+	var allMetricIds []schema.MKey
+	var noMetricIds []schema.MKey
+	for i := range testMetrics {
+		if i%2 == 0 {
+			evenMetricIds = append(evenMetricIds, testMetrics[i].Id)
+		}
+		if i%2 == 1 {
+			oddMetricIds = append(oddMetricIds, testMetrics[i].Id)
+		}
+		allMetricIds = append(allMetricIds, testMetrics[i].Id)
+	}
+
+	enricher.addMetaRecord(recordId(1), acceptEveryEven, evenMetricIds)
+	enricher.addMetaRecord(recordId(2), acceptAll, allMetricIds)
+	enricher.addMetaRecord(recordId(3), acceptNone, noMetricIds)
 
 	flushEnricherQueue := func() {
 		// stop and start to process the event queue
@@ -423,7 +409,7 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 	})
 	compareExpectedMetricCount(5)
 
-	enricher.addMetaRecord(recordId(4), acceptEveryOdd)
+	enricher.addMetaRecord(recordId(4), acceptEveryOdd, oddMetricIds)
 
 	compareResultToExpected(t, []map[recordId]struct{}{
 		{recordId(1): {}, recordId(2): {}},
@@ -434,8 +420,8 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 	})
 	compareExpectedMetricCount(5)
 
-	enricher.delMetaRecord(recordId(2), acceptAll)
-	enricher.delMetaRecord(recordId(4), acceptEveryOdd)
+	enricher.delMetaRecord(recordId(2), acceptAll, allMetricIds)
+	enricher.delMetaRecord(recordId(4), acceptEveryOdd, oddMetricIds)
 
 	compareResultToExpected(t, []map[recordId]struct{}{
 		{recordId(1): {}},
@@ -457,8 +443,8 @@ func TestAddingDeletingMetricsAndMetaRecordsToEnricher(t *testing.T) {
 	})
 	compareExpectedMetricCount(2)
 
-	enricher.delMetaRecord(recordId(1), acceptEveryEven)
-	enricher.delMetaRecord(recordId(3), acceptNone)
+	enricher.delMetaRecord(recordId(1), acceptEveryEven, evenMetricIds)
+	enricher.delMetaRecord(recordId(3), acceptNone, noMetricIds)
 
 	compareResultToExpected(t, []map[recordId]struct{}{
 		nil,


### PR DESCRIPTION
Fixes #1833 

The meta record upsert/swap methods now call the method `idsByTagQueryIntoCallback` on the main index before adding/deleting meta records in the enricher, when doing so they pass in a callback which takes the metric ids which resulted from the given query. The possible callbacks are the enricher's `addMetaRecord` & `delMetaRecord` methods, the callback is called before the main index releases its write lock to ensure that interleaved calls to `addMetaRecord`/`delMetaRecord`/`addMetric`/`delMetric` don't lead to inconsistencies in the enricher.