### PR TITLE
Update profiletrigger: switch from vsz to rss and add threshold for heap as well

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,11 +40,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bab97e18030f5f5676bfde674354f3484c064f52b228e52fd8c00dfefe594856"
+  digest = "1:6c4eb4786807047294c7a4e0d5582a48b9c71e81526282f495894d8a60f184b0"
   name = "github.com/Dieterbe/profiletrigger"
-  packages = ["heap"]
+  packages = [
+    "heap",
+    "procfs",
+  ]
   pruneopts = "NUT"
-  revision = "c507ee16f324a7fac721cda98a75e2b9596b7d0e"
+  revision = "3fc6b4ea613c05d6c3b0de46b001a4349fb36add"
 
 [[projects]]
   digest = "1:2941ec6eccc1bc46b6cff9eb416fc623524f554e474367d378bd0ed8301652db"

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -78,8 +78,8 @@ var (
 	proftrigPath           = flag.String("proftrigger-path", "/tmp", "path to store triggered profiles")
 	proftrigFreqStr        = flag.String("proftrigger-freq", "10s", "inspect status frequency. set to 0 to disable")
 	proftrigMinDiffStr     = flag.String("proftrigger-min-diff", "1h", "minimum time between triggered profiles")
-	proftrigHeapThresh     = flag.Int("proftrigger-heap-thresh", 25000000000, "threshold for process RSS, the amount of RAM memory used. (see \"rss\" on dashboard)")
-	proftrigHeapThreshHeap = flag.Int("proftrigger-heap-thresh-heap", 0, "threshold for bytes allocated on heap (see \"allocated in heap\" on dashboard)")
+	proftrigHeapThresh     = flag.Int("proftrigger-heap-thresh", 25000000000, "threshold for process RSS, the amount of RAM memory used. (0 to disable) (see \"rss\" on dashboard)")
+	proftrigHeapThreshHeap = flag.Int("proftrigger-heap-thresh-heap", 0, "threshold for bytes allocated on heap (0 to disable) (see \"allocated in heap\" on dashboard)")
 )
 
 func main() {

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -45,9 +45,9 @@ proftrigger-freq = 1s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -36,15 +36,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
 proftrigger-freq = 1s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -45,9 +45,9 @@ proftrigger-freq = 1s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -36,15 +36,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
 proftrigger-freq = 1s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -45,9 +45,9 @@ proftrigger-freq = 1s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -36,15 +36,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
 proftrigger-freq = 1s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -45,9 +45,9 @@ proftrigger-freq = 10s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -36,15 +36,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
-proftrigger-freq = 60s
+proftrigger-freq = 10s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/docs/config.md
+++ b/docs/config.md
@@ -75,9 +75,9 @@ proftrigger-freq = 10s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/docs/config.md
+++ b/docs/config.md
@@ -66,15 +66,21 @@ public-org = 0
 block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
-proftrigger-freq = 60s
+proftrigger-freq = 10s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -56,8 +56,7 @@ Metrictank crashed. What to do?
    Tips:
    * The [profiletrigger](https://github.com/grafana/metrictank/blob/master/docs/config.md#profiling-instrumentation-and-logging) functionality can automatically trigger
    a memory profile and save it to disk.  This can be very helpful if suddently memory usage spikes up and then metrictank gets killed in seconds or minutes.  
-   It helps diagnose problems in the codebase that may lead to memory savings.  The profiletrigger looks at the `bytes_sys` metric which is
-   the amount of memory consumed by the process.
+   It helps diagnose problems in the codebase that may lead to memory savings.   The profiletrigger can look at both RSS used and heap size.
    * Use [rollups](https://github.com/grafana/metrictank/blob/master/docs/consolidation.md#rollups) to be able to answer queries for long timeframes with less data
 2) Check the metrictank log.
    If it exited due to a panic, you should probably open a [ticket](https://github.com/grafana/metrictank/issues) with the output of `metrictank --version`, the panic, and perhaps preceding log data.

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -39,15 +39,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
-proftrigger-freq = 60s
+proftrigger-freq = 10s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -48,9 +48,9 @@ proftrigger-freq = 10s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -45,9 +45,9 @@ proftrigger-freq = 10s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -36,15 +36,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
-proftrigger-freq = 60s
+proftrigger-freq = 10s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -45,9 +45,9 @@ proftrigger-freq = 10s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -36,15 +36,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
-proftrigger-freq = 60s
+proftrigger-freq = 10s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -45,9 +45,9 @@ proftrigger-freq = 10s
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
+# threshold for process RSS, the amount of RAM memory used. (0 to disable) (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
-# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# threshold for bytes allocated on heap (0 to disable) (see "allocated in heap" on dashboard)
 # typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
 # but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
 proftrigger-heap-thresh-heap = 0

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -36,15 +36,21 @@ block-profile-rate = 0
 # 0 to disable. 1 for max precision (expensive!) see https://golang.org/pkg/runtime/#pkg-variables")
 mem-profile-rate = 524288 # 512*1024
 
+# heap profiletrigger: triggers a heap (memory) profile for diagnosis when usage threshold is breached
+# recommended usage: set proftrigger-heap-thresh-rss such that it is much larger than "normal" usage, but lower
+# then how much RAM capacity you have, so that a profile can be captured before the process gets killed by the OOM-killer
 # inspect status frequency. set to 0 to disable
-proftrigger-freq = 60s
+proftrigger-freq = 10s
 # path to store triggered profiles
 proftrigger-path = /tmp
 # minimum time between triggered profiles
 proftrigger-min-diff = 1h
-# if process consumes this many bytes (see bytes_sys in dashboard), trigger a heap profile for developer diagnosis
-# set it higher than your typical memory usage, but lower than how much RAM the process can take before its get killed
+# threshold for process RSS, the amount of RAM memory used. (see "rss" on dashboard)
 proftrigger-heap-thresh = 25000000000
+# threshold for bytes allocated on heap (see "allocated in heap" on dashboard)
+# typically, this is not all that useful, "rss" above is what most people care about (and the heap uses less than rss),
+# but this setting can help detect a large heap even if some of the memory is swapped out (and thus not accounted for in rss)
+proftrigger-heap-thresh-heap = 0
 
 # only log log-level and lower (read right to left: to the left is lower). panic|fatal|error|warning|info|debug
 log-level = info

--- a/vendor/github.com/Dieterbe/profiletrigger/procfs/AUTHORS.md
+++ b/vendor/github.com/Dieterbe/profiletrigger/procfs/AUTHORS.md
@@ -1,0 +1,12 @@
+The Prometheus project was started by Matt T. Proud (emeritus) and
+Julius Volz in 2012.
+
+Maintainers of this repository:
+
+* Tobias Schmidt <ts@soundcloud.com>
+
+The following individuals have contributed code to this repository
+(listed in alphabetical order):
+
+* Ji-Hoon, Seol <jihoon.seol@gmail.com>
+* Tobias Schmidt <tobidt@gmail.com>

--- a/vendor/github.com/Dieterbe/profiletrigger/procfs/LICENSE
+++ b/vendor/github.com/Dieterbe/profiletrigger/procfs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/Dieterbe/profiletrigger/procfs/NOTICE
+++ b/vendor/github.com/Dieterbe/profiletrigger/procfs/NOTICE
@@ -1,0 +1,7 @@
+procfs provides functions to retrieve system, kernel and process
+metrics from the pseudo-filesystem proc.
+
+Copyright 2014-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).

--- a/vendor/github.com/Dieterbe/profiletrigger/procfs/fs.go
+++ b/vendor/github.com/Dieterbe/profiletrigger/procfs/fs.go
@@ -1,0 +1,40 @@
+package procfs
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+// FS represents the pseudo-filesystem proc, which provides an interface to
+// kernel data structures.
+type FS string
+
+// DefaultMountPoint is the common mount point of the proc filesystem.
+const DefaultMountPoint = "/proc"
+
+// NewFS returns a new FS mounted under the given mountPoint. It will error
+// if the mount point can't be read.
+func NewFS(mountPoint string) (FS, error) {
+	info, err := os.Stat(mountPoint)
+	if err != nil {
+		return "", fmt.Errorf("could not read %s: %s", mountPoint, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("mount point %s is not a directory", mountPoint)
+	}
+
+	return FS(mountPoint), nil
+}
+
+func (fs FS) stat(p string) (os.FileInfo, error) {
+	return os.Stat(path.Join(string(fs), p))
+}
+
+func (fs FS) open(p string) (*os.File, error) {
+	return os.Open(path.Join(string(fs), p))
+}
+
+func (fs FS) readlink(p string) (string, error) {
+	return os.Readlink(path.Join(string(fs), p))
+}

--- a/vendor/github.com/Dieterbe/profiletrigger/procfs/proc.go
+++ b/vendor/github.com/Dieterbe/profiletrigger/procfs/proc.go
@@ -1,0 +1,188 @@
+package procfs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// Proc provides information about a running process.
+type Proc struct {
+	// The process ID.
+	PID int
+
+	fs FS
+}
+
+// Procs represents a list of Proc structs.
+type Procs []Proc
+
+func (p Procs) Len() int           { return len(p) }
+func (p Procs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p Procs) Less(i, j int) bool { return p[i].PID < p[j].PID }
+
+// Self returns a process for the current process.
+func Self() (Proc, error) {
+	return NewProc(os.Getpid())
+}
+
+// NewProc returns a process for the given pid under /proc.
+func NewProc(pid int) (Proc, error) {
+	fs, err := NewFS(DefaultMountPoint)
+	if err != nil {
+		return Proc{}, err
+	}
+
+	return fs.NewProc(pid)
+}
+
+// AllProcs returns a list of all currently avaible processes under /proc.
+func AllProcs() (Procs, error) {
+	fs, err := NewFS(DefaultMountPoint)
+	if err != nil {
+		return Procs{}, err
+	}
+
+	return fs.AllProcs()
+}
+
+// NewProc returns a process for the given pid.
+func (fs FS) NewProc(pid int) (Proc, error) {
+	if _, err := fs.stat(strconv.Itoa(pid)); err != nil {
+		return Proc{}, err
+	}
+
+	return Proc{PID: pid, fs: fs}, nil
+}
+
+// AllProcs returns a list of all currently avaible processes.
+func (fs FS) AllProcs() (Procs, error) {
+	d, err := fs.open("")
+	if err != nil {
+		return Procs{}, err
+	}
+	defer d.Close()
+
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return Procs{}, fmt.Errorf("could not read %s: %s", d.Name(), err)
+	}
+
+	p := Procs{}
+	for _, n := range names {
+		pid, err := strconv.ParseInt(n, 10, 64)
+		if err != nil {
+			continue
+		}
+		p = append(p, Proc{PID: int(pid), fs: fs})
+	}
+
+	return p, nil
+}
+
+// CmdLine returns the command line of a process.
+func (p Proc) CmdLine() ([]string, error) {
+	f, err := p.open("cmdline")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) < 1 {
+		return []string{}, nil
+	}
+
+	return strings.Split(string(data[:len(data)-1]), string(byte(0))), nil
+}
+
+// Executable returns the absolute path of the executable command of a process.
+func (p Proc) Executable() (string, error) {
+	exe, err := p.readlink("exe")
+
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+
+	return exe, err
+}
+
+// FileDescriptors returns the currently open file descriptors of a process.
+func (p Proc) FileDescriptors() ([]uintptr, error) {
+	names, err := p.fileDescriptors()
+	if err != nil {
+		return nil, err
+	}
+
+	fds := make([]uintptr, len(names))
+	for i, n := range names {
+		fd, err := strconv.ParseInt(n, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse fd %s: %s", n, err)
+		}
+		fds[i] = uintptr(fd)
+	}
+
+	return fds, nil
+}
+
+// FileDescriptorTargets returns the targets of all file descriptors of a process.
+// If a file descriptor is not a symlink to a file (like a socket), that value will be the empty string.
+func (p Proc) FileDescriptorTargets() ([]string, error) {
+	names, err := p.fileDescriptors()
+	if err != nil {
+		return nil, err
+	}
+
+	targets := make([]string, len(names))
+
+	for i, name := range names {
+		target, err := p.readlink("fd/" + name)
+		if err == nil {
+			targets[i] = target
+		}
+	}
+
+	return targets, nil
+}
+
+// FileDescriptorsLen returns the number of currently open file descriptors of
+// a process.
+func (p Proc) FileDescriptorsLen() (int, error) {
+	fds, err := p.fileDescriptors()
+	if err != nil {
+		return 0, err
+	}
+
+	return len(fds), nil
+}
+
+func (p Proc) fileDescriptors() ([]string, error) {
+	d, err := p.open("fd")
+	if err != nil {
+		return nil, err
+	}
+	defer d.Close()
+
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %s: %s", d.Name(), err)
+	}
+
+	return names, nil
+}
+
+func (p Proc) open(pa string) (*os.File, error) {
+	return p.fs.open(path.Join(strconv.Itoa(p.PID), pa))
+}
+
+func (p Proc) readlink(pa string) (string, error) {
+	return p.fs.readlink(path.Join(strconv.Itoa(p.PID), pa))
+}

