### PR TITLE
Priority index locking and logging of long operations

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1230,7 +1230,7 @@ func (m *UnpartitionedMemoryIdx) idsByTagQueryIntoCallback(orgId uint32, query t
 
 	bc := m.RLockLow()
 	defer bc.RUnlockLow("idsByTagQueryIntoCallback", func() interface{} {
-		return pattern
+		return query.Expressions.Strings()
 	})
 
 	// we never use the meta tag index in this function

--- a/idx/memory/priority_lock.go
+++ b/idx/memory/priority_lock.go
@@ -75,8 +75,8 @@ func (pm *PriorityRWMutex) Lock() BlockContext {
 // Unlock unlocks mutex acquired via Lock
 func (pm *PriorityRWMutex) Unlock(bc *BlockContext) {
 	bc.postOpTime = time.Now()
-	pm.lowPrioLock.Unlock()
 	pm.lock.Unlock()
+	pm.lowPrioLock.Unlock()
 }
 
 func (bc *BlockContext) RUnlockLow(op string, logCb func() interface{}) {

--- a/idx/memory/priority_lock.go
+++ b/idx/memory/priority_lock.go
@@ -37,16 +37,6 @@ func (pm *PriorityRWMutex) RUnlockHigh() {
 	pm.lock.RUnlock()
 }
 
-// RLock is an alias for RLockLow
-func (pm *PriorityRWMutex) RLock() BlockContext {
-	return pm.RLockLow()
-}
-
-// RUnlock is an alias for RUnlockLow
-func (pm *PriorityRWMutex) RUnlock(bc *BlockContext) {
-	pm.RUnlockLow(bc)
-}
-
 // RLockLow will block until requested writes complete. New writes that come in also get priority.
 func (pm *PriorityRWMutex) RLockLow() BlockContext {
 	// Wait for any pending writes
@@ -58,6 +48,7 @@ func (pm *PriorityRWMutex) RLockLow() BlockContext {
 }
 
 // RUnlockLow unlocks read lock called via RLockLow
+// Note: This function should not be called directly, but rather should be called via the returned BlockContext
 func (pm *PriorityRWMutex) RUnlockLow(bc *BlockContext) {
 	bc.postOpTime = time.Now()
 	pm.lock.RUnlock()
@@ -75,6 +66,7 @@ func (pm *PriorityRWMutex) Lock() BlockContext {
 }
 
 // Unlock unlocks mutex acquired via Lock
+// Note: This function should not be called directly, but rather should be called via the returned BlockContext
 func (pm *PriorityRWMutex) Unlock(bc *BlockContext) {
 	bc.postOpTime = time.Now()
 	pm.lock.Unlock()

--- a/idx/memory/priority_lock.go
+++ b/idx/memory/priority_lock.go
@@ -1,0 +1,158 @@
+package memory
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// PriorityRWMutex is a mutex that allows fair access to high priority read operations while
+// blocking low priority operations if a write lock is waiting.
+type PriorityRWMutex struct {
+	lock        sync.RWMutex
+	writeWaiter sync.WaitGroup
+	readWaiter  sync.WaitGroup
+}
+
+type BlockContext struct {
+	lock         *PriorityRWMutex
+	preLockTime  time.Time
+	postLockTime time.Time
+	postOpTime   time.Time
+}
+
+// RLockHigh allows *guaranteed fast* (or very high priority) ops to acquire the read lock as
+// quickly as possible. Note: This can block write lock acquisition
+func (pm *PriorityRWMutex) RLockHigh() {
+	// Don't increment activeReads just grab the lock. If an active write is holding the lock it
+	// will block, otherwise it *may* block a write acquisition, but that is opted into.
+	pm.lock.RLock()
+}
+
+// RUnlockHigh unlocks read lock called via RLockHigh
+func (pm *PriorityRWMutex) RUnlockHigh() {
+	pm.lock.RUnlock()
+}
+
+// Synonym for RLockLow
+func (pm *PriorityRWMutex) RLock() BlockContext {
+	return pm.RLockLow()
+}
+
+// Synonym for RUnlockLow
+func (pm *PriorityRWMutex) RUnlock(bc *BlockContext) {
+	pm.RUnlockLow(bc)
+}
+
+// RLockLow will block until requested writes complete. New writes that come in also get priority.
+func (pm *PriorityRWMutex) RLockLow() BlockContext {
+	// Wait for any pending writes
+	bc := BlockContext{lock: pm, preLockTime: time.Now()}
+	pm.writeWaiter.Wait()
+	pm.lock.RLock()
+	bc.postLockTime = time.Now()
+	pm.readWaiter.Add(1)
+	return bc
+}
+
+// RUnlockLow unlocks read lock called via RLockLow
+func (pm *PriorityRWMutex) RUnlockLow(bc *BlockContext) {
+	pm.readWaiter.Done()
+	bc.postOpTime = time.Now()
+	pm.lock.RUnlock()
+}
+
+// Lock will block new low prio read locks until can acquire the lock. High prio read locks will
+// not be blocked or accounted for.
+func (pm *PriorityRWMutex) Lock() BlockContext {
+	bc := BlockContext{lock: pm, preLockTime: time.Now()}
+	pm.writeWaiter.Add(1)
+	// Wait for any active reads
+	pm.readWaiter.Wait()
+	pm.lock.Lock()
+	bc.postLockTime = time.Now()
+	return bc
+}
+
+// Unlock unlocks mutex acquired via Lock
+func (pm *PriorityRWMutex) Unlock(bc *BlockContext) {
+	pm.writeWaiter.Done()
+	bc.postOpTime = time.Now()
+	pm.lock.Unlock()
+}
+
+func (bc *BlockContext) RUnlockLow(op string, logCb func() interface{}) {
+	bc.lock.RUnlockLow(bc)
+
+	lockWaitTime := bc.postLockTime.Sub(bc.preLockTime)
+	lockHoldTime := bc.postOpTime.Sub(bc.postLockTime)
+
+	if lockHoldTime > 5*time.Second {
+		bc.logLongOp("Read", op, getDetails(logCb))
+	} else if lockWaitTime > time.Second && lockWaitTime > 5*lockHoldTime {
+		bc.logLongOp("Blocked Read", op, getDetails(logCb))
+	}
+}
+
+func (bc *BlockContext) Unlock(op string, logCb func() interface{}) {
+	bc.lock.Unlock(bc)
+
+	lockWaitTime := bc.postLockTime.Sub(bc.preLockTime)
+	lockHoldTime := bc.postOpTime.Sub(bc.postLockTime)
+
+	if lockHoldTime > 100*time.Millisecond {
+		bc.logLongOp("Write", op, getDetails(logCb))
+	} else if lockWaitTime > 5*time.Second {
+		bc.logLongOp("Blocked Write", op, getDetails(logCb))
+	}
+}
+
+func (bc *BlockContext) logLongOp(opType, op, details string) {
+	waitSecs := bc.postLockTime.Sub(bc.preLockTime).Seconds()
+	holdsSecs := bc.postOpTime.Sub(bc.postLockTime).Seconds()
+
+	timeFormat := "15:04:05.000"
+
+	log.Infof("Long %s %s: lockWaitTime = %f, lockHoldTime = %f %s absoluteTimes = (%v -> %v -> %v)",
+		opType, op, waitSecs, holdsSecs, details,
+		bc.preLockTime.Format(timeFormat), bc.postLockTime.Format(timeFormat), bc.postOpTime.Format(timeFormat))
+}
+
+func getDetails(logCb func() interface{}) string {
+	if logCb == nil {
+		return ""
+	}
+	return fmt.Sprintf(", details = '%v'", logCb())
+}
+
+/*
+type timedRLocker struct {
+	lock              *sync.RWMutex
+	preLock, postLock time.Time
+}
+
+func acquireTimedLock(lock *sync.RWMutex) timedRLocker {
+	trl := timedRLocker{
+		lock:    lock,
+		preLock: time.Now(),
+	}
+	trl.lock.RLock()
+	trl.postLock = time.Now()
+	return trl
+}
+
+func (trl timedRLocker) RUnlock(op string, logCb func() interface{}) {
+	endTime := time.Now()
+	trl.lock.RUnlock()
+
+	lockHoldTime := endTime.Sub(trl.postLock)
+	lockWaitTime := trl.postLock.Sub(trl.preLock)
+	if lockHoldTime > time.Second {
+		log.Infof("Long %s: lockWaitTime = %f, lockHoldTime = %f (%v - %v), details = '%v' ", op, lockWaitTime.Seconds(), lockHoldTime.Seconds(), trl.postLock, endTime, logCb())
+	} else if lockWaitTime > time.Second {
+		log.Infof("Long Blocked %s: lockWaitTime = %f, lockHoldTime = %f, details = '%v'", op, lockWaitTime.Seconds(), lockHoldTime.Seconds(), logCb())
+	}
+}
+*/

--- a/idx/memory/priority_lock.go
+++ b/idx/memory/priority_lock.go
@@ -126,33 +126,3 @@ func getDetails(logCb func() interface{}) string {
 	}
 	return fmt.Sprintf(", details = '%v'", logCb())
 }
-
-/*
-type timedRLocker struct {
-	lock              *sync.RWMutex
-	preLock, postLock time.Time
-}
-
-func acquireTimedLock(lock *sync.RWMutex) timedRLocker {
-	trl := timedRLocker{
-		lock:    lock,
-		preLock: time.Now(),
-	}
-	trl.lock.RLock()
-	trl.postLock = time.Now()
-	return trl
-}
-
-func (trl timedRLocker) RUnlock(op string, logCb func() interface{}) {
-	endTime := time.Now()
-	trl.lock.RUnlock()
-
-	lockHoldTime := endTime.Sub(trl.postLock)
-	lockWaitTime := trl.postLock.Sub(trl.preLock)
-	if lockHoldTime > time.Second {
-		log.Infof("Long %s: lockWaitTime = %f, lockHoldTime = %f (%v - %v), details = '%v' ", op, lockWaitTime.Seconds(), lockHoldTime.Seconds(), trl.postLock, endTime, logCb())
-	} else if lockWaitTime > time.Second {
-		log.Infof("Long Blocked %s: lockWaitTime = %f, lockHoldTime = %f, details = '%v'", op, lockWaitTime.Seconds(), lockHoldTime.Seconds(), logCb())
-	}
-}
-*/

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -15,11 +15,11 @@ func filterAndCompareResults(t *testing.T, expressions tagquery.Expressions, met
 	index.Init()
 
 	archives, _ := getTestArchives(10)
-	index.Lock()
+	bc := index.Lock()
 	for i := range archives {
 		index.add(archives[i])
 	}
-	index.Unlock()
+	bc.Unlock("TestLoad", nil)
 
 	for i := range metaRecords {
 		index.MetaTagRecordUpsert(1, metaRecords[i])

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -37,11 +37,11 @@ func selectAndCompareResults(t *testing.T, expression tagquery.Expression, metaR
 	index.Init()
 
 	archives, _ := getTestArchives(10)
-	index.Lock()
+	bc := index.Lock()
 	for i := range archives {
 		index.add(archives[i])
 	}
-	index.Unlock()
+	bc.Unlock("TestLoad", nil)
 
 	for i := range metaRecords {
 		index.MetaTagRecordUpsert(1, metaRecords[i])

--- a/idx/memory/write_queue.go
+++ b/idx/memory/write_queue.go
@@ -123,10 +123,3 @@ func (wq *WriteQueue) loop() {
 		}
 	}
 }
-
-func (wq *WriteQueue) isFlushPending() bool {
-	wq.Lock()
-	defer wq.Unlock()
-
-	return wq.flushPending
-}

--- a/idx/memory/write_queue_test.go
+++ b/idx/memory/write_queue_test.go
@@ -55,6 +55,9 @@ func TestWriteQueue(t *testing.T) {
 	mkey, _ := schema.MKeyFromString(data.Id)
 	ix.AddOrUpdate(mkey, data, getPartition(data))
 
+	// TODO - make this less flaky (add flush counter? Flush wait func?)
+	time.Sleep(100 * time.Millisecond)
+
 	nodes, err = ix.Find(1, "some.metric.*", 0)
 	if err != nil {
 		t.Fatal(err)

--- a/idx/memory/write_queue_test.go
+++ b/idx/memory/write_queue_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -64,5 +65,56 @@ func TestWriteQueue(t *testing.T) {
 	}
 	if len(nodes) != writeMaxBatchSize {
 		t.Fatalf("expected %d nodes in the index. Instead found %d", writeMaxBatchSize, len(nodes))
+	}
+}
+
+func TestWriteQueueMultiThreads(t *testing.T) {
+	_writeQueueEnabled := writeQueueEnabled
+	defer func() {
+		writeQueueEnabled = _writeQueueEnabled
+	}()
+	writeQueueEnabled = true
+	ix := New()
+	ix.Init()
+	defer ix.Stop()
+
+	var wg sync.WaitGroup
+	numThreads := 4
+	for t := 0; t < numThreads; t++ {
+		wg.Add(1)
+		go func(threadNum int) {
+			count := writeMaxBatchSize - 1
+			for i := 0; i < count; i++ {
+				name := fmt.Sprintf("some.metric.%d.%d", threadNum, i)
+				data := &schema.MetricData{
+					Name:     name,
+					OrgId:    1,
+					Interval: 1,
+					Tags:     []string{},
+					Time:     time.Now().Unix(),
+				}
+				data.SetId()
+				mkey, _ := schema.MKeyFromString(data.Id)
+				ix.AddOrUpdate(mkey, data, getPartition(data))
+			}
+			wg.Done()
+		}(t)
+	}
+
+	wg.Wait()
+
+	time.Sleep(10 * time.Millisecond)
+
+	nodes, err := ix.Find(1, "some.metric.*.*", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	minNodes := writeMaxBatchSize * (numThreads - 1)
+	maxNodes := (writeMaxBatchSize - 1) * numThreads
+	if len(nodes) < minNodes {
+		t.Fatalf("expected at least %d nodes in the index. Instead found %d", minNodes, len(nodes))
+	} else if len(nodes) > maxNodes {
+		t.Fatalf("expected at most %d nodes in the index. Instead found %d", maxNodes, len(nodes))
 	}
 }


### PR DESCRIPTION
Still needs cleaning up and more testing, but this PR changes the locking behavior in the index so that long read queries can't block ingest (`Update` and `AddOrUpdate` calls).

There is a scenario (common in our case) where long index queries (say 5s) can block the acquisition of a write lock (like in the WriteQueue or `add` if not using the `WriteQueue`) which in turn blocks new read locks (like in `Update`). This means long index read ops can actually block ingest. 

This PR alleviates that problem by differentiating the possibly slow operations and the almost certainly fast operations so that a write lock is still blocked on long index operations, but the fast operations should only get blocked by write locks (which we should make sure are fast). 

It also adds logging around long lock waits/holds for non-high priority locking. I decided not to track the timings for those, since we may be doing them many thousands of times per second.