### PR TITLE
ConsolidateNudge: nudge without reducing capacity of underlying slice, to keep pointslicepool effective

### DIFF
--- a/consolidation/consolidate_test.go
+++ b/consolidation/consolidate_test.go
@@ -16,7 +16,7 @@ type testCase struct {
 
 func validate(cases []testCase, t *testing.T) {
 	for i, c := range cases {
-		out := Consolidate(c.in, c.num, c.consol)
+		out := Consolidate(c.in, 0, c.num, c.consol)
 		if len(out) != len(c.out) {
 			t.Fatalf("output for testcase %d mismatch: expected: %v, got: %v", i, c.out, out)
 
@@ -502,7 +502,7 @@ func benchmarkConsolidate(fn func() []schema.Point, aggNum uint32, consolidator 
 		in := fn()
 		l = len(in)
 		b.StartTimer()
-		ret := Consolidate(in, aggNum, consolidator)
+		ret := Consolidate(in, 0, aggNum, consolidator)
 		dummy = ret
 	}
 	b.SetBytes(int64(l * 12))

--- a/expr/normalize.go
+++ b/expr/normalize.go
@@ -77,7 +77,7 @@ func NormalizeTo(in models.Series, interval uint32, sc seriescycle.SeriesCycler)
 	}
 
 	sc.Done(in)
-	in.Datapoints = consolidation.Consolidate(datapoints, interval/in.Interval, in.Consolidator)
+	in.Datapoints = consolidation.Consolidate(datapoints, 0, interval/in.Interval, in.Consolidator)
 	in.Interval = interval
 	sc.New(in)
 


### PR DESCRIPTION
Note: this builds on top of #1922, review/merge that first.

Without this fix, you would commonly see that slices going into the pointslicepool would have a cap that is one or two points less then what you need on subsequent reads.

E.g. I added some debug lines and saw this:
```
metrictank-q1_1  | PSP.GetMin(2880) from github.com/grafana/metrictank/vendor/github.com/tinylib/msgp/msgp.Decode->github.com/grafana/metrictank/api/models.(*GetDataRespV1).DecodeMsg
metrictank-q1_1  | candidate has cap 2877 we want 2880
metrictank-q1_1  | PSP.GetMin(2880) from github.com/grafana/metrictank/api.(*Server).renderMetrics->github.com/grafana/metrictank/api.(*Server).executePlan
metrictank-q1_1  | candidate has cap 2877 we want 2880
metrictank-q1_1  | PSP.Put(2880) from github.com/grafana/metrictank/api.(*Server).renderMetrics->github.com/grafana/metrictank/expr.Plan.Clean
metrictank-q1_1  | PSP.Put(2877) from github.com/grafana/metrictank/api.(*Server).renderMetrics->github.com/grafana/metrictank/expr.Plan.Clean
```
This fix increases efficacy of the pool.

Here we can see the comparison of two query nodes q0 and q1. 
q0 runs master+stats (#1922)
q1 runs the code from this branch.
We can see that as time advances, there are periods where nudging happens, which breaks down the efficacy of the pointslicepool in q0.
Q1 doesn't have this problem. We see an increased hit rate, sadly it doesn't translate into memory savings

![comparison](https://user-images.githubusercontent.com/20774/96052208-b67cbf00-0e85-11eb-9ca9-ac88eaef3a69.png)
q1:
![q1](https://user-images.githubusercontent.com/20774/96052212-b7155580-0e85-11eb-88fd-c89e34941414.png)
q0: 
![q0](https://user-images.githubusercontent.com/20774/96052216-b7adec00-0e85-11eb-8414-b9b5988a5980.png)
