### PR TITLE
change defById to per-org and adds per-org locking to the index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - image: circleci/golang:1.15.2
     steps:
       - checkout
-      - run: go test -v -race $(go list ./... | grep -v github.com/grafana/metrictank/stacktest)
+      - run: go test -v -race -timeout 20m $(go list ./... | grep -v github.com/grafana/metrictank/stacktest)
 
   qa:
     working_directory: /go/src/github.com/grafana/metrictank

--- a/expr/func_aggregate_test.go
+++ b/expr/func_aggregate_test.go
@@ -337,7 +337,8 @@ func benchmarkAggregate(b *testing.B, numSeries int, fn0, fn1 func() []schema.Po
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
-			Target: strconv.Itoa(i),
+			Target:   strconv.Itoa(i),
+			Interval: 1,
 		}
 		if i%1 == 0 {
 			series.Datapoints = fn0()

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -148,9 +148,6 @@ func TestGetAddKey(t *testing.T) {
 			Convey(fmt.Sprintf("Then listing metrics for OrgId %d", orgId), func() {
 				defs := ix.List(orgId)
 				numSeries := len(series)
-				if orgId != idx.OrgIdPublic {
-					numSeries += 5
-				}
 				So(defs, ShouldHaveLength, numSeries)
 
 			})
@@ -170,7 +167,7 @@ func TestGetAddKey(t *testing.T) {
 		}
 		Convey("then listing metrics", func() {
 			defs := ix.List(1)
-			So(defs, ShouldHaveLength, 15)
+			So(defs, ShouldHaveLength, 10)
 		})
 	})
 }
