### PR TITLE
add capability to process bigtable indices with mt-index-cat and re-organize code

### DIFF
--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -303,7 +303,7 @@ func main() {
 	processDefs := func(defs []schema.MetricDefinition) {
 		total += len(defs)
 		if shown >= limit && limit > 0 {
-			log.Infof("Limit (%d) reached while processing Metric Definitions", limit)
+			fmt.Fprintf(os.Stderr, "Limit (%d) reached while processing Metric Definitions", limit)
 			return
 		}
 		for _, d := range defs {
@@ -341,7 +341,7 @@ func main() {
 			show(d)
 			shown++
 			if shown >= limit && limit > 0 {
-				log.Infof("Limit (%d) reached while processing Metric Definitions", limit)
+				fmt.Fprintf(os.Stderr, "Limit (%d) reached while processing Metric Definitions", limit)
 				return
 			}
 		}

--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -56,7 +56,7 @@ func main() {
 	globalFlags.StringVar(&substr, "substr", "", "only show metrics that have this substring")
 	globalFlags.StringVar(&suffix, "suffix", "", "only show metrics that have this suffix")
 	globalFlags.StringVar(&partitionStr, "partitions", "*", "only show metrics from the comma separated list of partitions or * for all")
-	globalFlags.IntVar(&btTotalPartitions, "bt-total-partitions", -1, "when using bigtable you must set this to the total number of partitions for the instance if you do not specify partitions with the 'partitions' setting")
+	globalFlags.IntVar(&btTotalPartitions, "bt-total-partitions", -1, "total number of partitions (when using bigtable and partitions='*')")
 	globalFlags.StringVar(&regexStr, "regex", "", "only show metrics that match this regex")
 	globalFlags.StringVar(&tags, "tags", "", "tag filter. empty (default), 'some', 'none', 'valid', or 'invalid'")
 	globalFlags.StringVar(&from, "from", "30min", "for vegeta outputs, will generate requests for data starting from now minus... eg '30min', '5h', '14d', etc. or a unix timestamp")

--- a/cmd/mt-index-cat/main.go
+++ b/cmd/mt-index-cat/main.go
@@ -88,7 +88,7 @@ func main() {
 		fmt.Println("     'valid'   only show metrics whose tags (if any) are valid")
 		fmt.Println("     'invalid' only show metrics that have one or more invalid tags")
 		fmt.Println()
-		fmt.Printf("\n\n")
+		fmt.Printf("idxtype: 'cass' (cassandra) or 'bt' (bigtable)\n\n")
 		fmt.Printf("cass config flags:\n\n")
 		cassFlags.PrintDefaults()
 		fmt.Printf("\n\n")

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -192,7 +192,7 @@ global config flags:
   -addr string
     	graphite/metrictank address (default "http://localhost:6060")
   -bt-total-partitions int
-    	when using bigtable you must set this to the total number of partitions for the instance if you do not specify partitions with the 'partitions' setting (default -1)
+    	total number of partitions (when using bigtable and partitions='*') (default -1)
   -from string
     	for vegeta outputs, will generate requests for data starting from now minus... eg '30min', '5h', '14d', etc. or a unix timestamp (default "30min")
   -limit int
@@ -223,7 +223,7 @@ tags filter:
      'valid'   only show metrics whose tags (if any) are valid
      'invalid' only show metrics that have one or more invalid tags
 
-
+idxtype: 'cass' (cassandra) or 'bt' (bigtable)
 
 cass config flags:
 

--- a/idx/bigtable/config.go
+++ b/idx/bigtable/config.go
@@ -57,7 +57,7 @@ func NewIdxConfig() *IdxConfig {
 
 var CliConfig = NewIdxConfig()
 
-func ConfigSetup() {
+func ConfigSetup() *flag.FlagSet {
 	btIdx := flag.NewFlagSet("bigtable-idx", flag.ExitOnError)
 
 	btIdx.BoolVar(&CliConfig.Enabled, "enabled", CliConfig.Enabled, "")
@@ -73,6 +73,7 @@ func ConfigSetup() {
 	btIdx.BoolVar(&CliConfig.CreateCF, "create-cf", CliConfig.CreateCF, "enable the creation of the table and column families")
 
 	globalconf.Register("bigtable-idx", btIdx, flag.ExitOnError)
+	return btIdx
 }
 
 func ConfigProcess() {


### PR DESCRIPTION
This adds the long-needed ability use mt-index-cat on Bigtable.