### PR TITLE
expr tests should do deep copies of input series. fix #1872

### DIFF
--- a/expr/func_absolute_test.go
+++ b/expr/func_absolute_test.go
@@ -54,8 +54,8 @@ func TestAbsoluteRandom(t *testing.T) {
 	input := []models.Series{
 		getSeries("rand", "random", random),
 	}
-	inputCopy := make([]models.Series, len(input))
-	copy(inputCopy, input)
+
+	inputCopy := models.SeriesCopy(input) // to later verify that it is unchanged
 
 	f := getNewAbsolute(input)
 	out := []models.Series{

--- a/expr/func_aggregate_test.go
+++ b/expr/func_aggregate_test.go
@@ -255,11 +255,9 @@ func makeAggregate(agg string, in [][]models.Series, xFilesFactor float64) Graph
 }
 
 func testAggregate(name, agg string, in [][]models.Series, out models.Series, t *testing.T, xFilesFactor float64) {
-	// Copy input to check that it is unchanged later
-	inputCopy := make([][]models.Series, len(in))
+	inputCopy := make([][]models.Series, len(in)) // to later verify that it is unchanged
 	for i := range in {
-		inputCopy[i] = make([]models.Series, len(in[i]))
-		copy(inputCopy[i], in[i])
+		inputCopy[i] = models.SeriesCopy(in[i])
 	}
 
 	f := makeAggregate(agg, in, xFilesFactor)

--- a/expr/func_alias_test.go
+++ b/expr/func_alias_test.go
@@ -48,9 +48,7 @@ func makeAlias(in []models.Series) GraphiteFunc {
 func testAlias(name string, in []models.Series, out []models.Series, t *testing.T) {
 	f := makeAlias(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_aliasbymetric_test.go
+++ b/expr/func_aliasbymetric_test.go
@@ -108,9 +108,7 @@ func testAliasByMetric(in []models.Series, out []models.Series, t *testing.T) {
 	f := NewAliasByMetric()
 	f.(*FuncAliasByMetric).in = NewMock(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_aliasbynode_test.go
+++ b/expr/func_aliasbynode_test.go
@@ -62,9 +62,7 @@ func makeAliasByNode(in []models.Series, nodes []expr) GraphiteFunc {
 func testAliasByNode(name string, in []models.Series, out []models.Series, t *testing.T) {
 	f := makeAliasByNode(in, []expr{{etype: etInt, int: 0}})
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_aliassub_test.go
+++ b/expr/func_aliassub_test.go
@@ -34,9 +34,7 @@ func testAliasSub(search, replace string, inStr, outStr []string, t *testing.T) 
 	alias.replace = replace
 	alias.in = NewMock(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_aspercent_test.go
+++ b/expr/func_aspercent_test.go
@@ -204,9 +204,7 @@ func getNewAsPercent(in []models.Series) (*FuncAsPercent, []models.Series) {
 }
 
 func execAndCheck(in, out []models.Series, f GraphiteFunc, t *testing.T) {
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 	got, err := f.Exec(dataMap)

--- a/expr/func_consolidateby_test.go
+++ b/expr/func_consolidateby_test.go
@@ -55,9 +55,7 @@ func testConsolidateBy(name string, in []models.Series, out []models.Series, t *
 		out[i].Consolidator = consolidation.Sum
 	}
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_countseries_test.go
+++ b/expr/func_countseries_test.go
@@ -48,11 +48,9 @@ func testCountSeries(name string, in [][]models.Series, out []models.Series, t *
 		f.(*FuncCountSeries).in = append(f.(*FuncCountSeries).in, NewMock(i))
 	}
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([][]models.Series, len(in))
+	inputCopy := make([][]models.Series, len(in)) // to later verify that it is unchanged
 	for i := range in {
-		inputCopy[i] = make([]models.Series, len(in[i]))
-		copy(inputCopy[i], in[i])
+		inputCopy[i] = models.SeriesCopy(in[i])
 	}
 
 	dataMap := initDataMapMultiple(in)

--- a/expr/func_derivative_test.go
+++ b/expr/func_derivative_test.go
@@ -77,9 +77,7 @@ func testDerivative(name string, in []models.Series, out []models.Series, t *tes
 	f := NewDerivative()
 	f.(*FuncDerivative).in = NewMock(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_divideseries_test.go
+++ b/expr/func_divideseries_test.go
@@ -104,11 +104,8 @@ func testDivideSeries(name string, dividend, divisor []models.Series, out []mode
 	DivideSeries.dividend = NewMock(dividend)
 	DivideSeries.divisor = NewMock(divisor)
 
-	// Copy input to check that it is unchanged later
-	dividendCopy := make([]models.Series, len(dividend))
-	copy(dividendCopy, dividend)
-	divisorCopy := make([]models.Series, len(divisor))
-	copy(divisorCopy, divisor)
+	dividendCopy := models.SeriesCopy(dividend) // to later verify that it is unchanged
+	divisorCopy := models.SeriesCopy(divisor)   // to later verify that it is unchanged
 
 	dataMap := initDataMapMultiple([][]models.Series{dividend, divisor})
 

--- a/expr/func_divideserieslists_test.go
+++ b/expr/func_divideserieslists_test.go
@@ -114,11 +114,8 @@ func testDivideSeriesLists(name string, dividend, divisor []models.Series, out [
 	DivideSeriesLists.dividends = NewMock(dividend)
 	DivideSeriesLists.divisors = NewMock(divisor)
 
-	// Copy input to check that it is unchanged later
-	dividendCopy := make([]models.Series, len(dividend))
-	copy(dividendCopy, dividend)
-	divisorCopy := make([]models.Series, len(divisor))
-	copy(divisorCopy, divisor)
+	dividendCopy := models.SeriesCopy(dividend) // to later verify that it is unchanged
+	divisorCopy := models.SeriesCopy(divisor)   // to later verify that it is unchanged
 
 	dataMap := initDataMapMultiple([][]models.Series{dividend, divisor})
 

--- a/expr/func_fallbackseries_test.go
+++ b/expr/func_fallbackseries_test.go
@@ -37,11 +37,8 @@ func makeFallbackSeries(in []models.Series, fallback []models.Series) *FuncFallb
 func testFallbackSeries(name string, in, fallback, out []models.Series, t *testing.T) {
 	f := makeFallbackSeries(in, fallback)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
-	fallbackCopy := make([]models.Series, len(fallback))
-	copy(fallbackCopy, fallback)
+	inputCopy := models.SeriesCopy(in)          // to later verify that it is unchanged
+	fallbackCopy := models.SeriesCopy(fallback) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_filterseries_test.go
+++ b/expr/func_filterseries_test.go
@@ -144,9 +144,7 @@ func testFilterSeries(name string, fn string, operator string, threshold float64
 	f.(*FuncFilterSeries).operator = operator
 	f.(*FuncFilterSeries).threshold = threshold
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_grep_test.go
+++ b/expr/func_grep_test.go
@@ -66,9 +66,7 @@ func testGrep(pattern string, exclude bool, inStr, outStr []string, t *testing.T
 	}
 	f := makeGrepOrExclude(in, pattern, exclude)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_group_test.go
+++ b/expr/func_group_test.go
@@ -46,11 +46,9 @@ func getNewGroup(in [][]models.Series) *FuncGroup {
 func testGroup(name string, in [][]models.Series, out []models.Series, t *testing.T) {
 	f := getNewGroup(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([][]models.Series, len(in))
+	inputCopy := make([][]models.Series, len(in)) // to later verify that it is unchanged
 	for i := range in {
-		inputCopy[i] = make([]models.Series, len(in[i]))
-		copy(inputCopy[i], in[i])
+		inputCopy[i] = models.SeriesCopy(in[i])
 	}
 
 	dataMap := initDataMapMultiple(in)

--- a/expr/func_groupbynodes_test.go
+++ b/expr/func_groupbynodes_test.go
@@ -227,9 +227,7 @@ func testGroupByNodes(name string, in []models.Series, expected []models.Series,
 	f.(*FuncGroupByNodes).aggregator = aggr
 	f.(*FuncGroupByNodes).nodes = nodes
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_groupbytags_test.go
+++ b/expr/func_groupbytags_test.go
@@ -195,9 +195,7 @@ func testGroupByTags(name string, in []models.Series, out []models.Series, agg s
 	gby.aggregator = agg
 	gby.tags = tags
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_highestlowest_test.go
+++ b/expr/func_highestlowest_test.go
@@ -277,9 +277,7 @@ func testHighestLowest(name string, fn string, n int64, highest bool, in []model
 	f.(*FuncHighestLowest).in = NewMock(in)
 	f.(*FuncHighestLowest).n = n
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	//inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_integral_test.go
+++ b/expr/func_integral_test.go
@@ -60,9 +60,7 @@ func getNewIntegral(in []models.Series) *FuncIntegral {
 func testIntegral(in []models.Series, out []models.Series, t *testing.T) {
 	f := getNewIntegral(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_invert.go
+++ b/expr/func_invert.go
@@ -55,6 +55,8 @@ func (s *FuncInvert) Exec(dataMap DataMap) ([]models.Series, error) {
 			Meta:         serie.Meta,
 			QueryMDP:     serie.QueryMDP,
 			QueryPNGroup: serie.QueryPNGroup,
+			QueryFrom:    serie.QueryFrom,
+			QueryTo:      serie.QueryTo,
 		}
 
 		outputs[i] = s

--- a/expr/func_isnonnull_test.go
+++ b/expr/func_isnonnull_test.go
@@ -85,9 +85,7 @@ func testIsNonNull(name string, in []models.Series, out []models.Series, t *test
 	f := NewIsNonNull()
 	f.(*FuncIsNonNull).in = NewMock(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_keeplastvalue_test.go
+++ b/expr/func_keeplastvalue_test.go
@@ -78,9 +78,7 @@ func testKeepLastValue(name string, limit int64, in []models.Series, out []model
 	f.(*FuncKeepLastValue).in = NewMock(in)
 	f.(*FuncKeepLastValue).limit = limit
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_minmax_test.go
+++ b/expr/func_minmax_test.go
@@ -136,9 +136,7 @@ func getNewMinMax(in []models.Series) *FuncMinMax {
 func testMinMax(name string, in []models.Series, out []models.Series, t *testing.T) {
 	f := getNewMinMax(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_nonnegativederivative_test.go
+++ b/expr/func_nonnegativederivative_test.go
@@ -127,9 +127,7 @@ func testNonNegativeDerivative(name string, maxValue float64, in []models.Series
 	f.(*FuncNonNegativeDerivative).in = NewMock(in)
 	f.(*FuncNonNegativeDerivative).maxValue = maxValue
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_offset_test.go
+++ b/expr/func_offset_test.go
@@ -67,9 +67,7 @@ func testOffset(name string, factor float64, in []models.Series, out []models.Se
 	f.(*FuncOffset).in = NewMock(in)
 	f.(*FuncOffset).factor = factor
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_persecond_test.go
+++ b/expr/func_persecond_test.go
@@ -123,11 +123,9 @@ func testPerSecond(name string, in [][]models.Series, out []models.Series, max i
 		ps.maxValue = max
 	}
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([][]models.Series, len(in))
+	inputCopy := make([][]models.Series, len(in)) // to later verify that it is unchanged
 	for i := range in {
-		inputCopy[i] = make([]models.Series, len(in[i]))
-		copy(inputCopy[i], in[i])
+		inputCopy[i] = models.SeriesCopy(in[i])
 	}
 
 	dataMap := initDataMapMultiple(in)

--- a/expr/func_removeabovebelowpercentile_test.go
+++ b/expr/func_removeabovebelowpercentile_test.go
@@ -139,9 +139,7 @@ func testRemoveAboveBelowPercentile(name string, above bool, n float64, in []mod
 	f.(*FuncRemoveAboveBelowPercentile).in = NewMock(in)
 	f.(*FuncRemoveAboveBelowPercentile).n = n
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_removeabovebelowvalue_test.go
+++ b/expr/func_removeabovebelowvalue_test.go
@@ -106,9 +106,7 @@ func testRemoveAboveBelowValue(name string, above bool, n float64, in []models.S
 	f.(*FuncRemoveAboveBelowValue).in = NewMock(in)
 	f.(*FuncRemoveAboveBelowValue).n = n
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_removeemptyseries_test.go
+++ b/expr/func_removeemptyseries_test.go
@@ -100,9 +100,7 @@ func testRemoveEmptySeries(xff float64, in []models.Series, out []models.Series,
 	f.(*FuncRemoveEmptySeries).in = NewMock(in)
 	f.(*FuncRemoveEmptySeries).xFilesFactor = xff
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_round_test.go
+++ b/expr/func_round_test.go
@@ -240,16 +240,14 @@ func TestRoundTiny(t *testing.T) {
 	checkCases(t, []models.Series{input}, testData)
 }
 
-func checkCases(t *testing.T, input []models.Series, cases []TestCase) {
+func checkCases(t *testing.T, in []models.Series, cases []TestCase) {
 	for _, c := range cases {
-		f := getNewRound(input, c.precision)
+		f := getNewRound(in, c.precision)
 		out := []models.Series{getSeriesNamed(c.expectedName, c.expectedOutput)}
 
-		// Copy input to check that it is unchanged later
-		inputCopy := make([]models.Series, len(input))
-		copy(inputCopy, input)
+		inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
-		dataMap := initDataMap(input)
+		dataMap := initDataMap(in)
 
 		got, err := f.Exec(dataMap)
 		if err := equalOutput(out, got, nil, err); err != nil {
@@ -257,7 +255,7 @@ func checkCases(t *testing.T, input []models.Series, cases []TestCase) {
 		}
 
 		t.Run("DidNotModifyInput", func(t *testing.T) {
-			if err := equalOutput(inputCopy, input, nil, nil); err != nil {
+			if err := equalOutput(inputCopy, in, nil, nil); err != nil {
 				t.Fatalf("Input was modified, err = %s", err)
 			}
 		})

--- a/expr/func_scale_test.go
+++ b/expr/func_scale_test.go
@@ -67,9 +67,7 @@ func testScale(name string, factor float64, in []models.Series, out []models.Ser
 	f.(*FuncScale).in = NewMock(in)
 	f.(*FuncScale).factor = factor
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_scaletoseconds_test.go
+++ b/expr/func_scaletoseconds_test.go
@@ -84,9 +84,7 @@ func testScaleToSeconds(name string, in []models.Series, out []models.Series, t 
 	f.(*FuncScaleToSeconds).in = NewMock(in)
 	f.(*FuncScaleToSeconds).seconds = seconds
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_sortby_test.go
+++ b/expr/func_sortby_test.go
@@ -133,9 +133,7 @@ func testSortBy(name string, fn string, reverse bool, in []models.Series, out []
 	f := NewSortByConstructor(fn, reverse)()
 	f.(*FuncSortBy).in = NewMock(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_sortbyname_test.go
+++ b/expr/func_sortbyname_test.go
@@ -98,9 +98,7 @@ func TestSortByName(t *testing.T) {
 			sort.natural = e.natural
 			sort.in = NewMock(in)
 
-			// Copy input to check that it is unchanged later
-			inputCopy := make([]models.Series, len(in))
-			copy(inputCopy, in)
+			inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 			dataMap := initDataMap(in)
 

--- a/expr/func_summarize_test.go
+++ b/expr/func_summarize_test.go
@@ -858,9 +858,7 @@ func testSummarize(name string, in []models.Series, out []models.Series, interva
 	summarize.fn = fn
 	summarize.alignToFrom = alignToFrom
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_timeshift_test.go
+++ b/expr/func_timeshift_test.go
@@ -45,8 +45,7 @@ func TestTimeShiftSingle(t *testing.T) {
 			Datapoints: shiftInput(a, -offset), // shift forward to avoid underflow
 		},
 	}
-	inputCopy := make([]models.Series, len(input))
-	copy(inputCopy, input)
+	inputCopy := models.SeriesCopy(input) // to later verify that it is unchanged
 
 	testTimeShift(
 		"identity",

--- a/expr/func_transformnull_test.go
+++ b/expr/func_transformnull_test.go
@@ -57,9 +57,7 @@ func testTransformNull(name string, def float64, in []models.Series, out []model
 	f.(*FuncTransformNull).in = NewMock(in)
 	f.(*FuncTransformNull).def = def
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([]models.Series, len(in))
-	copy(inputCopy, in)
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	dataMap := initDataMap(in)
 

--- a/expr/func_unique_test.go
+++ b/expr/func_unique_test.go
@@ -47,11 +47,9 @@ func TestUnique(t *testing.T) {
 func testUnique(name string, in [][]models.Series, out []models.Series, t *testing.T) {
 	f := getNewUnique(in)
 
-	// Copy input to check that it is unchanged later
-	inputCopy := make([][]models.Series, len(in))
+	inputCopy := make([][]models.Series, len(in)) // to later verify that it is unchanged
 	for i := range in {
-		inputCopy[i] = make([]models.Series, len(in[i]))
-		copy(inputCopy[i], in[i])
+		inputCopy[i] = models.SeriesCopy(in[i])
 	}
 
 	dataMap := initDataMapMultiple(in)


### PR DESCRIPTION
to verify whether the input has been tampered with, we
need to take full, pristine copies of the input series

fix #1872 