--- a/vendor/github.com/Dieterbe/profiletrigger/procfs/proc_stat.go
+++ b/vendor/github.com/Dieterbe/profiletrigger/procfs/proc_stat.go
@@ -1,0 +1,175 @@
+package procfs
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// Originally, this USER_HZ value was dynamically retrieved via a sysconf call which
+// required cgo. However, that caused a lot of problems regarding
+// cross-compilation. Alternatives such as running a binary to determine the
+// value, or trying to derive it in some other way were all problematic.
+// After much research it was determined that USER_HZ is actually hardcoded to
+// 100 on all Go-supported platforms as of the time of this writing. This is
+// why we decided to hardcode it here as well. It is not impossible that there
+// could be systems with exceptions, but they should be very exotic edge cases,
+// and in that case, the worst outcome will be two misreported metrics.
+//
+// See also the following discussions:
+//
+// - https://github.com/prometheus/node_exporter/issues/52
+// - https://github.com/prometheus/procfs/pull/2
+// - http://stackoverflow.com/questions/17410841/how-does-user-hz-solve-the-jiffy-scaling-issue
+const userHZ = 100
+
+// ProcStat provides status information about the process,
+// read from /proc/[pid]/stat.
+type ProcStat struct {
+	// The process ID.
+	PID int
+	// The filename of the executable.
+	Comm string
+	// The process state.
+	State string
+	// The PID of the parent of this process.
+	PPID int
+	// The process group ID of the process.
+	PGRP int
+	// The session ID of the process.
+	Session int
+	// The controlling terminal of the process.
+	TTY int
+	// The ID of the foreground process group of the controlling terminal of
+	// the process.
+	TPGID int
+	// The kernel flags word of the process.
+	Flags uint
+	// The number of minor faults the process has made which have not required
+	// loading a memory page from disk.
+	MinFlt uint
+	// The number of minor faults that the process's waited-for children have
+	// made.
+	CMinFlt uint
+	// The number of major faults the process has made which have required
+	// loading a memory page from disk.
+	MajFlt uint
+	// The number of major faults that the process's waited-for children have
+	// made.
+	CMajFlt uint
+	// Amount of time that this process has been scheduled in user mode,
+	// measured in clock ticks.
+	UTime uint
+	// Amount of time that this process has been scheduled in kernel mode,
+	// measured in clock ticks.
+	STime uint
+	// Amount of time that this process's waited-for children have been
+	// scheduled in user mode, measured in clock ticks.
+	CUTime uint
+	// Amount of time that this process's waited-for children have been
+	// scheduled in kernel mode, measured in clock ticks.
+	CSTime uint
+	// For processes running a real-time scheduling policy, this is the negated
+	// scheduling priority, minus one.
+	Priority int
+	// The nice value, a value in the range 19 (low priority) to -20 (high
+	// priority).
+	Nice int
+	// Number of threads in this process.
+	NumThreads int
+	// The time the process started after system boot, the value is expressed
+	// in clock ticks.
+	Starttime uint64
+	// Virtual memory size in bytes.
+	VSize int
+	// Resident set size in pages.
+	RSS int
+
+	fs FS
+}
+
+// NewStat returns the current status information of the process.
+func (p Proc) NewStat() (ProcStat, error) {
+	f, err := p.open("stat")
+	if err != nil {
+		return ProcStat{}, err
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return ProcStat{}, err
+	}
+
+	var (
+		ignore int
+
+		s = ProcStat{PID: p.PID, fs: p.fs}
+		l = bytes.Index(data, []byte("("))
+		r = bytes.LastIndex(data, []byte(")"))
+	)
+
+	if l < 0 || r < 0 {
+		return ProcStat{}, fmt.Errorf(
+			"unexpected format, couldn't extract comm: %s",
+			data,
+		)
+	}
+
+	s.Comm = string(data[l+1 : r])
+	_, err = fmt.Fscan(
+		bytes.NewBuffer(data[r+2:]),
+		&s.State,
+		&s.PPID,
+		&s.PGRP,
+		&s.Session,
+		&s.TTY,
+		&s.TPGID,
+		&s.Flags,
+		&s.MinFlt,
+		&s.CMinFlt,
+		&s.MajFlt,
+		&s.CMajFlt,
+		&s.UTime,
+		&s.STime,
+		&s.CUTime,
+		&s.CSTime,
+		&s.Priority,
+		&s.Nice,
+		&s.NumThreads,
+		&ignore,
+		&s.Starttime,
+		&s.VSize,
+		&s.RSS,
+	)
+	if err != nil {
+		return ProcStat{}, err
+	}
+
+	return s, nil
+}
+
+// VirtualMemory returns the virtual memory size in bytes.
+func (s ProcStat) VirtualMemory() int {
+	return s.VSize
+}
+
+// ResidentMemory returns the resident memory size in bytes.
+func (s ProcStat) ResidentMemory() int {
+	return s.RSS * os.Getpagesize()
+}
+
+// StartTime returns the unix timestamp of the process in seconds.
+func (s ProcStat) StartTime() (float64, error) {
+	stat, err := s.fs.NewStat()
+	if err != nil {
+		return 0, err
+	}
+	return float64(stat.BootTime) + (float64(s.Starttime) / userHZ), nil
+}
+
+// CPUTime returns the total CPU user and system time in seconds.
+func (s ProcStat) CPUTime() float64 {
+	return float64(s.UTime+s.STime) / userHZ
+}

