### PR TITLE
duplicate series: deduplicate + fix runtime normalization

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -71,18 +71,14 @@ func Fix(in []schema.Point, from, to, interval uint32) []schema.Point {
 		// the requested range is too narrow for the requested interval
 		return []schema.Point{}
 	}
-	// 3 attempts to get a sufficiently sized slice from the pool. if it fails, allocate a new one.
+	// try to get a sufficiently sized slice from the pool. if it fails, allocate a new one.
 	var out []schema.Point
 	neededCap := int((last-first)/interval + 1)
-	for attempt := 1; attempt < 4; attempt++ {
-		candidate := pointSlicePool.Get().([]schema.Point)
-		if cap(candidate) >= neededCap {
-			out = candidate[:neededCap]
-			break
-		}
+	candidate := pointSlicePool.Get().([]schema.Point)
+	if cap(candidate) >= neededCap {
+		out = candidate[:neededCap]
+	} else {
 		pointSlicePool.Put(candidate)
-	}
-	if out == nil {
 		out = make([]schema.Point, neededCap)
 	}
 

--- a/api/graphite_req.go
+++ b/api/graphite_req.go
@@ -37,7 +37,7 @@ func (r ReqMap) Dump() string {
 	out := fmt.Sprintf("ReqsMap (%d entries):\n", r.cnt)
 	out += "  Groups:\n"
 	for i, reqs := range r.pngroups {
-		out += fmt.Sprintf("    * group %d:", i)
+		out += fmt.Sprintf("    * group %d:\n", i)
 		for _, r := range reqs {
 			out += "      " + r.DebugString() + "\n"
 		}

--- a/devdocs/expr.md
+++ b/devdocs/expr.md
@@ -60,7 +60,7 @@ Note: even if the same series is present elsewhere in the datamap, each copy is 
 
 # function processing
 
-loading data and feeding into the function processing chain happens through FuncGet, which lookups data based on the expr.Req coming from the user, which maps 1:1 to the datamap above.
+Loading data and feeding into the function processing chain happens through FuncGet, which looks up data based on the expr.Req coming from the user, which maps 1:1 to the datamap above.
 In particular: it takes into account pngroups (even if they lead to equivalent fetches and thus identical series). But each copy of a series is a distinct, deep copy.
 It is important to note that any series may be processed or returned more than once. E.g. a query like `target=a&target=a`. For this reason, any function or operation such as runtime consolidation, needs to make sure not to effect the contents of the datamap.
 How we solve this is described in the section "Considerations around Series changes and reuse and why we chose copy-on-write" below.

--- a/expr/plan.go
+++ b/expr/plan.go
@@ -176,12 +176,30 @@ func NewPlan(exprs []*expr, from, to, mdp uint32, stable bool, optimizations Opt
 
 // newplan adds requests as needed for the given expr, resolving function calls as needed
 func newplan(e *expr, context Context, stable bool, reqs []Req) (GraphiteFunc, []Req, error) {
+
+	// surpress duplicate queries such as target=foo&target=foo
+	// note that unless `pre-normalization = false`,
+	// this cannot surpress duplicate reqs in these cases:
+	// target=foo&target=sum(foo)      // reqs are different, one has a PNGroup set
+	// target=sum(foo)&target=sum(foo) // reqs get different PNGroups
+	// perhaps in the future we can improve on this and
+	// deduplicate the largest common (sub)expressions
+
+	addReqIfNew := func(req Req) {
+		for _, r := range reqs {
+			if r == req {
+				return
+			}
+		}
+		reqs = append(reqs, req)
+	}
+
 	if e.etype != etFunc && e.etype != etName {
 		return nil, nil, errors.NewBadRequest("request must be a function call or metric pattern")
 	}
 	if e.etype == etName {
 		req := NewReqFromContext(e.str, context)
-		reqs = append(reqs, req)
+		addReqIfNew(req)
 		return NewGet(req), reqs, nil
 	} else if e.etype == etFunc && e.str == "seriesByTag" {
 		// `seriesByTag` function requires resolving expressions to series
@@ -191,7 +209,7 @@ func newplan(e *expr, context Context, stable bool, reqs []Req) (GraphiteFunc, [
 		// TODO - find a way to prevent this parse/encode/parse/encode loop
 		expressionStr := "seriesByTag(" + e.argsStr + ")"
 		req := NewReqFromContext(expressionStr, context)
-		reqs = append(reqs, req)
+		addReqIfNew(req)
 		return NewGet(req), reqs, nil
 	}
 	// here e.type is guaranteed to be etFunc

--- a/expr/plan.go
+++ b/expr/plan.go
@@ -177,9 +177,9 @@ func NewPlan(exprs []*expr, from, to, mdp uint32, stable bool, optimizations Opt
 // newplan adds requests as needed for the given expr, resolving function calls as needed
 func newplan(e *expr, context Context, stable bool, reqs []Req) (GraphiteFunc, []Req, error) {
 
-	// surpress duplicate queries such as target=foo&target=foo
+	// suppress duplicate queries such as target=foo&target=foo
 	// note that unless `pre-normalization = false`,
-	// this cannot surpress duplicate reqs in these cases:
+	// this cannot suppress duplicate reqs in these cases:
 	// target=foo&target=sum(foo)      // reqs are different, one has a PNGroup set
 	// target=sum(foo)&target=sum(foo) // reqs get different PNGroups
 	// perhaps in the future we can improve on this and

--- a/expr/pool.go
+++ b/expr/pool.go
@@ -20,13 +20,10 @@ func Pool(p *sync.Pool) {
 // pointSlicePoolGet returns a pointslice of at least minCap capacity.
 // similar code lives also in api.Fix(). at some point we should really clean up our pool code.
 func pointSlicePoolGet(minCap int) []schema.Point {
-	// 3 attempts to get a sufficiently sized slice from the pool. if it fails, allocate a new one
-	for attempt := 1; attempt < 4; attempt++ {
-		candidate := pointSlicePool.Get().([]schema.Point)
-		if cap(candidate) >= minCap {
-			return candidate
-		}
-		pointSlicePool.Put(candidate)
+	candidate := pointSlicePool.Get().([]schema.Point)
+	if cap(candidate) >= minCap {
+		return candidate
 	}
+	pointSlicePool.Put(candidate)
 	return make([]schema.Point, 0, minCap)
 }


### PR DESCRIPTION
In this PR, I introduce a fairly trivial deduplication optimization, followed by a good chunk of developer documentation to clarify our use of request types and where the sources of duplication and reuse are (as well as opportunities for deduplication), finally arriving at a clearer, more precise explanation of the input data reuse (which all boils down to the dataMap), and finally fixing bug 1807.

fix #1807