### PR TITLE
add script to format stackdump

### DIFF
--- a/scripts/dev/format-stackdump.sh
+++ b/scripts/dev/format-stackdump.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function format() {
+  sed \
+    -e "s#$GOPATH#\$GOPATH#g" \
+    -e 's#$GOPATH#\n$GOPATH#g' \
+    -e 's#<body>#\n<body>\n#' \
+    -e 's#</body>#\n</body>#' \
+    -e 's# /usr/lib/go/src#\n/usr/lib/go/src#g'
+}
+
+
+
+if [ -n "$1" ]; then
+	if [ "$1" == "-h" -o "$1" == "--help" ]; then
+		echo "$0: reads an unformatted stackdump, and formats it"
+		echo "replaces your GOPATH with the string \#GOPATH and introduces newlines where appropriate"
+		echo "usage:"
+		echo "$0 --help, -h     this message"
+		echo "$0 <filename>     reads input from file"
+		echo "$0                reads input from stdin"
+		exit 0
+	elif [ -r "$1" ]; then
+		format < "$1"
+		exit 0
+	else
+		echo "unrecognized input flag: $1 (not a file)"
+		exit 2
+	fi
+fi
+
+format


### PR DESCRIPTION
before:
```
<html> <head><title>PANIC: runtime error: index out of range [1] with length 1</title> <meta charset="utf-8" /> <style type="text/css"> html, body { font-family: "Roboto", sans-serif; color: #333333; background-color: #ea5343; margin: 0px; } h1 { color: #d04526; background-color: #ffffff; padding: 20px; border-bottom: 1px dashed #2b3848; } pre { margin: 20px; padding: 20px; border: 2px solid #2b3848; background-color: #ffffff; white-space: pre-wrap; /* css-3 */ white-space: -moz-pre-wrap; /* Mozilla, since 1999 */ white-space: -pre-wrap; /* Opera 4-6 */ white-space: -o-pre-wrap; /* Opera 7 */ word-wrap: break-word; /* Internet Explorer 5.5+ */ } </style> </head><body> <h1>PANIC</h1> <pre style="font-weight: bold;">runtime error: index out of range [1] with length 1</pre> <pre>/usr/lib/go/src/runtime/panic.go:88 (0x4326e2) /home/dieter/go/src/github.com/grafana/metrictank/expr/seriesaggregators.go:147 (0xbaf325) /home/dieter/go/src/github.com/grafana/metrictank/expr/func_aggregate.go:74 (0xb8540d) /home/dieter/go/src/github.com/grafana/metrictank/expr/func_aggregate.go:61 (0xb84f5d) /home/dieter/go/src/github.com/grafana/metrictank/expr/plan.go:309 (0xbae7f7) /home/dieter/go/src/github.com/grafana/metrictank/api/graphite.go:851 (0xc20597) /home/dieter/go/src/github.com/grafana/metrictank/api/graphite.go:270 (0xc19773) /usr/lib/go/src/reflect/value.go:460 (0x4b6eca) /usr/lib/go/src/reflect/value.go:321 (0x4b63d3) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:177 (0xab1dab) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:137 (0xab1789) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xc07691) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/raintank/gziper/gzip.go:100 (0xc07684) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:79 (0xacc490) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xadd0f5) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/recovery.go:161 (0xadd0e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/logger.go:40 (0xad0053) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xb31520) /home/dieter/go/src/github.com/grafana/metrictank/api/middleware/logger.go:45 (0xb31509) /usr/lib/go/src/reflect/value.go:460 (0x4b6eca) /usr/lib/go/src/reflect/value.go:321 (0x4b63d3) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:177 (0xab1dab) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:137 (0xab1789) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xb32dab) /home/dieter/go/src/github.com/grafana/metrictank/api/middleware/tracer.go:70 (0xb32d96) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:79 (0xacc490) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xb3248d) /home/dieter/go/src/github.com/grafana/metrictank/api/middleware/stats.go:76 (0xb32478) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:79 (0xacc490) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xadd0f5) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/recovery.go:161 (0xadd0e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/logger.go:40 (0xad0053) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) /home/dieter/go/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/router.go:187 (0xade306) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/router.go:294 (0xad876d) /home/dieter/go/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/macaron.go:220 (0xad138a) /usr/lib/go/src/net/http/server.go:2807 (0x742792) /usr/lib/go/src/net/http/server.go:1895 (0x73e20b) /usr/lib/go/src/runtime/asm_amd64.s:1373 (0x467780) </pre> </body> </html>"
message:"Internal Server Error
```

