### PR TITLE
Tagged delete

### DIFF
--- a/api/ccache.go
+++ b/api/ccache.go
@@ -65,7 +65,7 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 				res.AddError(err)
 				code = http.StatusBadRequest
 			} else {
-				query, err := tagquery.NewQuery(expressions, 0)
+				query, err := tagquery.NewQuery(expressions, 0, 0)
 				if err != nil {
 					res.AddError(err)
 					code = http.StatusInternalServerError

--- a/api/models/cluster.go
+++ b/api/models/cluster.go
@@ -53,3 +53,8 @@ type IndexFindByTagResp struct {
 type IndexTagDelSeriesResp struct {
 	Count int
 }
+
+//go:generate msgp
+type IndexTagDelByQueryResp struct {
+	Count int
+}

--- a/api/models/cluster_gen.go
+++ b/api/models/cluster_gen.go
@@ -691,6 +691,109 @@ func (z *IndexFindResp) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *IndexTagDelByQueryResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z IndexTagDelByQueryResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "Count"
+	err = en.Append(0x81, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt(z.Count)
+	if err != nil {
+		err = msgp.WrapError(err, "Count")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z IndexTagDelByQueryResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Count"
+	o = append(o, 0x81, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	o = msgp.AppendInt(o, z.Count)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IndexTagDelByQueryResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z IndexTagDelByQueryResp) Msgsize() (s int) {
+	s = 1 + 6 + msgp.IntSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *IndexTagDelSeriesResp) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/api/models/cluster_gen_test.go
+++ b/api/models/cluster_gen_test.go
@@ -461,6 +461,119 @@ func BenchmarkDecodeIndexFindResp(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalIndexTagDelByQueryResp(t *testing.T) {
+	v := IndexTagDelByQueryResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIndexTagDelByQueryResp(b *testing.B) {
+	v := IndexTagDelByQueryResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIndexTagDelByQueryResp(b *testing.B) {
+	v := IndexTagDelByQueryResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIndexTagDelByQueryResp(b *testing.B) {
+	v := IndexTagDelByQueryResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIndexTagDelByQueryResp(t *testing.T) {
+	v := IndexTagDelByQueryResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := IndexTagDelByQueryResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIndexTagDelByQueryResp(b *testing.B) {
+	v := IndexTagDelByQueryResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIndexTagDelByQueryResp(b *testing.B) {
+	v := IndexTagDelByQueryResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalIndexTagDelSeriesResp(t *testing.T) {
 	v := IndexTagDelSeriesResp{}
 	bts, err := v.MarshalMsg(nil)

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -165,6 +165,28 @@ type GraphiteTagDelSeriesResp struct {
 	Peers map[string]int `json:"peers"`
 }
 
+type GraphiteTagDelByQuery struct {
+	Expr      []string `json:"expressions" binding:"Required"`
+	OlderThan int64    `json:"olderThan" form:"olderThan"`
+	Execute   bool     `json:execute binding:"Default(false)"`
+}
+
+func (g GraphiteTagDelByQuery) Trace(span opentracing.Span) {
+	span.LogFields(
+		traceLog.String("expressions", fmt.Sprintf("%q", g.Expr)),
+		traceLog.String("olderThan", fmt.Sprintf("%d", g.OlderThan)),
+		traceLog.String("execute", fmt.Sprintf("%t", g.Execute)),
+	)
+}
+
+func (g GraphiteTagDelByQuery) TraceDebug(span opentracing.Span) {
+}
+
+type GraphiteTagDelByQueryResp struct {
+	Count int            `json:"count"`
+	Peers map[string]int `json:"peers"`
+}
+
 type GraphiteTagTerms struct {
 	Tags []string `json:"tags"`
 	Expr []string `json:"expressions"`

--- a/api/models/graphite_gen.go
+++ b/api/models/graphite_gen.go
@@ -225,6 +225,397 @@ func (z *GraphiteExpand) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *GraphiteTagDelByQuery) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Expr":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Expr")
+				return
+			}
+			if cap(z.Expr) >= int(zb0002) {
+				z.Expr = (z.Expr)[:zb0002]
+			} else {
+				z.Expr = make([]string, zb0002)
+			}
+			for za0001 := range z.Expr {
+				z.Expr[za0001], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Expr", za0001)
+					return
+				}
+			}
+		case "OlderThan":
+			z.OlderThan, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "OlderThan")
+				return
+			}
+		case "Execute":
+			z.Execute, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "Execute")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GraphiteTagDelByQuery) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 3
+	// write "Expr"
+	err = en.Append(0x83, 0xa4, 0x45, 0x78, 0x70, 0x72)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Expr)))
+	if err != nil {
+		err = msgp.WrapError(err, "Expr")
+		return
+	}
+	for za0001 := range z.Expr {
+		err = en.WriteString(z.Expr[za0001])
+		if err != nil {
+			err = msgp.WrapError(err, "Expr", za0001)
+			return
+		}
+	}
+	// write "OlderThan"
+	err = en.Append(0xa9, 0x4f, 0x6c, 0x64, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.OlderThan)
+	if err != nil {
+		err = msgp.WrapError(err, "OlderThan")
+		return
+	}
+	// write "Execute"
+	err = en.Append(0xa7, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.Execute)
+	if err != nil {
+		err = msgp.WrapError(err, "Execute")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GraphiteTagDelByQuery) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "Expr"
+	o = append(o, 0x83, 0xa4, 0x45, 0x78, 0x70, 0x72)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Expr)))
+	for za0001 := range z.Expr {
+		o = msgp.AppendString(o, z.Expr[za0001])
+	}
+	// string "OlderThan"
+	o = append(o, 0xa9, 0x4f, 0x6c, 0x64, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6e)
+	o = msgp.AppendInt64(o, z.OlderThan)
+	// string "Execute"
+	o = append(o, 0xa7, 0x45, 0x78, 0x65, 0x63, 0x75, 0x74, 0x65)
+	o = msgp.AppendBool(o, z.Execute)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GraphiteTagDelByQuery) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Expr":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Expr")
+				return
+			}
+			if cap(z.Expr) >= int(zb0002) {
+				z.Expr = (z.Expr)[:zb0002]
+			} else {
+				z.Expr = make([]string, zb0002)
+			}
+			for za0001 := range z.Expr {
+				z.Expr[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Expr", za0001)
+					return
+				}
+			}
+		case "OlderThan":
+			z.OlderThan, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "OlderThan")
+				return
+			}
+		case "Execute":
+			z.Execute, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Execute")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *GraphiteTagDelByQuery) Msgsize() (s int) {
+	s = 1 + 5 + msgp.ArrayHeaderSize
+	for za0001 := range z.Expr {
+		s += msgp.StringPrefixSize + len(z.Expr[za0001])
+	}
+	s += 10 + msgp.Int64Size + 8 + msgp.BoolSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *GraphiteTagDelByQueryResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		case "Peers":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Peers")
+				return
+			}
+			if z.Peers == nil {
+				z.Peers = make(map[string]int, zb0002)
+			} else if len(z.Peers) > 0 {
+				for key := range z.Peers {
+					delete(z.Peers, key)
+				}
+			}
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				var za0002 int
+				za0001, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Peers")
+					return
+				}
+				za0002, err = dc.ReadInt()
+				if err != nil {
+					err = msgp.WrapError(err, "Peers", za0001)
+					return
+				}
+				z.Peers[za0001] = za0002
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *GraphiteTagDelByQueryResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Count"
+	err = en.Append(0x82, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt(z.Count)
+	if err != nil {
+		err = msgp.WrapError(err, "Count")
+		return
+	}
+	// write "Peers"
+	err = en.Append(0xa5, 0x50, 0x65, 0x65, 0x72, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteMapHeader(uint32(len(z.Peers)))
+	if err != nil {
+		err = msgp.WrapError(err, "Peers")
+		return
+	}
+	for za0001, za0002 := range z.Peers {
+		err = en.WriteString(za0001)
+		if err != nil {
+			err = msgp.WrapError(err, "Peers")
+			return
+		}
+		err = en.WriteInt(za0002)
+		if err != nil {
+			err = msgp.WrapError(err, "Peers", za0001)
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *GraphiteTagDelByQueryResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Count"
+	o = append(o, 0x82, 0xa5, 0x43, 0x6f, 0x75, 0x6e, 0x74)
+	o = msgp.AppendInt(o, z.Count)
+	// string "Peers"
+	o = append(o, 0xa5, 0x50, 0x65, 0x65, 0x72, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Peers)))
+	for za0001, za0002 := range z.Peers {
+		o = msgp.AppendString(o, za0001)
+		o = msgp.AppendInt(o, za0002)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *GraphiteTagDelByQueryResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Count":
+			z.Count, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Count")
+				return
+			}
+		case "Peers":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Peers")
+				return
+			}
+			if z.Peers == nil {
+				z.Peers = make(map[string]int, zb0002)
+			} else if len(z.Peers) > 0 {
+				for key := range z.Peers {
+					delete(z.Peers, key)
+				}
+			}
+			for zb0002 > 0 {
+				var za0001 string
+				var za0002 int
+				zb0002--
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Peers")
+					return
+				}
+				za0002, bts, err = msgp.ReadIntBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Peers", za0001)
+					return
+				}
+				z.Peers[za0001] = za0002
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *GraphiteTagDelByQueryResp) Msgsize() (s int) {
+	s = 1 + 6 + msgp.IntSize + 6 + msgp.MapHeaderSize
+	if z.Peers != nil {
+		for za0001, za0002 := range z.Peers {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + msgp.IntSize
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *GraphiteTagDelSeries) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/api/models/graphite_gen_test.go
+++ b/api/models/graphite_gen_test.go
@@ -122,6 +122,232 @@ func BenchmarkDecodeGraphiteExpand(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalGraphiteTagDelByQuery(t *testing.T) {
+	v := GraphiteTagDelByQuery{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGraphiteTagDelByQuery(b *testing.B) {
+	v := GraphiteTagDelByQuery{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGraphiteTagDelByQuery(b *testing.B) {
+	v := GraphiteTagDelByQuery{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGraphiteTagDelByQuery(b *testing.B) {
+	v := GraphiteTagDelByQuery{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGraphiteTagDelByQuery(t *testing.T) {
+	v := GraphiteTagDelByQuery{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GraphiteTagDelByQuery{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGraphiteTagDelByQuery(b *testing.B) {
+	v := GraphiteTagDelByQuery{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGraphiteTagDelByQuery(b *testing.B) {
+	v := GraphiteTagDelByQuery{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalGraphiteTagDelByQueryResp(t *testing.T) {
+	v := GraphiteTagDelByQueryResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgGraphiteTagDelByQueryResp(b *testing.B) {
+	v := GraphiteTagDelByQueryResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgGraphiteTagDelByQueryResp(b *testing.B) {
+	v := GraphiteTagDelByQueryResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalGraphiteTagDelByQueryResp(b *testing.B) {
+	v := GraphiteTagDelByQueryResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeGraphiteTagDelByQueryResp(t *testing.T) {
+	v := GraphiteTagDelByQueryResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := GraphiteTagDelByQueryResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeGraphiteTagDelByQueryResp(b *testing.B) {
+	v := GraphiteTagDelByQueryResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeGraphiteTagDelByQueryResp(b *testing.B) {
+	v := GraphiteTagDelByQueryResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalGraphiteTagDelSeries(t *testing.T) {
 	v := GraphiteTagDelSeries{}
 	bts, err := v.MarshalMsg(nil)

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -158,6 +158,24 @@ func (t IndexTagDelSeries) Trace(span opentracing.Span) {
 func (i IndexTagDelSeries) TraceDebug(span opentracing.Span) {
 }
 
+type IndexTagDelByQuery struct {
+	OrgId     uint32   `json:"orgId" binding:"Required"`
+	Expr      []string `json:"expressions" binding:"Required"`
+	OlderThan int64    `json:"olderThan" form:"olderThan"`
+	Execute   bool     `json:execute binding:"Default(false)"`
+}
+
+func (t IndexTagDelByQuery) Trace(span opentracing.Span) {
+	span.LogFields(
+		traceLog.String("expressions", fmt.Sprintf("%q", t.Expr)),
+		traceLog.String("olderThan", fmt.Sprintf("%d", t.OlderThan)),
+		traceLog.String("execute", fmt.Sprintf("%t", t.Execute)),
+	)
+}
+
+func (t IndexTagDelByQuery) TraceDebug(span opentracing.Span) {
+}
+
 type IndexGet struct {
 	MKey schema.MKey `json:"id" form:"id" binding:"Required"`
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -51,6 +51,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/index/tags/autoComplete/values", ready, bind(models.IndexAutoCompleteTagValues{})).Get(s.indexAutoCompleteTagValues).Post(s.indexAutoCompleteTagValues)
 	r.Combo("/index/tags/delSeries", ready, bind(models.IndexTagDelSeries{})).Get(s.indexTagDelSeries).Post(s.indexTagDelSeries)
 	r.Combo("/index/tags/terms", ready, bind(models.IndexTagTerms{})).Get(s.IndexTagTerms).Post(s.IndexTagTerms)
+	r.Combo("/index/tags/delByQuery", ready, bind(models.IndexTagDelByQuery{})).Get(s.IndexTagDelByQuery).Post(s.IndexTagDelByQuery)
 
 	r.Options("/*", func(ctx *macaron.Context) {
 		ctx.Write(nil)
@@ -60,6 +61,7 @@ func (s *Server) RegisterRoutes() {
 	r.Combo("/showplan", cBody, withOrg, ready, bind(models.GraphiteRender{})).Get(s.showPlan).Post(s.showPlan)
 	r.Combo("/tags/terms", ready, bind(models.GraphiteTagTerms{})).Get(s.graphiteTagTerms).Post(s.graphiteTagTerms)
 	r.Combo("/ccache/delete", bind(models.CCacheDelete{})).Post(s.ccacheDelete).Get(s.ccacheDelete)
+	r.Combo("/tags/delByQuery", withOrg, ready, bind(models.GraphiteTagDelByQuery{})).Post(s.graphiteTagDelByQuery).Get(s.graphiteTagDelByQuery)
 
 	// Graphite endpoints
 	r.Combo("/render", cBody, withOrg, ready, bind(models.GraphiteRender{})).Get(s.renderMetrics).Post(s.renderMetrics)

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -187,8 +187,37 @@ POST /metrics/delete
 curl -H "X-Org-Id: 12345" --data query=statsd.fakesite.counters.session_start.*.count "http://localhost:6060/metrics/delete"
 ```
 
+## Deleting tagged metrics (Preferred Method)
 
-## Deleting tagged metrics
+This will delete (if `execute` is true) metrics matching all of the specified `expressions` parameters and that have not been seen since before the `olderThan` parameter.
+Note that the data stays in the datastore until it expires.
+Should the metrics enter the system again with the same metadata, the data will show up again.
+
+```
+POST /tags/delByQuery
+```
+
+* header `X-Org-Id` required
+* expr (required, multiple allowed): A tag filter expression (e.g. `name=reqs.count`)
+* olderThan (optional): A unix epoch time. Series seen more recently than this will not be deleted.
+* execute (optional, default false): Execute this deletion. If false, just returns the count that *would* have been deleted
+
+#### Example
+
+The following request will delete series with tag `cluster=decommed`.
+```bash
+curl -H "X-Org-Id: 12345" "expr=cluster=decommed" -d "execute=true" "http://localhost:6060/tags/delByQuery"
+
+{
+    "count": 120,
+    "peers": {
+        "m1": 120
+    }
+}
+```
+
+
+## Deleting tagged metrics (Method 2)
 
 This will delete the metrics (technically metricdefinitions) matching the `path` parameter(s).
 Note that the data stays in the datastore until it expires.

--- a/expr/tagquery/expression_test.go
+++ b/expr/tagquery/expression_test.go
@@ -292,7 +292,7 @@ func BenchmarkExpressionParsing(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < 4; i++ {
-			NewQueryFromStrings(expressions[i], 0)
+			NewQueryFromStrings(expressions[i], 0, 0)
 		}
 	}
 }

--- a/expr/tagquery/meta_tag_record.go
+++ b/expr/tagquery/meta_tag_record.go
@@ -28,7 +28,7 @@ func ParseMetaTagRecord(metaTags []string, expressions []string) (MetaTagRecord,
 	// that it is possible to instantiate a query from the given meta record expressions.
 	// if we can't instantiate a query from the given expressions, then the meta record
 	// upsert request should be considered invalid and should get rejected.
-	_, err = NewQuery(res.Expressions, 0)
+	_, err = NewQuery(res.Expressions, 0, 0)
 	if err != nil {
 		return res, errors.NewBadRequestf("Failed to instantiate query from given expressions: %s", err)
 	}

--- a/expr/tagquery/query.go
+++ b/expr/tagquery/query.go
@@ -24,7 +24,7 @@ func init() {
 //tag expression definitions: https://graphite.readthedocs.io/en/latest/tags.html#querying
 //seriesByTag documentation: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag
 type Query struct {
-	// clauses that operates on LastUpdate field
+	// clauses that operate on LastUpdate field
 	From int64
 	To   int64
 

--- a/expr/tagquery/query.go
+++ b/expr/tagquery/query.go
@@ -24,8 +24,9 @@ func init() {
 //tag expression definitions: https://graphite.readthedocs.io/en/latest/tags.html#querying
 //seriesByTag documentation: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag
 type Query struct {
-	// clause that operates on LastUpdate field
+	// clauses that operates on LastUpdate field
 	From int64
+	To   int64
 
 	// slice of expressions sorted by the estimated cost of their operators
 	Expressions Expressions
@@ -40,17 +41,17 @@ type Query struct {
 //tag expression definitions: https://graphite.readthedocs.io/en/latest/tags.html#querying
 //seriesByTag documentation: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.seriesByTag
 //Some possible tag expressions are: "status=200", "path!=/", "name=~cpu\..*" (`name` is  a special tag which is automatically applied to the metric name).
-func NewQueryFromStrings(expressionStrs []string, from int64) (Query, error) {
+func NewQueryFromStrings(expressionStrs []string, from int64, to int64) (Query, error) {
 	var res Query
 	expressions, err := ParseExpressions(expressionStrs)
 	if err != nil {
 		return res, err
 	}
-	return NewQuery(expressions, from)
+	return NewQuery(expressions, from, to)
 }
 
-func NewQuery(expressions Expressions, from int64) (Query, error) {
-	q := Query{From: from, tagClause: -1}
+func NewQuery(expressions Expressions, from int64, to int64) (Query, error) {
+	q := Query{From: from, To: to, tagClause: -1}
 
 	if len(expressions) == 0 {
 		return q, errInvalidQuery

--- a/expr/tagquery/query_test.go
+++ b/expr/tagquery/query_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 func TestQueryByTagFilterByTagPrefixWithEmptyString(t *testing.T) {
-	_, err := NewQueryFromStrings([]string{"__tag^="}, 0)
+	_, err := NewQueryFromStrings([]string{"__tag^="}, 0, 0)
 	if err == nil {
 		t.Fatalf("Expected an error, but didn't get it")
 	}
 }
 
 func TestQueryByTagInvalidQuery(t *testing.T) {
-	_, err := NewQueryFromStrings([]string{"key!=value1"}, 0)
+	_, err := NewQueryFromStrings([]string{"key!=value1"}, 0, 0)
 	if err != errInvalidQuery {
 		t.Fatalf("Expected an error, but didn't get it")
 	}
@@ -194,7 +194,7 @@ func TestNewQueryFromStrings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewQueryFromStrings(tt.args.expressionStrs, tt.args.from)
+			got, err := NewQueryFromStrings(tt.args.expressionStrs, tt.args.from, 0)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewQueryFromStrings() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -932,7 +932,7 @@ func (m *UnpartitionedMemoryIdx) TagDetails(orgId uint32, key string, filter *re
 				continue
 			}
 
-			query, err := tagquery.NewQuery(record.Expressions, 0)
+			query, err := tagquery.NewQuery(record.Expressions, 0, 0)
 			if err != nil {
 				corruptIndex.Inc()
 				log.Errorf("memory-idx: corrupt. record expressions cannot instantiate query: %+v results in %s", record.Expressions, err)

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -588,7 +588,7 @@ func testTagSortingInFindByTag(t *testing.T) {
 	md1.Tags = []string{"d=a", "b=a", "c=a", "a=a", "e=a"}
 	index.AddOrUpdate(mkey, md1, getPartition(md1))
 
-	query, err := tagquery.NewQueryFromStrings([]string{"b=a"}, 0)
+	query, err := tagquery.NewQueryFromStrings([]string{"b=a"}, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error returned when parsing query: %s", err)
 	}
@@ -617,7 +617,7 @@ func testTagSortingInFindByTag(t *testing.T) {
 	md2[0].Tags = []string{"5=a", "1=a", "2=a", "4=a", "3=a"}
 	index.LoadPartition(getPartitionFromName("name2"), md2)
 
-	query, err = tagquery.NewQueryFromStrings([]string{"3=a"}, 0)
+	query, err = tagquery.NewQueryFromStrings([]string{"3=a"}, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when parsing query: %s", err)
 	}
@@ -857,7 +857,7 @@ func testAutoCompleteTagsWithQueryWithMetaTagSupport(t *testing.T) {
 func autoCompleteTagsWithQueryAndCompare(t testing.TB, tcIdx int, prefix string, expr []string, limit uint, expRes []string) {
 	t.Helper()
 
-	query, err := tagquery.NewQueryFromStrings(expr, 0)
+	query, err := tagquery.NewQueryFromStrings(expr, 0, 0)
 	if err != nil {
 		t.Fatalf("Error when instantiating query: %s", err)
 	}
@@ -1179,7 +1179,7 @@ func testAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {
 func autoCompleteTagValuesWithQueryAndCompare(t testing.TB, tc int, tag, prefix string, expr []string, limit uint, expRes []string) {
 	t.Helper()
 
-	query, err := tagquery.NewQueryFromStrings(expr, 0)
+	query, err := tagquery.NewQueryFromStrings(expr, 0, 0)
 	if err != nil {
 		t.Fatalf("TC %d: Unexpected error when instantiating query: %s", tc, err)
 	}
@@ -1459,7 +1459,7 @@ func benchmarkConcurrentInsertFind(b *testing.B) {
 }
 
 func ixFindByTag(b *testing.B, org uint32, q int) {
-	query, err := tagquery.NewQueryFromStrings(tagQueries[q].Expressions, 0)
+	query, err := tagquery.NewQueryFromStrings(tagQueries[q].Expressions, 0, 0)
 	if err != nil {
 		panic(err)
 	}
@@ -1586,7 +1586,7 @@ func benchmarkTagQueryFilterAndIntersect(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		q := queries[n%len(queries)]
-		query, err := tagquery.NewQueryFromStrings(q.Expressions, 150000)
+		query, err := tagquery.NewQueryFromStrings(q.Expressions, 150000, 0)
 		if err != nil {
 			b.Fatalf(err.Error())
 		}
@@ -1618,7 +1618,7 @@ func benchmarkTagQueryFilterAndIntersectOnlyRegex(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		q := queries[n%len(queries)]
-		query, err := tagquery.NewQueryFromStrings(q.Expressions, 0)
+		query, err := tagquery.NewQueryFromStrings(q.Expressions, 0, 0)
 		if err != nil {
 			b.Fatalf(err.Error())
 		}

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -42,7 +42,7 @@ func parseExpressionsMustCompile(t testing.TB, expressions []string) tagquery.Ex
 }
 
 func parseQueryMustCompile(t testing.TB, expressions []string) tagquery.Query {
-	query, err := tagquery.NewQueryFromStrings(expressions, 0)
+	query, err := tagquery.NewQueryFromStrings(expressions, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when parsing query expressions: %s", err)
 	}
@@ -269,7 +269,7 @@ func testGetAddKey(t *testing.T) {
 	if TagSupport {
 		Convey("When adding metricDefs with the same series name as existing metricDefs (tagged)", t, func() {
 			Convey("then findByTag", func() {
-				query, err := tagquery.NewQueryFromStrings([]string{"name!="}, 0)
+				query, err := tagquery.NewQueryFromStrings([]string{"name!="}, 0, 0)
 				So(err, ShouldBeNil)
 				nodes := ix.FindByTag(1, query)
 				defs := make([]idx.Archive, 0, len(nodes))
@@ -524,19 +524,19 @@ func testDeleteTagged(t *testing.T) {
 		testName := schema.MetricDefinitionFromMetricData(org1Series[3]).NameWithTags()
 		tags, err := tagquery.ParseTagsFromMetricName(testName)
 		So(err, ShouldBeNil)
-		query, err := tagquery.NewQueryFromStrings(tags.Strings(), 0)
+		query, err := tagquery.NewQueryFromStrings(tags.Strings(), 0, 0)
 		So(err, ShouldBeNil)
 		ids, err := ix.DeleteTagged(1, query)
 		So(err, ShouldBeNil)
 		So(ids, ShouldHaveLength, 1)
 		So(ids[0].Id.String(), ShouldEqual, org1Series[3].Id)
 		Convey("series should not be present in the metricDef index", func() {
-			query, err := tagquery.NewQueryFromStrings([]string{"series_id=3"}, 0)
+			query, err := tagquery.NewQueryFromStrings([]string{"series_id=3"}, 0, 0)
 			So(err, ShouldBeNil)
 			nodes := ix.FindByTag(1, query)
 			So(nodes, ShouldHaveLength, 0)
 			Convey("but others should still be present", func() {
-				query, err := tagquery.NewQueryFromStrings([]string{"series_id=~[0-9]"}, 0)
+				query, err := tagquery.NewQueryFromStrings([]string{"series_id=~[0-9]"}, 0, 0)
 				So(err, ShouldBeNil)
 				nodes := ix.FindByTag(1, query)
 				So(err, ShouldBeNil)
@@ -818,15 +818,15 @@ func testPruneTaggedSeries(t *testing.T) {
 		pruned, err := ix.Prune(time.Unix(100, 0)) // old series should be gone
 		So(err, ShouldBeNil)
 		So(pruned, ShouldHaveLength, 5)
-		query, err := tagquery.NewQueryFromStrings([]string{"name=~longterm\\.old.*", "series_id=~[0-4]"}, 0)
+		query, err := tagquery.NewQueryFromStrings([]string{"name=~longterm\\.old.*", "series_id=~[0-4]"}, 0, 0)
 		So(err, ShouldBeNil)
 		nodes := ix.FindByTag(1, query)
 		So(nodes, ShouldHaveLength, 0)
-		query, err = tagquery.NewQueryFromStrings([]string{"name=~longterm.*", "series_id=~[0-4]"}, 0)
+		query, err = tagquery.NewQueryFromStrings([]string{"name=~longterm.*", "series_id=~[0-4]"}, 0, 0)
 		So(err, ShouldBeNil)
 		nodes = ix.FindByTag(1, query)
 		So(nodes, ShouldHaveLength, 5)
-		query, err = tagquery.NewQueryFromStrings([]string{"name=~metric\\.never\\.exp.*", "series_id=~[0-4]"}, 0)
+		query, err = tagquery.NewQueryFromStrings([]string{"name=~metric\\.never\\.exp.*", "series_id=~[0-4]"}, 0, 0)
 		So(err, ShouldBeNil)
 		nodes = ix.FindByTag(1, query)
 		So(nodes, ShouldHaveLength, 5)
@@ -862,11 +862,11 @@ func testPruneTaggedSeries(t *testing.T) {
 			pruned, err := ix.Prune(time.Unix(120, 0))
 			So(err, ShouldBeNil)
 			So(pruned, ShouldHaveLength, 4)
-			query, err := tagquery.NewQueryFromStrings([]string{"name=~longterm", "series_id=~[0-4]"}, 0)
+			query, err := tagquery.NewQueryFromStrings([]string{"name=~longterm", "series_id=~[0-4]"}, 0, 0)
 			So(err, ShouldBeNil)
 			nodes := ix.FindByTag(1, query)
 			So(nodes, ShouldHaveLength, 1)
-			query, err = tagquery.NewQueryFromStrings([]string{"name=~metric\\.never.*", "series_id=~[0-4]"}, 0)
+			query, err = tagquery.NewQueryFromStrings([]string{"name=~metric\\.never.*", "series_id=~[0-4]"}, 0, 0)
 			So(err, ShouldBeNil)
 			nodes = ix.FindByTag(1, query)
 			So(nodes, ShouldHaveLength, 5)
@@ -933,7 +933,7 @@ func testPruneTaggedSeriesWithCollidingTagSets(t *testing.T) {
 	})
 
 	Convey("After pruning", t, func() {
-		query, err := tagquery.NewQueryFromStrings(findExpressions, 0)
+		query, err := tagquery.NewQueryFromStrings(findExpressions, 0, 0)
 		So(err, ShouldBeNil)
 		nodes := ix.FindByTag(1, query)
 		So(nodes, ShouldHaveLength, 1)
@@ -951,7 +951,7 @@ func testPruneTaggedSeriesWithCollidingTagSets(t *testing.T) {
 	})
 
 	Convey("After pruning", t, func() {
-		query, err := tagquery.NewQueryFromStrings(findExpressions, 0)
+		query, err := tagquery.NewQueryFromStrings(findExpressions, 0, 0)
 		So(err, ShouldBeNil)
 		nodes := ix.FindByTag(1, query)
 		So(nodes, ShouldHaveLength, 0)
@@ -1182,7 +1182,7 @@ func testMetricNameStartingWithTilde(t *testing.T) {
 	}
 
 	// query by the name minus the leading ~ characters
-	query, err := tagquery.NewQueryFromStrings([]string{"name=" + expectedNameTag}, 0)
+	query, err := tagquery.NewQueryFromStrings([]string{"name=" + expectedNameTag}, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when parsing query expression: %q", err)
 	}

--- a/idx/memory/meta_tags.go
+++ b/idx/memory/meta_tags.go
@@ -131,7 +131,7 @@ func (m *metaTagIdx) MetaTagRecordUpsert(orgId uint32, upsertRecord tagquery.Met
 
 	// initialize query in preparation to execute it once we have the swapMutex
 	// doing struct instantiations before acquiring lock to keep mutex time short
-	query, err := tagquery.NewQuery(upsertRecord.Expressions, 0)
+	query, err := tagquery.NewQuery(upsertRecord.Expressions, 0, 0)
 	if err != nil {
 		return fmt.Errorf("Invalid record with expressions/meta tags: %q/%q", upsertRecord.Expressions, upsertRecord.MetaTags)
 	}
@@ -213,7 +213,7 @@ func (m *metaTagIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaT
 			continue
 		}
 
-		query, err := tagquery.NewQuery(newRecords[i].Expressions, 0)
+		query, err := tagquery.NewQuery(newRecords[i].Expressions, 0, 0)
 		if err != nil {
 			log.Errorf("Invalid record (%q/%q): %s", newRecords[i].Expressions.Strings(), newRecords[i].MetaTags.Strings(), err)
 			continue
@@ -271,7 +271,7 @@ func (m *metaTagIdx) MetaTagRecordSwap(orgId uint32, newRecords []tagquery.MetaT
 		// remove all references to the pruned meta records from the meta
 		// tag index and the enricher
 		for recordId, record := range pruned {
-			query, err := tagquery.NewQuery(record.Expressions, 0)
+			query, err := tagquery.NewQuery(record.Expressions, 0, 0)
 			if err != nil {
 				log.Errorf("Invalid record to prune, cannot instantiate query for (%q/%q): %s", record.Expressions.Strings(), record.MetaTags.Strings(), err)
 				continue

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -50,7 +50,7 @@ func getTestIndexWithMetaTags(t testing.TB, metaRecords []tagquery.MetaTagRecord
 func queryAndCompareResultsWithMetaTags(t *testing.T, idx *UnpartitionedMemoryIdx, expressions tagquery.Expressions, expectedData IdSet) {
 	t.Helper()
 
-	query, err := tagquery.NewQuery(expressions, 0)
+	query, err := tagquery.NewQuery(expressions, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when instantiating query from expressions %q: %s", expressions, err)
 	}
@@ -200,7 +200,7 @@ func TestMetaTagEnrichmentForQueryByMetricTag(t *testing.T) {
 		t.Fatalf("Error when parsing expressions: %s", err)
 	}
 
-	query, err := tagquery.NewQuery(expressions, 0)
+	query, err := tagquery.NewQuery(expressions, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when instantiating query from expressions %q: %s", expressions, err)
 	}
@@ -262,7 +262,7 @@ func TestMetaTagEnrichmentForQueryByMetaTag(t *testing.T) {
 		t.Fatalf("Error when parsing expressions: %s", err)
 	}
 
-	query, err := tagquery.NewQuery(expressions, 0)
+	query, err := tagquery.NewQuery(expressions, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when instantiating query from expressions %q: %s", expressions, err)
 	}
@@ -724,7 +724,7 @@ func getQueriesForMetaTagQueryBenchmark(b *testing.B, count int, queryGen func(u
 	queries := make([]tagquery.Query, count)
 	var err error
 	for i := 0; i < 2; i++ {
-		queries[i], err = tagquery.NewQueryFromStrings(queryGen(uint32(i)), 0)
+		queries[i], err = tagquery.NewQueryFromStrings(queryGen(uint32(i)), 0, 0)
 		if err != nil {
 			b.Fatalf("Error when parsing query: %s", err.Error())
 		}

--- a/idx/memory/tag_query_id_selector.go
+++ b/idx/memory/tag_query_id_selector.go
@@ -122,7 +122,7 @@ func (i *idSelector) byTagValueFromMetricTagIndex() {
 	// this is faster than having to call expr.Matches on each value
 	if i.expr.MatchesExactly() {
 		for id := range i.ctx.index[i.expr.GetKey()][i.expr.GetValue()] {
-			if i.ctx.query.From > 0 && !i.ctx.newerThanFrom(id) {
+			if !i.ctx.withinTimeBounds(id) {
 				continue
 			}
 
@@ -145,7 +145,7 @@ func (i *idSelector) byTagValueFromMetricTagIndex() {
 		}
 
 		for id := range ids {
-			if i.ctx.query.From > 0 && !i.ctx.newerThanFrom(id) {
+			if !i.ctx.withinTimeBounds(id) {
 				continue
 			}
 
@@ -199,7 +199,7 @@ func (i *idSelector) byTagFromMetricTagIndex() {
 	if i.expr.MatchesExactly() {
 		for _, ids := range i.ctx.index[i.expr.GetKey()] {
 			for id := range ids {
-				if i.ctx.query.From > 0 && !i.ctx.newerThanFrom(id) {
+				if !i.ctx.withinTimeBounds(id) {
 					continue
 				}
 
@@ -221,7 +221,7 @@ func (i *idSelector) byTagFromMetricTagIndex() {
 
 		for _, ids := range i.ctx.index[tag] {
 			for id := range ids {
-				if i.ctx.query.From > 0 && !i.ctx.newerThanFrom(id) {
+				if !i.ctx.withinTimeBounds(id) {
 					continue
 				}
 
@@ -279,7 +279,7 @@ func (i *idSelector) evaluateMetaRecord(id recordId) {
 func (i *idSelector) subQueryFromExpressions(expressions tagquery.Expressions) (TagQueryContext, error) {
 	var queryCtx TagQueryContext
 
-	query, err := tagquery.NewQuery(expressions, i.ctx.query.From)
+	query, err := tagquery.NewQuery(expressions, i.ctx.query.From, 0)
 	if err != nil {
 		// this means we've stored a meta record containing invalid queries
 		corruptIndex.Inc()

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -607,7 +607,7 @@ func TestExpressionSortingByCost(t *testing.T) {
 		"g=h",  // metric tag
 		"i=~j", // metric tag
 		"k=l",  // metric and meta tag
-	}, 0)
+	}, 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error when instantiating query: %s", err)
 	}

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -106,7 +106,7 @@ func TestIdHasTag(t *testing.T) {
 
 func TestQueryByTagSimpleEqual(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3=value3"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3=value3"}, 0, 0)
 
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
@@ -116,7 +116,7 @@ func TestQueryByTagSimpleEqual(t *testing.T) {
 
 func TestQueryByTagSimplePrefix(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key3^=val"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key3^=val"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
 	expect[ids[3]] = struct{}{}
@@ -128,7 +128,7 @@ func TestQueryByTagSimplePrefix(t *testing.T) {
 
 func TestQueryByTagPrefixSpecialCaseName(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "name^=metric2"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "name^=metric2"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[2]] = struct{}{}
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
@@ -136,7 +136,7 @@ func TestQueryByTagPrefixSpecialCaseName(t *testing.T) {
 
 func TestQueryByTagFilterByPrefix(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3^=val"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3^=val"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
 	expect[ids[3]] = struct{}{}
@@ -145,7 +145,7 @@ func TestQueryByTagFilterByPrefix(t *testing.T) {
 
 func TestQueryByTagSimplePattern(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key4=~value[43]", "key3=~value[1-3]"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key4=~value[43]", "key3=~value[1-3]"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[6]] = struct{}{}
 	expect[ids[3]] = struct{}{}
@@ -154,7 +154,7 @@ func TestQueryByTagSimplePattern(t *testing.T) {
 
 func TestQueryByTagSimpleUnequal(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key4!=value4"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key4!=value4"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[0]] = struct{}{}
 	expect[ids[1]] = struct{}{}
@@ -164,7 +164,7 @@ func TestQueryByTagSimpleUnequal(t *testing.T) {
 
 func TestQueryByTagSimpleNotPattern(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=~value?", "key4!=~value[0-9]", "key2!=~va.+"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=~value?", "key4!=~value[0-9]", "key2!=~va.+"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
@@ -172,7 +172,7 @@ func TestQueryByTagSimpleNotPattern(t *testing.T) {
 
 func TestQueryByTagWithEqualEmpty(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key2=", "key2=~"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key2=", "key2=~"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
 	expect[ids[2]] = struct{}{}
@@ -182,7 +182,7 @@ func TestQueryByTagWithEqualEmpty(t *testing.T) {
 
 func TestQueryByTagWithUnequalEmpty(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3!="}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3!="}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
 	expect[ids[3]] = struct{}{}
@@ -191,7 +191,7 @@ func TestQueryByTagWithUnequalEmpty(t *testing.T) {
 
 func TestQueryByTagNameEquals(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3=value3", "name=metric1"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3=value3", "name=metric1"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
@@ -199,7 +199,7 @@ func TestQueryByTagNameEquals(t *testing.T) {
 
 func TestQueryByTagNameRegex(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3=value3", "name=~metr"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1", "key3=value3", "name=~metr"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[1]] = struct{}{}
 	expect[ids[3]] = struct{}{}
@@ -208,7 +208,7 @@ func TestQueryByTagNameRegex(t *testing.T) {
 
 func TestQueryByTagFilterByTagMatchWithExpressionAndNameException(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"__tag=~na", "key2=value2"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"__tag=~na", "key2=value2"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[0]] = struct{}{}
 	expect[ids[5]] = struct{}{}
@@ -217,34 +217,34 @@ func TestQueryByTagFilterByTagMatchWithExpressionAndNameException(t *testing.T) 
 
 func TestQueryByTagFilterByTagMatchWithExpression(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"__tag=~a{1}", "key2=value2"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"__tag=~a{1}", "key2=value2"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[5]] = struct{}{}
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"__tag=~a{2}", "key2=value2"}, 0)
+	q, _ = tagquery.NewQueryFromStrings([]string{"__tag=~a{2}", "key2=value2"}, 0, 0)
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"__tag=~a{3}", "key2=value2"}, 0)
+	q, _ = tagquery.NewQueryFromStrings([]string{"__tag=~a{3}", "key2=value2"}, 0, 0)
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"__tag=~a{4}", "key2=value2"}, 0)
+	q, _ = tagquery.NewQueryFromStrings([]string{"__tag=~a{4}", "key2=value2"}, 0, 0)
 	delete(expect, ids[5])
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 }
 
 func TestQueryByTagFilterByTagPrefixWithExpression(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"__tag^=aa", "key2=value2"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"__tag^=aa", "key2=value2"}, 0, 0)
 
 	expect := make(IdSet)
 	expect[ids[5]] = struct{}{}
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaa", "key2=value2"}, 0)
+	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaa", "key2=value2"}, 0, 0)
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaaa", "key2=value2"}, 0)
+	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaaa", "key2=value2"}, 0, 0)
 	delete(expect, ids[5])
 	delete(expect, ids[6])
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
@@ -252,7 +252,7 @@ func TestQueryByTagFilterByTagPrefixWithExpression(t *testing.T) {
 
 func TestQueryByTagFilterByTagPrefixWithFrom(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"__tag^=aa"}, 7)
+	q, _ := tagquery.NewQueryFromStrings([]string{"__tag^=aa"}, 7, 0)
 	expect := make(IdSet)
 	expect[ids[6]] = struct{}{}
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
@@ -260,18 +260,18 @@ func TestQueryByTagFilterByTagPrefixWithFrom(t *testing.T) {
 
 func TestQueryByTagFilterByTagPrefixWithDifferentLengths(t *testing.T) {
 	ids := getTestIDs()
-	q, _ := tagquery.NewQueryFromStrings([]string{"__tag^=a"}, 0)
+	q, _ := tagquery.NewQueryFromStrings([]string{"__tag^=a"}, 0, 0)
 	expect := make(IdSet)
 	expect[ids[3]] = struct{}{}
 	expect[ids[5]] = struct{}{}
 	expect[ids[6]] = struct{}{}
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaa"}, 0)
+	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaa"}, 0, 0)
 	delete(expect, ids[3])
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaaa"}, 0)
+	q, _ = tagquery.NewQueryFromStrings([]string{"__tag^=aaaa"}, 0, 0)
 	delete(expect, ids[5])
 	delete(expect, ids[6])
 	queryAndCompareResults(t, NewTagQueryContext(q), expect)
@@ -280,7 +280,7 @@ func TestQueryByTagFilterByTagPrefixWithDifferentLengths(t *testing.T) {
 func TestTagExpressionQueryByTagWithFrom(t *testing.T) {
 	tagIdx, byId := getTestIndex()
 
-	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1"}, 4)
+	q, _ := tagquery.NewQueryFromStrings([]string{"key1=value1"}, 4, 0)
 	qCtx := NewTagQueryContext(q)
 	resCh := make(chan schema.MKey, 100)
 	go func() {
@@ -296,7 +296,7 @@ func TestTagExpressionQueryByTagWithFrom(t *testing.T) {
 		t.Fatalf("Expected %d results, but got %d", 1, len(res))
 	}
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"key1=value1"}, 3)
+	q, _ = tagquery.NewQueryFromStrings([]string{"key1=value1"}, 3, 0)
 	qCtx = NewTagQueryContext(q)
 	resCh = make(chan schema.MKey, 100)
 	go func() {
@@ -311,7 +311,7 @@ func TestTagExpressionQueryByTagWithFrom(t *testing.T) {
 		t.Fatalf("Expected %d results, but got %d", 2, len(res))
 	}
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"key1=value1"}, 2)
+	q, _ = tagquery.NewQueryFromStrings([]string{"key1=value1"}, 2, 0)
 	qCtx = NewTagQueryContext(q)
 	resCh = make(chan schema.MKey, 100)
 	go func() {
@@ -326,7 +326,7 @@ func TestTagExpressionQueryByTagWithFrom(t *testing.T) {
 		t.Fatalf("Expected %d results, but got %d", 3, len(res))
 	}
 
-	q, _ = tagquery.NewQueryFromStrings([]string{"key1=value1"}, 1)
+	q, _ = tagquery.NewQueryFromStrings([]string{"key1=value1"}, 1, 0)
 	qCtx = NewTagQueryContext(q)
 	resCh = make(chan schema.MKey, 100)
 	go func() {
@@ -472,7 +472,7 @@ TEST_CASES:
 			builder.WriteString(";")
 		}
 		t.Run(builder.String(), func(t *testing.T) {
-			query, err := tagquery.NewQuery(expressions, 0)
+			query, err := tagquery.NewQuery(expressions, 0, 0)
 			if err != nil {
 				t.Fatalf("Unexpected error when getting query from expressions %q: %q", expressions, err)
 			}
@@ -570,7 +570,7 @@ func testGetByTag(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		q, err := tagquery.NewQueryFromStrings(tc.expressions, 0)
+		q, err := tagquery.NewQueryFromStrings(tc.expressions, 0, 0)
 		if err != nil {
 			t.Fatalf("Got an unexpected error with query %s: %s", tc.expressions, err)
 		}


### PR DESCRIPTION
This PR does 2 things:

1. Support `To` filter (or "older than") in tagquery filtering. This is useful for delete, where you might want to only delete series that haven't had any recent data.
2. Support delete by tag query with an "olderThan" and dry run capability.