### PR TITLE
ensure query mode ignores input, store, and idx settings

### DIFF
--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -181,6 +181,17 @@ func main() {
 	}
 	cluster.Init(*instance, version, startupTime, scheme, int(port))
 
+	// while in query mode, ensure all input, store, and idx plugins are turned off
+	if cluster.Mode == cluster.ModeQuery {
+		inCarbon.Enabled = false
+		inKafkaMdm.Enabled = false
+		memory.Enabled = false
+		cassandra.CliConfig.Enabled = false
+		bigtable.CliConfig.Enabled = false
+		cassandraStore.CliConfig.Enabled = false
+		bigtableStore.CliConfig.Enabled = false
+	}
+
 	/***********************************
 		Validate remaining settings
 	***********************************/

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -264,7 +264,7 @@ reject-invalid-input = true
 ### carbon input (optional)
 [carbon-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -273,7 +273,7 @@ partition = 0
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
 # tcp address (may be given multiple times as a comma-separated list)

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -94,7 +94,7 @@ agent-addr = jaeger:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = cassandra:9042
@@ -155,7 +155,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -263,7 +263,8 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -271,7 +272,8 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
 # tcp address (may be given multiple times as a comma-separated list)
@@ -411,6 +413,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -463,6 +466,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -503,6 +507,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -264,7 +264,7 @@ reject-invalid-input = true
 ### carbon input (optional)
 [carbon-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -273,7 +273,7 @@ partition = 0
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
 # tcp address (may be given multiple times as a comma-separated list)

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -94,7 +94,7 @@ agent-addr = jaeger:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = cassandra
@@ -155,7 +155,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -263,7 +263,8 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -271,7 +272,8 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
 # tcp address (may be given multiple times as a comma-separated list)
@@ -411,6 +413,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -463,6 +466,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -503,6 +507,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -264,7 +264,7 @@ reject-invalid-input = true
 ### carbon input (optional)
 [carbon-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -273,7 +273,7 @@ partition = 0
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
 # tcp address (may be given multiple times as a comma-separated list)

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -94,7 +94,7 @@ agent-addr = jaeger:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = cassandra
@@ -155,7 +155,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -263,7 +263,8 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -271,7 +272,8 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
 # tcp address (may be given multiple times as a comma-separated list)
@@ -411,6 +413,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -463,6 +466,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -503,6 +507,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -264,7 +264,7 @@ reject-invalid-input = true
 ### carbon input (optional)
 [carbon-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -273,7 +273,7 @@ partition = 0
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 1
 # tcp address (may be given multiple times as a comma-separated list)

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -94,7 +94,7 @@ agent-addr = jaeger:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = cassandra:9042
@@ -155,7 +155,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -263,7 +263,8 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -271,7 +272,8 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 1
 # tcp address (may be given multiple times as a comma-separated list)
@@ -411,6 +413,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -463,6 +466,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -503,6 +507,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/docs/config.md
+++ b/docs/config.md
@@ -128,7 +128,7 @@ agent-addr = localhost:6831
 ```
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = localhost
@@ -192,7 +192,7 @@ max-chunkspan = 24h
 
 ```
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -317,6 +317,7 @@ reject-invalid-input = true
 
 ```
 [carbon-in]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # tcp address
 addr = :2003
@@ -328,6 +329,7 @@ partition = 0
 
 ```
 [kafka-mdm-in]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
@@ -479,6 +481,7 @@ tls-client-key =
 
 ```
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -534,6 +537,7 @@ connection-check-timeout = 30s
 
 ```
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -577,6 +581,7 @@ write-max-batch-size = 5000
 
 ```
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -33,6 +33,7 @@ Refer to the [cassandra guide](https://github.com/grafana/metrictank/blob/master
 #### Configuration
 ```
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = raintank

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -97,7 +97,7 @@ agent-addr = localhost:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = localhost
@@ -158,7 +158,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -266,6 +266,7 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # tcp address
 addr = :2003
@@ -274,6 +275,7 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
@@ -414,6 +416,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -466,6 +469,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -506,6 +510,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -94,7 +94,7 @@ agent-addr = jaeger:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = cassandra:9042
@@ -155,7 +155,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -263,7 +263,8 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -271,6 +272,7 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
@@ -411,6 +413,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -463,6 +466,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -503,6 +507,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -264,7 +264,7 @@ reject-invalid-input = true
 ### carbon input (optional)
 [carbon-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -94,7 +94,7 @@ agent-addr = localhost:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = cassandra:9042
@@ -155,7 +155,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -263,7 +263,8 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -271,6 +272,7 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
@@ -411,6 +413,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -463,6 +466,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -503,6 +507,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -264,7 +264,7 @@ reject-invalid-input = true
 ### carbon input (optional)
 [carbon-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -94,7 +94,7 @@ agent-addr = localhost:6831
 [cassandra]
 # see https://github.com/grafana/metrictank/blob/master/docs/cassandra.md for more details
 
-# enable the cassandra backend store plugin
+# enable the cassandra backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # comma-separated list of hostnames to connect to
 addrs = localhost
@@ -155,7 +155,7 @@ max-chunkspan = 24h
 
 ## Bigtable backend Store Settings ##
 [bigtable-store]
-# enable the bigtable backend store plugin
+# enable the bigtable backend store plugin -- This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default
@@ -263,7 +263,8 @@ reject-invalid-input = true
 
 ### carbon input (optional)
 [carbon-in]
-enabled = true
+# This setting is ignored and overridden (set to false) in query mode
+enabled = false
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.
@@ -271,6 +272,7 @@ partition = 0
 
 ### kafka-mdm input (optional, recommended)
 [kafka-mdm-in]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # For incoming MetricPoint messages without org-id, assume this org id
 org-id = 0
@@ -411,6 +413,7 @@ tls-client-key =
 
 ### in memory, cassandra-backed
 [cassandra-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = true
 # Cassandra keyspace to store metricDefinitions in.
 keyspace = metrictank
@@ -463,6 +466,7 @@ connection-check-timeout = 30s
 
 ### in-memory only
 [memory-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # enables/disables querying based on tags
 tag-support = true
@@ -503,6 +507,7 @@ write-max-batch-size = 5000
 
 ### Bigtable index
 [bigtable-idx]
+# This setting is ignored and overridden (set to false) in query mode
 enabled = false
 # Name of GCP project the bigtable cluster resides in
 gcp-project = default

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -264,7 +264,7 @@ reject-invalid-input = true
 ### carbon input (optional)
 [carbon-in]
 # This setting is ignored and overridden (set to false) in query mode
-enabled = false
+enabled = true
 # tcp address
 addr = :2003
 # represents the "partition" of your data if you decide to partition your data.


### PR DESCRIPTION
Ignore settings by overriding them to false when in query mode.

Fix: grafana/hosted-metrics-api#333