### PR TITLE
Fix functions aliasByNode and aliasSub when a tag contains a space char

### DIFF
--- a/expr/func_aliasbymetric_test.go
+++ b/expr/func_aliasbymetric_test.go
@@ -82,6 +82,28 @@ func TestAliasByMetricWithTags(t *testing.T) {
 	)
 }
 
+func TestAliasByMetricWithTagsWithSpaces(t *testing.T) {
+	originalMetric := "my.test;my tag=my value"
+	expectedMetric := "test;my tag=my value"
+
+	testAliasByMetric(
+		[]models.Series{
+			// No Function wrapper
+			getSeriesNamed(originalMetric, a),
+			// Function wrapper - single
+			getSeries("functionBlah("+originalMetric+", funcValue1, funcValue2)", originalMetric, a),
+			// Function wrapper - multiple
+			getSeries("functionBlah(functionBlahBlah("+originalMetric+"),funcValue1, funcValue2)", originalMetric, a),
+		},
+		[]models.Series{
+			getSeriesNamed(expectedMetric, a),
+			getSeriesNamed(expectedMetric, a),
+			getSeriesNamed(expectedMetric, a),
+		},
+		t,
+	)
+}
+
 func testAliasByMetric(in []models.Series, out []models.Series, t *testing.T) {
 	f := NewAliasByMetric()
 	f.(*FuncAliasByMetric).in = NewMock(in)

--- a/expr/func_aliasbynode_test.go
+++ b/expr/func_aliasbynode_test.go
@@ -38,6 +38,19 @@ func TestAliasByNodeMultiple(t *testing.T) {
 	)
 }
 
+func TestAliasByNodeWithSpaceInTag(t *testing.T) {
+	testAliasByNode(
+		"space in tag",
+		[]models.Series{
+			getSeriesNamed("some.id.of.a.metric.1;my tag=the value", a),
+		},
+		[]models.Series{
+			getSeriesNamed("some", a),
+		},
+		t,
+	)
+}
+
 func makeAliasByNode(in []models.Series, nodes []expr) GraphiteFunc {
 	f := NewAliasByNode()
 	abn := f.(*FuncAliasByNode)

--- a/expr/func_aliassub_test.go
+++ b/expr/func_aliassub_test.go
@@ -18,6 +18,7 @@ func TestAliasSub(t *testing.T) {
 	testAliasSub(`^.*TCP(\d+)`, `\1`, []string{"ip-foobar-TCP25", "ip-foobar-TCPfoo"}, []string{"25", "ip-foobar-TCPfoo"}, t)
 	testAliasSub(".*\\.([^\\.]+)\\.metrics_received.*", "\\1 in", []string{"metrictank.stats.env.instance.input.pluginname.metrics_received.counter32"}, []string{"pluginname in"}, t)
 	testAliasSub(".*host=([^;]+)(;.*)?", "\\1", []string{"foo.bar.baz;a=b;host=ab1"}, []string{"ab1"}, t)
+	testAliasSub(".*([0-9].+)lue", "\\1", []string{"some.id.of.a.metric.1;my tag=the value"}, []string{"1;my tag=the va"}, t)
 }
 
 func testAliasSub(search, replace string, inStr, outStr []string, t *testing.T) {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -403,7 +403,7 @@ func parseString(s string) (string, string, error) {
 // metric name / path expression is defined by the following criteria:
 // 1. Not a function name
 // 2. Consists only of name characters
-// 	2.1 '=' / ' ' are conditionally allowed if ';' is found (denoting tag format)
+// 	2.1 '=' and ' ' are conditionally allowed if ';' is found (denoting tag format)
 // 	2.2 ',' is conditionally allowed within matching '{}'
 // 3. Is not a string literal (i.e. contained within single/double quote pairs)
 func extractMetric(m string) string {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -403,7 +403,7 @@ func parseString(s string) (string, string, error) {
 // metric name / path expression is defined by the following criteria:
 // 1. Not a function name
 // 2. Consists only of name characters
-// 	2.1 '=' is conditionally allowed if ';' is found (denoting tag format)
+// 	2.1 '=' / ' ' are conditionally allowed if ';' is found (denoting tag format)
 // 	2.2 ',' is conditionally allowed within matching '{}'
 // 3. Is not a string literal (i.e. contained within single/double quote pairs)
 func extractMetric(m string) string {
@@ -411,7 +411,7 @@ func extractMetric(m string) string {
 	end := 0
 	curlyBraces := 0
 	quoteChar := byte(0)
-	allowEqual := false
+	allowTagChars := false
 	for end < len(m) {
 		c := m[end]
 		if (c == '\'' || c == '"') && (end == 0 || m[end-1] != '\\') {
@@ -430,11 +430,11 @@ func extractMetric(m string) string {
 				curlyBraces--
 			} else if c == ')' || (c == ',' && curlyBraces == 0) {
 				return m[start:end]
-			} else if !(isNameChar(c) || c == ',' || (allowEqual && c == '=')) {
+			} else if !(isNameChar(c) || c == ',' || (allowTagChars && strings.IndexByte("= ", c) >= 0)) {
 				start = end + 1
-				allowEqual = false
+				allowTagChars = false
 			} else if c == ';' {
-				allowEqual = true
+				allowTagChars = true
 			}
 		}
 


### PR DESCRIPTION
This first adds unit tests to check for the bug, then fixes the bug.

@Dieterbe I'm trying to think of cases which get broken by this change, but can't find any. Can you maybe think of something which would break because of this?

Fixes: https://github.com/grafana/metrictank/issues/1672