### PR TITLE
only generate metric definition filter if it will be used

### DIFF
--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -115,7 +115,9 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 				}
 			}
 
-			metaRecordFilters = append(metaRecordFilters, record.GetMetricDefinitionFilter(ctx.index.idHasTag))
+			if !optimizeForOnlyEqualOperators {
+				metaRecordFilters = append(metaRecordFilters, record.GetMetricDefinitionFilter(ctx.index.idHasTag))
+			}
 		}
 
 		if optimizeForOnlyEqualOperators {

--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/grafana/metrictank/expr/tagquery"
 	"github.com/grafana/metrictank/schema"
@@ -170,7 +169,6 @@ func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord) tagque
 	// is sufficient to let it pass the filter.
 	validValues := make(map[string]struct{})
 	validNames := make(map[string]struct{})
-	var builder strings.Builder
 	for _, record := range records {
 		if len(record.Expressions) < 1 {
 			corruptIndex.Inc()
@@ -181,9 +179,7 @@ func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord) tagque
 		if record.Expressions[0].GetKey() == "name" {
 			validNames[record.Expressions[0].GetValue()] = struct{}{}
 		} else {
-			record.Expressions[0].StringIntoWriter(&builder)
-			validValues[builder.String()] = struct{}{}
-			builder.Reset()
+			validValues[record.Expressions[0].GetKey()+"="+record.Expressions[0].GetValue()] = struct{}{}
 		}
 	}
 
@@ -211,16 +207,13 @@ func metaRecordFilterBySetOfValidValueSets(records []tagquery.MetaTagRecord) tag
 		name string
 		tags []string
 	}, len(records))
-	var builder strings.Builder
 	for i := range records {
 		validValueSets[i].tags = make([]string, 0, len(records[i].Expressions))
 		for j := range records[i].Expressions {
 			if records[i].Expressions[j].GetKey() == "name" {
 				validValueSets[i].name = records[i].Expressions[j].GetValue()
 			} else {
-				records[i].Expressions[j].StringIntoWriter(&builder)
-				validValueSets[i].tags = append(validValueSets[i].tags, builder.String())
-				builder.Reset()
+				validValueSets[i].tags = append(validValueSets[i].tags, records[i].Expressions[j].GetKey()+"="+records[i].Expressions[j].GetValue())
 			}
 		}
 


### PR DESCRIPTION
when we generate the filter functions from query expressions to filter the initial result set there's an optimization specifically for filters using meta tags where all records are only using `=` conditions. when this optimization is used then we do not need to also instantiate a "normal" metric definition filter from each involved meta record, which saves quite a bit of allocations. 

related: #1816

this is using the benchmark `BenchmarkFilter100kByMetaTagWithIndexSize1mAnd50kMetaRecords` to compare with/without this change:

```
benchmark                                                                                  old allocs     new allocs     delta
BenchmarkFilter100kByMetaTagWithIndexSize1mAnd50kMetaRecords-12                            548633         398595         -27.35%
BenchmarkFilter100kByMetaTagWithIndexSize1mAnd50kMetaRecordsWithMultipleExpressions-12     806158         606061         -24.82%

benchmark                                                                                  old bytes     new bytes     delta
BenchmarkFilter100kByMetaTagWithIndexSize1mAnd50kMetaRecords-12                            44703794      39990370      -10.54%
BenchmarkFilter100kByMetaTagWithIndexSize1mAnd50kMetaRecordsWithMultipleExpressions-12     50377024      44055984      -12.55%
```