--- a/vendor/github.com/Dieterbe/profiletrigger/procfs/stat.go
+++ b/vendor/github.com/Dieterbe/profiletrigger/procfs/stat.go
@@ -1,0 +1,55 @@
+package procfs
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Stat represents kernel/system statistics.
+type Stat struct {
+	// Boot time in seconds since the Epoch.
+	BootTime int64
+}
+
+// NewStat returns kernel/system statistics read from /proc/stat.
+func NewStat() (Stat, error) {
+	fs, err := NewFS(DefaultMountPoint)
+	if err != nil {
+		return Stat{}, err
+	}
+
+	return fs.NewStat()
+}
+
+// NewStat returns an information about current kernel/system statistics.
+func (fs FS) NewStat() (Stat, error) {
+	f, err := fs.open("stat")
+	if err != nil {
+		return Stat{}, err
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := s.Text()
+		if !strings.HasPrefix(line, "btime") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return Stat{}, fmt.Errorf("couldn't parse %s line %s", f.Name(), line)
+		}
+		i, err := strconv.ParseInt(fields[1], 10, 32)
+		if err != nil {
+			return Stat{}, fmt.Errorf("couldn't parse %s: %s", fields[1], err)
+		}
+		return Stat{BootTime: i}, nil
+	}
+	if err := s.Err(); err != nil {
+		return Stat{}, fmt.Errorf("couldn't parse %s: %s", f.Name(), err)
+	}
+
+	return Stat{}, fmt.Errorf("couldn't parse %s, missing btime", f.Name())
+}


### PR DESCRIPTION
* old version used to look at Memstats.Sys, which was the entire virtual
  memory space, and effectively useless. Hence also why it's been hidden
  in the dashboard since forever.   Most people expect this would
  look effectively at rss, so that's what we do now. + optional
  parameter to look at (only) the heap specifically
* change default collection interval to 10s. That's what we've been
  running in prod for years without any issues.