### PR TITLE
update qa to use cimg/go:1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
   qa:
     working_directory: /go/src/github.com/grafana/metrictank
     docker:
-      - image: cimg/go:1.12
+      - image: circleci/golang:1.12
     steps:
       - checkout
       - run: scripts/qa/gofmt.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
   qa:
     working_directory: /go/src/github.com/grafana/metrictank
     docker:
-      - image: circleci/golang:1.11.4
+      - image: cimg/go:1.12
     steps:
       - checkout
       - run: scripts/qa/gofmt.sh


### PR DESCRIPTION
We need to update qa tests in CircleCI to use a newer image for golang.