### PR TITLE
Use non-blocking write to flushed

### DIFF
--- a/idx/memory/write_queue.go
+++ b/idx/memory/write_queue.go
@@ -79,9 +79,9 @@ func (wq *WriteQueue) flush() {
 	wq.archives = make(map[schema.MKey]*idx.Archive)
 
 	select {
-       case wq.flushed <- struct{}{}:
-       default:
-    }
+	case wq.flushed <- struct{}{}:
+	default:
+	}
 }
 
 func (wq *WriteQueue) loop() {

--- a/idx/memory/write_queue.go
+++ b/idx/memory/write_queue.go
@@ -77,7 +77,11 @@ func (wq *WriteQueue) flush() {
 	}
 	wq.idx.Unlock()
 	wq.archives = make(map[schema.MKey]*idx.Archive)
-	wq.flushed <- struct{}{}
+
+	select {
+       case wq.flushed <- struct{}{}:
+       default:
+    }
 }
 
 func (wq *WriteQueue) loop() {


### PR DESCRIPTION
Fix #1836 

Simplest change is to use a non-blocking write to the `flushed` chan. Possibly more ideal would be for the `Queue`ing thread to trigger a flush, rather than flush manually, but that would be a larger change that would need more proof of correctness.