### PR TITLE
assure that consolidation.Consolidate always gets a non-None consolidator

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -743,6 +743,8 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan)
 					for _, rawReq := range rawReqs {
 						var cons consolidation.Consolidator
 						consReq := rawReq.Cons
+
+						// while consReq may be 0, the actual cons to use may not be 0
 						if consReq == 0 {
 							// we will use the primary method dictated by the storage-aggregations rules
 							// note:

--- a/api/models/request.go
+++ b/api/models/request.go
@@ -28,9 +28,9 @@ type Req struct {
 	MaxPoints   uint32      `json:"maxPoints"`
 	PNGroup     PNGroup     `json:"pngroup"`
 	RawInterval uint32      `json:"rawInterval"` // the interval of the raw metric before any consolidation
-	// the consolidation method for rollup archive and normalization (pre-normalization and runtime normalization). (but not runtime consolidation)
-	// ConsReq 0 -> configured value
-	// Conseq != 0 -> closest value we can offer based on config
+	// the consolidation method for rollup archive and normalization (pre-normalization and runtime normalization). (but not runtime consolidation). Is never 0/None
+	// if ConsReq == 0 -> configured value
+	// if Conseq != 0 -> closest value we can offer based on config
 	Consolidator consolidation.Consolidator `json:"consolidator"`
 	// requested consolidation method via consolidateBy(), if any.
 	// could be 0 if it was not specified or reset by a "special" functions. in which case, we use the configured default.

--- a/consolidation/consolidate.go
+++ b/consolidation/consolidate.go
@@ -33,6 +33,9 @@ func ConsolidateNudged(points []schema.Point, interval, maxDataPoints uint32, co
 // it will always aggregate aggNum-sized groups of points together, with the timestamp of the last of them, and it always starts at the beginning,
 // possibly having a point at the end that didn't incorporate as much data
 func Consolidate(in []schema.Point, aggNum uint32, consolidator Consolidator) []schema.Point {
+	if consolidator == None {
+		panic("Consolidate called with consolidation.None. this should never happen")
+	}
 	num := int(aggNum)
 	aggFunc := GetAggFunc(consolidator)
 

--- a/consolidation/consolidation.go
+++ b/consolidation/consolidation.go
@@ -101,6 +101,10 @@ func FromArchive(archive schema.Method) Consolidator {
 	return None
 }
 
+// FromConsolidateBy returns a consolidator based on a "consolidateBy" string
+// for any string allowed by Validate(), or None otherwise.
+// note that we also recognize "lst" here whereas Validate() doesn't, which does
+// not violate the above statement.
 func FromConsolidateBy(c string) Consolidator {
 	switch c {
 	case "avg", "average":
@@ -129,7 +133,8 @@ func FromConsolidateBy(c string) Consolidator {
 	return None
 }
 
-// map the consolidation to the respective aggregation function, if applicable.
+// GetAggFunc returns a batch aggregation function or any valid consolidator,
+// or nil otherwise
 func GetAggFunc(consolidator Consolidator) batch.AggFunc {
 	var consFunc batch.AggFunc
 	switch consolidator {

--- a/expr/func_filterseries.go
+++ b/expr/func_filterseries.go
@@ -84,6 +84,7 @@ func (s *FuncFilterSeries) Exec(dataMap DataMap) ([]models.Series, error) {
 		return nil, err
 	}
 
+	// note that s.fn has already been validated at series construction time using consolidation.IsConsolFunc
 	consolidationFunc := consolidation.GetAggFunc(consolidation.FromConsolidateBy(s.fn))
 	operatorFunc, err := getOperatorFunc(s.operator)
 	if err != nil {

--- a/expr/func_sortby.go
+++ b/expr/func_sortby.go
@@ -50,6 +50,7 @@ func (s *FuncSortBy) Exec(dataMap DataMap) ([]models.Series, error) {
 		seriesCpy = append(seriesCpy, serie)
 	}
 
+	// note that s.fn has already been validated at series construction time using consolidation.IsConsolFunc
 	SortSeriesWithConsolidator(seriesCpy, consolidation.FromConsolidateBy(s.fn), s.reverse)
 
 	return seriesCpy, nil

--- a/expr/func_summarize.go
+++ b/expr/func_summarize.go
@@ -45,6 +45,7 @@ func (s *FuncSummarize) Exec(dataMap DataMap) ([]models.Series, error) {
 	}
 
 	interval, _ := dur.ParseDuration(s.intervalString)
+	// note that s.fn has already been validated at series construction time using consolidation.IsConsolFunc
 	aggFunc := consolidation.GetAggFunc(consolidation.FromConsolidateBy(s.fn))
 
 	var alignToFromTarget string

--- a/expr/normalize.go
+++ b/expr/normalize.go
@@ -90,6 +90,11 @@ func NormalizeTo(dataMap DataMap, in models.Series, interval uint32) models.Seri
 	numDrop := int((datapoints[len(datapoints)-1].Ts - canonicalTs) / in.Interval)
 	datapoints = datapoints[0 : len(datapoints)-numDrop]
 
+	// series may have been created by a function that didn't know which consolidation function to default to.
+	// in the future maybe we can do more clever things here. e.g. perSecond maybe consolidate by max.
+	if in.Consolidator == 0 {
+		in.Consolidator = consolidation.Avg
+	}
 	in.Datapoints = consolidation.Consolidate(datapoints, interval/in.Interval, in.Consolidator)
 	in.Interval = interval
 	dataMap.Add(Req{}, in)


### PR DESCRIPTION
fix #1814 
Note that "special functions" resetting the consolidator is part of the current design, as described in
https://github.com/grafana/metrictank/blob/master/devdocs/expr.md, section about `consolidateBy`

>    - when returning data back to the user via a json response and whatnot, we can consolidate down using the method requested by the user (or average, if not specified). Likewise here, when the setting encounters a special* function while traveling up to the root, the consolidation value is reset to the default (average)

arguably, this design needs to be revised completely as proposed in #1490, or until we do, special functions should set the consolidator to average rather than None, which would be more robust, and depending on how you interpret the spec, implement it more accurately, rather than having to add these checks after functions have run.

But for now, this does the job.