### PR TITLE
meta tags: avoid frequent write locks

### DIFF
--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -494,7 +494,10 @@ func (m *UnpartitionedMemoryIdx) indexTags(def *schema.MetricDefinition) {
 
 	if MetaTagSupport {
 		if ok := m.getOrgMetaTagIndex(def.OrgId).enricher.tryAddMetric(*def); !ok {
-			log.Warnf("Failed to add ")
+			log.Warnf("Failed to add metric def need to relinquish lock")
+			m.Unlock()
+			m.getOrgMetaTagIndex(def.OrgId).enricher.addMetric(*def)
+			m.Lock()
 		}
 	}
 }

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -528,9 +528,12 @@ func (m *UnpartitionedMemoryIdx) deindexTags(tags TagIndex, def *schema.MetricDe
 	m.defByTagSet.del(def)
 
 	if MetaTagSupport {
-		m.Unlock()
-		m.getOrgMetaTagIndex(def.OrgId).enricher.delMetric(def)
-		m.Lock()
+		if ok := m.getOrgMetaTagIndex(def.OrgId).enricher.tryDelMetric(def); !ok {
+			log.Warnf("Failed to del metric def, need to relinquish lock")
+			m.Unlock()
+			m.getOrgMetaTagIndex(def.OrgId).enricher.delMetric(def)
+			m.Lock()
+		}
 	}
 
 	return true

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -493,9 +493,9 @@ func (m *UnpartitionedMemoryIdx) indexTags(def *schema.MetricDefinition) {
 	m.defByTagSet.add(def)
 
 	if MetaTagSupport {
-		m.Unlock()
-		m.getOrgMetaTagIndex(def.OrgId).enricher.addMetric(*def)
-		m.Lock()
+		if ok := m.getOrgMetaTagIndex(def.OrgId).enricher.tryAddMetric(*def); !ok {
+			log.Warnf("Failed to add ")
+		}
 	}
 }
 

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -719,6 +719,18 @@ func (e *metaTagEnricher) addMetric(md schema.MetricDefinition) {
 	}
 }
 
+func (e *metaTagEnricher) tryAddMetric(md schema.MetricDefinition) bool {
+	select {
+	case e.eventQueue <- enricherEvent{
+		eventType: addMetric,
+		payload:   md,
+	}:
+		return true
+	default:
+		return false
+	}
+}
+
 func (e *metaTagEnricher) delMetric(md *schema.MetricDefinition) {
 	e.eventQueue <- enricherEvent{
 		eventType: delMetric,

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -731,7 +731,7 @@ func (e *metaTagEnricher) tryAddMetric(md schema.MetricDefinition) bool {
 	}
 }
 
-func (e *metaTagEnricher) tryDelMetric(md schema.MetricDefinition) bool {
+func (e *metaTagEnricher) tryDelMetric(md *schema.MetricDefinition) bool {
 	select {
 	case e.eventQueue <- enricherEvent{
 		eventType: delMetric,

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -731,6 +731,18 @@ func (e *metaTagEnricher) tryAddMetric(md schema.MetricDefinition) bool {
 	}
 }
 
+func (e *metaTagEnricher) tryDelMetric(md schema.MetricDefinition) bool {
+	select {
+	case e.eventQueue <- enricherEvent{
+		eventType: delMetric,
+		payload:   md,
+	}:
+		return true
+	default:
+		return false
+	}
+}
+
 func (e *metaTagEnricher) delMetric(md *schema.MetricDefinition) {
 	e.eventQueue <- enricherEvent{
 		eventType: delMetric,


### PR DESCRIPTION
This is a branch for a concept change. Right now we need to frequently relinquish the write lock to avoid deadlock scenarios when adding/deleting series within the meta tags component.

As [discussed before](https://github.com/grafana/metrictank/pull/1847) acquiring the write lock can be very expensive. This change is designed to reduce the number of times we need to acquire the write lock within batching operations.

Open question: is calling `getOrgMetaTagIndex` under lock a potential deadlock?