after:
```
<html> <head><title>PANIC: runtime error: index out of range [1] with length 1</title> <meta charset="utf-8" /> <style type="text/css"> html, body { font-family: "Roboto", sans-serif; color: #333333; background-color: #ea5343; margin: 0px; } h1 { color: #d04526; background-color: #ffffff; padding: 20px; border-bottom: 1px dashed #2b3848; } pre { margin: 20px; padding: 20px; border: 2px solid #2b3848; background-color: #ffffff; white-space: pre-wrap; /* css-3 */ white-space: -moz-pre-wrap; /* Mozilla, since 1999 */ white-space: -pre-wrap; /* Opera 4-6 */ white-space: -o-pre-wrap; /* Opera 7 */ word-wrap: break-word; /* Internet Explorer 5.5+ */ } </style> </head>
<body>
 <h1>PANIC</h1> <pre style="font-weight: bold;">runtime error: index out of range [1] with length 1</pre> <pre>/usr/lib/go/src/runtime/panic.go:88 (0x4326e2) 
$GOPATH/src/github.com/grafana/metrictank/expr/seriesaggregators.go:147 (0xbaf325) 
$GOPATH/src/github.com/grafana/metrictank/expr/func_aggregate.go:74 (0xb8540d) 
$GOPATH/src/github.com/grafana/metrictank/expr/func_aggregate.go:61 (0xb84f5d) 
$GOPATH/src/github.com/grafana/metrictank/expr/plan.go:309 (0xbae7f7) 
$GOPATH/src/github.com/grafana/metrictank/api/graphite.go:851 (0xc20597) 
$GOPATH/src/github.com/grafana/metrictank/api/graphite.go:270 (0xc19773)
/usr/lib/go/src/reflect/value.go:460 (0x4b6eca)
/usr/lib/go/src/reflect/value.go:321 (0x4b63d3) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:177 (0xab1dab) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:137 (0xab1789) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xc07691) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/raintank/gziper/gzip.go:100 (0xc07684) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:79 (0xacc490) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xadd0f5) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/recovery.go:161 (0xadd0e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/logger.go:40 (0xad0053) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xb31520) 
$GOPATH/src/github.com/grafana/metrictank/api/middleware/logger.go:45 (0xb31509)
/usr/lib/go/src/reflect/value.go:460 (0x4b6eca)
/usr/lib/go/src/reflect/value.go:321 (0x4b63d3) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:177 (0xab1dab) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:137 (0xab1789) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xb32dab) 
$GOPATH/src/github.com/grafana/metrictank/api/middleware/tracer.go:70 (0xb32d96) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:79 (0xacc490) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xb3248d) 
$GOPATH/src/github.com/grafana/metrictank/api/middleware/stats.go:76 (0xb32478) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:79 (0xacc490) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:112 (0xadd0f5) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/recovery.go:161 (0xadd0e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/logger.go:40 (0xad0053) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:157 (0xab1ad7) 
$GOPATH/src/github.com/grafana/metrictank/vendor/github.com/go-macaron/inject/inject.go:135 (0xab1878) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/context.go:121 (0xacc5e8) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/router.go:187 (0xade306) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/router.go:294 (0xad876d) 
$GOPATH/src/github.com/grafana/metrictank/vendor/gopkg.in/macaron.v1/macaron.go:220 (0xad138a)
/usr/lib/go/src/net/http/server.go:2807 (0x742792)
/usr/lib/go/src/net/http/server.go:1895 (0x73e20b)
/usr/lib/go/src/runtime/asm_amd64.s:1373 (0x467780) </pre> 
</body> </html>"
message:"Internal Server Error"
```