### PR TITLE
Fix same models.Series getting added to the sync.Pool (or datamap) twice

### DIFF
--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -62,6 +62,8 @@ type getTargetsResp struct {
 // note: values are quantized to the right because we can't lie about the future:
 // e.g. if interval is 10 and we have a point at 8 or at 2, it will be quantized to 10, we should never move
 // values to earlier in time.
+// Note: `in` series is returned to the pool and should not be reused.
+// output series comes out of the pool if possible.
 func Fix(in []schema.Point, from, to, interval uint32) []schema.Point {
 
 	first := align.ForwardIfNotAligned(from, interval)
@@ -150,6 +152,7 @@ func divide(pointsA, pointsB []schema.Point) []schema.Point {
 	return pointsA
 }
 
+// getTargets retrieves the series for the given requests by querying remote and/or remote nodes as needed
 func (s *Server) getTargets(ctx context.Context, ss *models.StorageStats, reqs []models.Req) ([]models.Series, error) {
 	// split reqs into local and remote.
 	localReqs := make([]models.Req, 0)

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -153,7 +153,7 @@ func divide(pointsA, pointsB []schema.Point) []schema.Point {
 	return pointsA
 }
 
-// getTargets retrieves the series for the given requests by querying remote and/or remote nodes as needed
+// getTargets retrieves the series for the given requests by querying local and/or remote nodes as needed
 func (s *Server) getTargets(ctx context.Context, ss *models.StorageStats, reqs []models.Req) ([]models.Series, error) {
 	// split reqs into local and remote.
 	localReqs := make([]models.Req, 0)

--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/seriescycle"
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/conf"
 	"github.com/grafana/metrictank/consolidation"
-	"github.com/grafana/metrictank/expr"
 	"github.com/grafana/metrictank/mdata"
 	"github.com/grafana/metrictank/mdata/cache"
 	"github.com/grafana/metrictank/mdata/cache/accnt"
@@ -583,7 +583,7 @@ func TestMergeSeries(t *testing.T) {
 		Interval: 10,
 	})
 
-	merged := mergeSeries(out, expr.NewDataMap())
+	merged := mergeSeries(out, seriescycle.NullCycler)
 	if len(merged) != 5 {
 		t.Errorf("Expected data to be merged down to 5 series. got %d instead", len(merged))
 	}

--- a/api/seriescycle/seriescycle.go
+++ b/api/seriescycle/seriescycle.go
@@ -1,0 +1,23 @@
+package seriescycle
+
+import (
+	"github.com/grafana/metrictank/api/models"
+)
+
+// SeriesCycler manages what should happen to a models.Series
+// when we create it, or drop our reference to it
+// Warning: this is for managing recycling of the Datapoints field.
+// In some places we create "new" series by repurposing existing
+// Series and adding a new Datapoints slice onto it.
+// E.g. in expr.NormalizeTo
+type SeriesCycler struct {
+	New  func(models.Series)
+	Done func(models.Series)
+}
+
+var NullCycler = SeriesCycler{
+	New: func(in models.Series) {
+	},
+	Done: func(in models.Series) {
+	},
+}

--- a/expr/cowcycler.go
+++ b/expr/cowcycler.go
@@ -1,0 +1,20 @@
+package expr
+
+import (
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/seriescycle"
+)
+
+// NewCOW returns a SeriesCycler tailored towards COW scoped to a user request
+// * newly provisioned series go into the datamap, such that the datamap can reclaim them when the request finishes
+// * discarded series are left alone (not recycled, because they may be read elsewhere)
+// (keeping this in expr to keep calls from expr code short, and avoid import cycle)
+func NewCOWCycler(dm DataMap) seriescycle.SeriesCycler {
+	return seriescycle.SeriesCycler{
+		New: func(in models.Series) {
+			dm.Add(Req{}, in)
+		},
+		Done: func(in models.Series) {
+		},
+	}
+}

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -57,7 +57,7 @@ func (s *FuncAggregate) Exec(dataMap DataMap) ([]models.Series, error) {
 	}
 
 	agg := seriesAggregator{function: getCrossSeriesAggFunc(s.name), name: s.name}
-	series = Normalize(dataMap, series)
+	series = Normalize(series, NewCOWCycler(dataMap))
 	return aggregate(dataMap, series, queryPatts, agg, s.xFilesFactor)
 }
 

--- a/expr/func_divideseries.go
+++ b/expr/func_divideseries.go
@@ -73,9 +73,9 @@ func (s *FuncDivideSeries) Exec(dataMap DataMap) ([]models.Series, error) {
 			if ok {
 				divisor = newDiv
 				// we now have the right divisor but may still need to normalize the dividend
-				dividend, divisor = NormalizeTwo(dataMap, dividend, divisor)
+				dividend, divisor = NormalizeTwo(dividend, divisor, NewCOWCycler(dataMap))
 			} else {
-				dividend, divisor = NormalizeTwo(dataMap, dividend, divisor)
+				dividend, divisor = NormalizeTwo(dividend, divisor, NewCOWCycler(dataMap))
 				divisorsByRes[lcm] = divisor
 			}
 		}

--- a/expr/func_divideserieslists.go
+++ b/expr/func_divideserieslists.go
@@ -52,7 +52,7 @@ func (s *FuncDivideSeriesLists) Exec(dataMap DataMap) ([]models.Series, error) {
 
 	var series []models.Series
 	for i := range dividends {
-		dividend, divisor := NormalizeTwo(dataMap, dividends[i], divisors[i])
+		dividend, divisor := NormalizeTwo(dividends[i], divisors[i], NewCOWCycler(dataMap))
 
 		out := pointSlicePool.Get().([]schema.Point)
 		for i := 0; i < len(dividend.Datapoints); i++ {

--- a/expr/func_groupbynodes.go
+++ b/expr/func_groupbynodes.go
@@ -93,7 +93,7 @@ func (s *FuncGroupByNodes) Exec(dataMap DataMap) ([]models.Series, error) {
 			QueryPNGroup: group.s[0].QueryPNGroup,
 			Meta:         group.m,
 		}
-		group.s = Normalize(dataMap, group.s)
+		group.s = Normalize(group.s, NewCOWCycler(dataMap))
 		outSeries.Interval = group.s[0].Interval
 		outSeries.SetTags()
 		outSeries.Datapoints = pointSlicePool.Get().([]schema.Point)

--- a/expr/func_groupbytags.go
+++ b/expr/func_groupbytags.go
@@ -132,7 +132,7 @@ func (s *FuncGroupByTags) Exec(dataMap DataMap) ([]models.Series, error) {
 		newSeries.SetTags()
 
 		newSeries.Datapoints = pointSlicePool.Get().([]schema.Point)
-		group.s = Normalize(dataMap, group.s)
+		group.s = Normalize(group.s, NewCOWCycler(dataMap))
 		aggFunc(group.s, &newSeries.Datapoints)
 		dataMap.Add(Req{}, newSeries)
 

--- a/expr/normalize.go
+++ b/expr/normalize.go
@@ -54,6 +54,7 @@ func NormalizeTwo(dataMap DataMap, a, b models.Series) (models.Series, models.Se
 // the following MUST be true when calling this:
 // * interval > in.Interval
 // * interval % in.Interval == 0
+// the adjusted series gets created in a series drawn out of the pool and is added to the dataMap so it can be reclaimed
 func NormalizeTo(dataMap DataMap, in models.Series, interval uint32) models.Series {
 
 	if len(in.Datapoints) == 0 {

--- a/expr/normalize_test.go
+++ b/expr/normalize_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/seriescycle"
 	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/schema"
 )
@@ -52,8 +53,7 @@ func TestNormalizeOneSeriesAdjustWithPreCanonicalize(t *testing.T) {
 			},
 		},
 	}
-	dataMap := NewDataMap()
-	got := Normalize(dataMap, in)
+	got := Normalize(in, seriescycle.NullCycler)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("TestNormalize() mismatch (-want +got):\n%s", diff)
 	}
@@ -141,8 +141,7 @@ func TestNormalizeMultiLCMSeriesAdjustWithPreCanonicalize(t *testing.T) {
 			},
 		},
 	}
-	dataMap := NewDataMap()
-	got := Normalize(dataMap, in)
+	got := Normalize(in, seriescycle.NullCycler)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("TestNormalize() mismatch (-want +got):\n%s", diff)
 	}
@@ -175,8 +174,7 @@ func TestNormalizeToWithMissingBeginning(t *testing.T) {
 			{Ts: 120, Val: 75 + 90 + 105 + 120},
 		},
 	}
-	dataMap := NewDataMap()
-	got := NormalizeTo(dataMap, in, 60)
+	got := NormalizeTo(in, 60, seriescycle.NullCycler)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("TestNormalize() mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
first commit introduces mostly comments and diagnosis
second commit fixes the issue and removes diagnosis

fix #1875 

Not supper happy with adding a bit of complexity, but seems like it's either this, or providing a bunch of alternative normalization functions that only differ in their side effects.