### PR TITLE
Improve performance of metatag doesnt exist expr

### DIFF
--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -99,7 +99,7 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 		// in a metric that gets filtered, compared to doing a full tag index lookup
 		// to check whether a metric has one of the necessary meta tags associated
 		// with it.
-		onlyEqualOperators, singleExprPerRecord := viableOptimizations(invertSetOfMetaRecords, records)
+		onlyEqualOperators, singleExprPerRecord := viableOptimizations(records)
 
 		if onlyEqualOperators {
 			// there are two different ways how we optimize for the case where all expressions
@@ -108,9 +108,9 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 			// otherwise we use the second way which is a bit more expensive but it also works
 			// if some of the involved meta records have multiple expressions.
 			if singleExprPerRecord {
-				res.filters[i].testByMetaTags = metaRecordFilterBySetOfValidValues(records)
+				res.filters[i].testByMetaTags = metaRecordFilterBySetOfValidValues(records, invertSetOfMetaRecords)
 			} else {
-				res.filters[i].testByMetaTags = metaRecordFilterBySetOfValidValueSets(records)
+				res.filters[i].testByMetaTags = metaRecordFilterBySetOfValidValueSets(records, invertSetOfMetaRecords)
 			}
 		} else {
 			metaRecordFilters := make([]tagquery.MetricDefinitionFilter, 0, len(records))
@@ -138,10 +138,7 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 //   expression and this expression is using the equal operator.
 // * the second bool refers to the optimization for sets of records which all only have
 //   expressions using the equal operator, but there may be more than one per record.
-func viableOptimizations(invertSetOfMetaRecords bool, records []tagquery.MetaTagRecord) (bool, bool) {
-	if invertSetOfMetaRecords {
-		return false, false
-	}
+func viableOptimizations(records []tagquery.MetaTagRecord) (bool, bool) {
 	singleExprPerRecord := true
 	for recordIdx := range records {
 		for exprIdx := range records[recordIdx].Expressions {
@@ -161,7 +158,7 @@ func viableOptimizations(invertSetOfMetaRecords bool, records []tagquery.MetaTag
 // which only involves meta records of which each only has exactly one expression and that
 // expression is using the "=" operator. this is quite a narrow scenario, but since it is
 // a very common use case it makes sense to optimize for it.
-func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord) tagquery.MetricDefinitionFilter {
+func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord, invertFilter bool) tagquery.MetricDefinitionFilter {
 	// we first build a set of valid tags and names.
 	// since we know that each of the involved meta records uses exactly one expression
 	// which is using the "=" operator we know that if a given metric's name matches a
@@ -183,14 +180,19 @@ func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord) tagque
 		}
 	}
 
+	resultOnHit := tagquery.Pass
+	if invertFilter {
+		resultOnHit = tagquery.Fail
+	}
+
 	return func(_ schema.MKey, name string, tags []string) tagquery.FilterDecision {
 		for i := range tags {
 			if _, ok := validValues[tags[i]]; ok {
-				return tagquery.Pass
+				return resultOnHit
 			}
 		}
 		if _, ok := validNames[name]; ok {
-			return tagquery.Pass
+			return resultOnHit
 		}
 		return tagquery.None
 	}
@@ -199,7 +201,7 @@ func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord) tagque
 // metaRecordFilterBySetOfValidValueSets creates a filter function to filter by a meta tag
 // which only involves meta records of which all expressions are only using the "=" operator,
 // it is ok if one meta record uses multiple such expressions.
-func metaRecordFilterBySetOfValidValueSets(records []tagquery.MetaTagRecord) tagquery.MetricDefinitionFilter {
+func metaRecordFilterBySetOfValidValueSets(records []tagquery.MetaTagRecord, invertFilter bool) tagquery.MetricDefinitionFilter {
 	// we first build a set of tag and name value combinations of which each is sufficient
 	// to pass the generated filter when a metric contains all values of one of these
 	// combinations
@@ -221,6 +223,11 @@ func metaRecordFilterBySetOfValidValueSets(records []tagquery.MetaTagRecord) tag
 		sort.Strings(validValueSets[i].tags)
 	}
 
+	resultOnHit := tagquery.Pass
+	if invertFilter {
+		resultOnHit = tagquery.Fail
+	}
+
 	return func(_ schema.MKey, name string, tags []string) tagquery.FilterDecision {
 		// iterate over the acceptable value combinations and check if one matches this metric
 		for _, validValueSet := range validValueSets {
@@ -231,7 +238,7 @@ func metaRecordFilterBySetOfValidValueSets(records []tagquery.MetaTagRecord) tag
 			}
 
 			if sliceContainsElements(validValueSet.tags, tags) {
-				return tagquery.Pass
+				return resultOnHit
 			}
 		}
 

--- a/idx/memory/tag_query_id_filter.go
+++ b/idx/memory/tag_query_id_filter.go
@@ -92,9 +92,8 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 			records = append(records, record)
 		}
 
-		// if we don't use an inverted set of meta records, then we check if
-		// all meta records involved in a meta tag filter use the "=" operator.
-		// if this is the case then it is cheaper to build a set of acceptable tags
+		// if a query only involves meta tags of which all underlying expressions
+		// use the "=" operator, then it is cheaper to build a set of acceptable tags
 		// based on the meta record expressions and just check whether they are present
 		// in a metric that gets filtered, compared to doing a full tag index lookup
 		// to check whether a metric has one of the necessary meta tags associated
@@ -132,7 +131,6 @@ func newIdFilter(expressions tagquery.Expressions, ctx *TagQueryContext) *idFilt
 // viableOptimizations looks at a set of meta tag records and decides whether two possible
 // optimizations can be applied when filtering by these records. it returns two bools to
 // indicate which optimizations are or are not viable.
-// if invertSetOfMetaRecords is true then none of these optimizations can be used.
 //
 // * the first bool refers to the optimization for sets of records which all have only one
 //   expression and this expression is using the equal operator.
@@ -158,6 +156,8 @@ func viableOptimizations(records []tagquery.MetaTagRecord) (bool, bool) {
 // which only involves meta records of which each only has exactly one expression and that
 // expression is using the "=" operator. this is quite a narrow scenario, but since it is
 // a very common use case it makes sense to optimize for it.
+// The invertFilter bool flips the filter logic so that instead of removing metrics which
+// do not have a meta tag it filters metrics which do have a meta tag.
 func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord, invertFilter bool) tagquery.MetricDefinitionFilter {
 	// we first build a set of valid tags and names.
 	// since we know that each of the involved meta records uses exactly one expression
@@ -201,6 +201,8 @@ func metaRecordFilterBySetOfValidValues(records []tagquery.MetaTagRecord, invert
 // metaRecordFilterBySetOfValidValueSets creates a filter function to filter by a meta tag
 // which only involves meta records of which all expressions are only using the "=" operator,
 // it is ok if one meta record uses multiple such expressions.
+// The invertFilter bool flips the filter logic so that instead of removing metrics which
+// do not have a meta tag it filters metrics which do have a meta tag.
 func metaRecordFilterBySetOfValidValueSets(records []tagquery.MetaTagRecord, invertFilter bool) tagquery.MetricDefinitionFilter {
 	// we first build a set of tag and name value combinations of which each is sufficient
 	// to pass the generated filter when a metric contains all values of one of these


### PR DESCRIPTION
Fixes #1871 

This PR's branch is based on top of the branch of PR #1898, it only makes sense to review this PR once #1898 is merged.

This adds an optimization which is specific for queries that query for the absence of a meta tag of which all underlying expressions are using the `=` operator. This optimization currently already exists for queries which query for the presence of a meta tag using `=` and of which all underlying expressions are also using the `=` operator, in this PR that existing optimization gets extended to also work for filter expressions which check for the absence of a meta tag.

I also added a benchmark to test for that specific case, and It shows significant improvements with/without this change:

```
benchmark                                old ns/op        new ns/op     delta
BenchmarkFilterByAbsenceOfMetaTag-12     207231916200     253464875     -99.88%

benchmark                                old allocs     new allocs     delta
BenchmarkFilterByAbsenceOfMetaTag-12     407059         232777         -42.81%

benchmark                                old bytes     new bytes     delta
BenchmarkFilterByAbsenceOfMetaTag-12     37499976      34272224      -8.61%
```