@@ -406,7 +403,7 @@ func TestFind(t *testing.T) {
 	})
 	Convey("When searching nodes for unknown orgId", t, func() {
 		nodes, err := ix.Find(4, "foo.demo.*", 0)
-		So(err, ShouldBeNil)
+		So(err, ShouldNotBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
 

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -612,6 +612,9 @@ func testTagSortingInFindByTag(t *testing.T) {
 	}
 	md2[0].SetId()
 
+	// workaround to ensure orgLock exists
+	ensureOrgLocksExist(index)
+
 	// set out of order tags after SetId (because that would sort it)
 	// e.g. mimic the case where somebody sent us a MD with an id already set and out-of-order tags
 	md2[0].Tags = []string{"5=a", "1=a", "2=a", "4=a", "3=a"}

--- a/idx/memory/meta_tags_query_test.go
+++ b/idx/memory/meta_tags_query_test.go
@@ -434,7 +434,7 @@ func BenchmarkMetaTagEnricher(b *testing.B) {
 	defs := make([]idx.Archive, len(keys))
 	i := 0
 	for _, key := range keys {
-		defs[i] = *memoryIdx.defById[key]
+		defs[i] = *memoryIdx.defById[key.Org][key]
 		i++
 	}
 

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -526,6 +526,15 @@ func (p *PartitionedMemoryIdx) LoadPartition(partition int32, defs []schema.Metr
 }
 
 func (p *PartitionedMemoryIdx) add(archive *idx.Archive) {
+	m := p.Partition[archive.Partition]
+	m.globalOrgLock.Lock()
+	if _, ok := m.orgLocks[archive.MetricDefinition.Id.Org]; !ok {
+		m.orgLocks[archive.MetricDefinition.Id.Org] = new(PriorityRWMutex)
+		// we need to create the map here, as it should now exist
+		m.defById[archive.MetricDefinition.Id.Org] = make(map[schema.MKey]*idx.Archive)
+	}
+	m.globalOrgLock.Unlock()
+
 	p.Partition[archive.Partition].add(archive)
 }
 

--- a/idx/memory/write_queue.go
+++ b/idx/memory/write_queue.go
@@ -66,7 +66,7 @@ func (wq *WriteQueue) Get(id schema.MKey) (*idx.Archive, bool) {
 	if _, ok := wq.archives[id.Org]; !ok {
 		// doesn't exist, nothing to get
 		wq.RUnlock()
-		return &idx.Archive{}, false
+		return nil, false
 	}
 	a, ok := wq.archives[id.Org][id]
 	wq.RUnlock()

--- a/idx/memory/write_queue.go
+++ b/idx/memory/write_queue.go
@@ -17,7 +17,7 @@ type WriteQueue struct {
 	flushTrigger chan struct{}
 	flushPending bool
 
-	archives map[schema.MKey]*idx.Archive
+	archives map[uint32]map[schema.MKey]*idx.Archive
 	sync.RWMutex
 
 	idx *UnpartitionedMemoryIdx
@@ -27,7 +27,7 @@ type WriteQueue struct {
 // in batches
 func NewWriteQueue(index *UnpartitionedMemoryIdx, maxDelay time.Duration, maxBuffered int) *WriteQueue {
 	wq := &WriteQueue{
-		archives:     make(map[schema.MKey]*idx.Archive),
+		archives:     make(map[uint32]map[schema.MKey]*idx.Archive),
 		shutdown:     make(chan struct{}),
 		done:         make(chan struct{}),
 		maxBuffered:  maxBuffered,
@@ -47,7 +47,10 @@ func (wq *WriteQueue) Stop() {
 
 func (wq *WriteQueue) Queue(archive *idx.Archive) {
 	wq.Lock()
-	wq.archives[archive.Id] = archive
+	if _, ok := wq.archives[archive.Id.Org]; !ok {
+		wq.archives[archive.Id.Org] = make(map[schema.MKey]*idx.Archive)
+	}
+	wq.archives[archive.OrgId][archive.Id] = archive
 	if !wq.flushPending && len(wq.archives) >= wq.maxBuffered {
 		wq.flushPending = true
 		select {
@@ -60,41 +63,47 @@ func (wq *WriteQueue) Queue(archive *idx.Archive) {
 
 func (wq *WriteQueue) Get(id schema.MKey) (*idx.Archive, bool) {
 	wq.RLock()
-	a, ok := wq.archives[id]
+	if _, ok := wq.archives[id.Org]; !ok {
+		// doesn't exist, nothing to get
+		wq.RUnlock()
+		return &idx.Archive{}, false
+	}
+	a, ok := wq.archives[id.Org][id]
 	wq.RUnlock()
 	return a, ok
 }
 
 // flush adds the buffered archives to the memoryIdx.
 func (wq *WriteQueue) flush() {
+	var archiveSize int
 	// Quick check to see if we have any archives we need to flush
 	wq.Lock()
-	archiveSize := len(wq.archives)
-	wq.flushPending = archiveSize > 0
+	for _, archives := range wq.archives {
+		archiveSize += len(archives)
+		wq.flushPending = archiveSize > 0
+	}
 	wq.Unlock()
 
 	if archiveSize == 0 {
 		return
 	}
 
-	// wq.idx.Lock() can be very slow to acquire (if there are long read ops). wq.Lock has much
-	// smaller bounds on lock hold time. So, to avoid blocking writes while waiting on the idx,
-	// we make sure to acquire the index lock first and only then acquire wq.Lock
 	pre := time.Now()
-
-	bc := wq.idx.Lock()
-	defer bc.Unlock("WriteQueueFlush", func() interface{} {
-		return fmt.Sprintf("numAdds = %d", archiveSize)
-	})
 
 	wq.Lock()
 	defer wq.Unlock()
 
-	archiveSize = len(wq.archives)
-	for _, archive := range wq.archives {
-		wq.idx.add(archive)
+	for orgID, archives := range wq.archives {
+		archiveSize = len(archives)
+		bc := wq.idx.orgLocks[orgID].Lock()
+		for _, archive := range archives {
+			wq.idx.add(archive)
+		}
+		bc.Unlock(fmt.Sprintf("WriteQueueFlush - Org %d", orgID), func() interface{} {
+			return fmt.Sprintf("numAdds = %d", archiveSize)
+		})
 	}
-	wq.archives = make(map[schema.MKey]*idx.Archive)
+	wq.archives = make(map[uint32]map[schema.MKey]*idx.Archive)
 	wq.flushPending = false
 
 	statAddDuration.Value(time.Since(pre))

--- a/test/key.go
+++ b/test/key.go
@@ -17,6 +17,7 @@ func GetMKey(suffix int) schema.MKey {
 	s := uint32(suffix)
 	return schema.MKey{
 		Key: [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, byte(s >> 24), byte(s >> 16), byte(s >> 8), byte(s)},
+		Org: 1,
 	}
 }
 


### PR DESCRIPTION
This changes the nature of defById from a flat map to a per-org map. It also adds per-org locking which may result in improved performance on multitenant instances and add a layer of protection between the orgs.

Overall I am happy-ish with this PR, but I believe that I will take another look at the write_queue and partitioned index. I don't like the extra checks during `add` and `Queue` so I am open to ideas.