### PR TITLE
apply max-series-per-req to non-tagged queries

### DIFF
--- a/api/ccache.go
+++ b/api/ccache.go
@@ -49,7 +49,7 @@ func (s *Server) ccacheDelete(ctx *middleware.Context, req models.CCacheDelete) 
 		var toClear []idx.Node
 		if len(req.Patterns) > 0 {
 			for _, pattern := range req.Patterns {
-				nodes, err := s.MetricIndex.Find(req.OrgId, pattern, 0)
+				nodes, err := s.MetricIndex.Find(req.OrgId, pattern, 0, 0)
 				if err != nil {
 					res.AddError(err)
 					code = http.StatusInternalServerError

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -128,7 +128,7 @@ func (s *Server) indexFind(ctx *middleware.Context, req models.IndexFind) {
 	}
 
 	for _, pattern := range req.Patterns {
-		nodes, err := s.MetricIndex.Find(req.OrgId, pattern, req.From)
+		nodes, err := s.MetricIndex.Find(req.OrgId, pattern, req.From, req.Limit)
 		if err != nil {
 			response.Write(ctx, response.WrapError(err))
 			return

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -503,7 +503,7 @@ func (s *Server) queryAllShards(ctx context.Context, data cluster.Traceable, nam
 // are missing the others, try to speculatively query other members of the shard group.
 // ctx:          request context
 // fetchFunc:    function to call to fetch the data from a peer
-func (s *Server) queryAllShardsGeneric(ctx context.Context, name string, fetchFunc func(context.Context, cluster.Node) (interface{}, error)) (<-chan GenericPeerResponse, <-chan error) {
+func (s *Server) queryAllShardsGeneric(ctx context.Context, name string, fetchFn fetchFunc) (<-chan GenericPeerResponse, <-chan error) {
 	peerGroups, err := cluster.MembersForSpeculativeQuery()
 	if err != nil {
 		log.Errorf("HTTP peerQuery unable to get peers, %s", err.Error())
@@ -513,7 +513,7 @@ func (s *Server) queryAllShardsGeneric(ctx context.Context, name string, fetchFu
 		return resultChan, errorChan
 	}
 
-	return queryPeers(ctx, peerGroups, name, fetchFunc)
+	return queryPeers(ctx, peerGroups, name, fetchFn)
 }
 
 type fetchFunc func(context.Context, cluster.Node) (interface{}, error)

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -475,6 +475,7 @@ func (s *Server) queryAllPeers(ctx context.Context, data cluster.Traceable, name
 // across the cluster. If any peer fails, we try another replica. If enough
 // peers have been heard from (based on speculation-threshold configuration), and we
 // are missing the others, try to speculatively query other members of the shard group.
+// all responses are collected and returned at once.
 // ctx:          request context
 // data:         request to be submitted
 // name:         name to be used in logging & tracing
@@ -501,7 +502,9 @@ func (s *Server) queryAllShards(ctx context.Context, data cluster.Traceable, nam
 // across the cluster. If any peer fails, we try another replica. If enough
 // peers have been heard from (based on speculation-threshold configuration), and we
 // are missing the others, try to speculatively query other members of the shard group.
+// all responses and errors are streamed through the returned channels
 // ctx:          request context
+// name:         name to be used in logging & tracing
 // fetchFunc:    function to call to fetch the data from a peer
 func (s *Server) queryAllShardsGeneric(ctx context.Context, name string, fetchFn fetchFunc) (<-chan GenericPeerResponse, <-chan error) {
 	peerGroups, err := cluster.MembersForSpeculativeQuery()

--- a/api/dataprocessor.go
+++ b/api/dataprocessor.go
@@ -239,7 +239,7 @@ func (s *Server) getTargetsRemote(ctx context.Context, ss *models.StorageStats, 
 	rCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	resultChan, errorChan := queryPeers(rCtx, requiredPeers, "getTargetsRemote", func(ctx context.Context, node cluster.Node) (interface{}, error) {
+	resultChan, errorChan := queryPeers(rCtx, requiredPeers, "getTargetsRemote", func(ctx context.Context, node cluster.Node, peerGroups map[int32][]cluster.Node) (interface{}, error) {
 		var resp models.GetDataRespV1
 		reqs, ok := shardReqs[node.GetPartitions()[0]]
 		if !ok {

--- a/api/graphite.go
+++ b/api/graphite.go
@@ -1161,7 +1161,7 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 	newCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	responseChan, errorChan := s.queryAllShardsGeneric(newCtx, "clusterFindByTag",
-		func(reqCtx context.Context, peer cluster.Node) (interface{}, error) {
+		func(reqCtx context.Context, peer cluster.Node, peerGroups map[int32][]cluster.Node) (interface{}, error) {
 			resp := models.IndexFindByTagResp{}
 			body, err := peer.PostRaw(reqCtx, "clusterFindByTag", "/index/find_by_tag", data)
 			if body == nil || err != nil {

--- a/api/models/node.go
+++ b/api/models/node.go
@@ -166,6 +166,7 @@ type IndexFind struct {
 	Patterns []string `json:"patterns" form:"patterns" binding:"Required"`
 	OrgId    uint32   `json:"orgId" form:"orgId" binding:"Required"`
 	From     int64    `json:"from" form:"from"`
+	Limit    int64    `json:"limit"`
 }
 
 func (i IndexFind) Trace(span opentracing.Span) {

--- a/cmd-dev/mt-simulate-memory-idx-lock-contention/runner/test_runner.go
+++ b/cmd-dev/mt-simulate-memory-idx-lock-contention/runner/test_runner.go
@@ -222,7 +222,7 @@ func (t *TestRun) runQuery(pattern string, wg *sync.WaitGroup, active chan struc
 	}()
 	pre := time.Now()
 	active <- struct{}{}
-	_, err := t.index.Find(orgID, pattern, 0)
+	_, err := t.index.Find(orgID, pattern, 0, 0)
 	if err != nil {
 		log.Printf("Warning: Query failed with error: %s", err)
 	}

--- a/idx/bigtable/bigtable.go
+++ b/idx/bigtable/bigtable.go
@@ -260,7 +260,7 @@ func (b *BigtableIdx) updateBigtable(now uint32, inMemory bool, archive idx.Arch
 	return archive
 }
 
-func (b *BigtableIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, error) {
+func (b *BigtableIdx) Find(orgId uint32, pattern string, from, limit int64) ([]idx.Node, error) {
 	// The lastUpdate timestamp does not get updated in the bigtable index every time when
 	// a data point is received, there can be a delay of up to b.cfg.updateInterval32. To
 	// avoid falsely excluding a metric based on its lastUpdate timestamp we offset the
@@ -268,7 +268,7 @@ func (b *BigtableIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node
 	if from > int64(b.cfg.updateInterval32) {
 		from -= int64(b.cfg.updateInterval32)
 	}
-	return b.MemoryIndex.Find(orgId, pattern, from)
+	return b.MemoryIndex.Find(orgId, pattern, from, limit)
 }
 
 func (b *BigtableIdx) rebuildIndex() {

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -297,7 +297,7 @@ func (c *CasIdx) updateCassandra(now uint32, inMemory bool, archive idx.Archive,
 	return archive
 }
 
-func (c *CasIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, error) {
+func (c *CasIdx) Find(orgId uint32, pattern string, from, limit int64) ([]idx.Node, error) {
 	// The lastUpdate timestamp does not get updated in the cassandra index every time when
 	// a data point is received, there can be a delay of up to c.updateInterval32. To avoid
 	// falsely excluding a metric based on its lastUpdate timestamp we offset the from time
@@ -305,7 +305,7 @@ func (c *CasIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, err
 	if from > int64(c.updateInterval32) {
 		from -= int64(c.updateInterval32)
 	}
-	return c.MemoryIndex.Find(orgId, pattern, from)
+	return c.MemoryIndex.Find(orgId, pattern, from, limit)
 }
 
 func (c *CasIdx) rebuildIndex() {

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -340,7 +340,7 @@ func TestFind(t *testing.T) {
 
 	Convey("When listing root nodes", t, func() {
 		Convey("root nodes for orgId 1", func() {
-			nodes, err := ix.Find(1, "*", 0)
+			nodes, err := ix.Find(1, "*", 0, 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 2)
 			So(nodes[0].Path, ShouldBeIn, "metric", "foo")
@@ -348,7 +348,7 @@ func TestFind(t *testing.T) {
 			So(nodes[0].Leaf, ShouldBeFalse)
 		})
 		Convey("root nodes for orgId 2", func() {
-			nodes, err := ix.Find(2, "*", 0)
+			nodes, err := ix.Find(2, "*", 0, 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 1)
 			So(nodes[0].Path, ShouldEqual, "metric")
@@ -357,7 +357,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with GLOB", t, func() {
-		nodes, err := ix.Find(2, "metric.{f*,demo}.*", 0)
+		nodes, err := ix.Find(2, "metric.{f*,demo}.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 10)
 		for _, n := range nodes {
@@ -366,7 +366,7 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching with multiple wildcards", t, func() {
-		nodes, err := ix.Find(1, "*.*", 0)
+		nodes, err := ix.Find(1, "*.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 2)
 		for _, n := range nodes {
@@ -375,24 +375,24 @@ func TestFind(t *testing.T) {
 	})
 
 	Convey("When searching nodes not in public series", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.*", 0)
+		nodes, err := ix.Find(1, "foo.demo.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 		Convey("When searching for specific series", func() {
-			found, err := ix.Find(1, nodes[0].Path, 0)
+			found, err := ix.Find(1, nodes[0].Path, 0, 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 1)
 			So(found[0].Path, ShouldEqual, nodes[0].Path)
 		})
 		Convey("When searching nodes that are children of a leaf", func() {
-			found, err := ix.Find(1, nodes[0].Path+".*", 0)
+			found, err := ix.Find(1, nodes[0].Path+".*", 0, 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 0)
 		})
 	})
 
 	Convey("When searching with multiple wildcards mixed leaf/branch", t, func() {
-		nodes, err := ix.Find(1, "*.demo.*", 0)
+		nodes, err := ix.Find(1, "*.demo.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 15)
 		for _, n := range nodes {
@@ -405,13 +405,13 @@ func TestFind(t *testing.T) {
 		}
 	})
 	Convey("When searching nodes for unknown orgId", t, func() {
-		nodes, err := ix.Find(4, "foo.demo.*", 0)
+		nodes, err := ix.Find(4, "foo.demo.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
 
 	Convey("When searching nodes that don't exist", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.blah.*", 0)
+		nodes, err := ix.Find(1, "foo.demo.blah.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -85,7 +85,7 @@ type MetricIndex interface {
 	// * orgId describes the org to search in (public data in orgIdPublic is automatically included)
 	// * pattern is handled like graphite does. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
 	// * from is a unix timestamp. series not updated since then are excluded.
-	// * limit is the limit on the amount of nodes. if this number is reached, we return only an error
+	// * limit is the limit on the amount of nodes. if this number is exceeded, we return only an error
 	Find(orgId uint32, pattern string, from, limit int64) ([]Node, error)
 
 	// List returns all Archives for the passed OrgId and the public orgId

--- a/idx/idx.go
+++ b/idx/idx.go
@@ -85,7 +85,8 @@ type MetricIndex interface {
 	// * orgId describes the org to search in (public data in orgIdPublic is automatically included)
 	// * pattern is handled like graphite does. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
 	// * from is a unix timestamp. series not updated since then are excluded.
-	Find(orgId uint32, pattern string, from int64) ([]Node, error)
+	// * limit is the limit on the amount of nodes. if this number is reached, we return only an error
+	Find(orgId uint32, pattern string, from, limit int64) ([]Node, error)
 
 	// List returns all Archives for the passed OrgId and the public orgId
 	List(orgId uint32) []Archive

--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -60,6 +60,11 @@ type FindCache struct {
 	sync.RWMutex
 }
 
+type CacheResult struct {
+	nodes []*Node
+	err   error
+}
+
 func NewFindCache(size, invalidateQueueSize, invalidateMaxSize int, invalidateMaxWait, backoffTime time.Duration) *FindCache {
 	fc := &FindCache{
 		size:                size,
@@ -80,28 +85,34 @@ func NewFindCache(size, invalidateQueueSize, invalidateMaxSize int, invalidateMa
 	return fc
 }
 
-func (c *FindCache) Get(orgId uint32, pattern string) ([]*Node, bool) {
+func (c *FindCache) Get(orgId uint32, pattern string) (CacheResult, bool) {
 	c.RLock()
 	cache, ok := c.cache[orgId]
 	c.RUnlock()
 	if !ok {
 		findCacheMiss.Inc()
-		return nil, ok
+		return CacheResult{}, ok
 	}
 	nodes, ok := cache.Get(pattern)
 	if !ok {
 		findCacheMiss.Inc()
-		return nil, ok
+		return CacheResult{}, ok
 	}
 	findCacheHit.Inc()
-	return nodes.([]*Node), ok
+	return nodes.(CacheResult), ok
 }
 
-func (c *FindCache) Add(orgId uint32, pattern string, nodes []*Node) {
+func (c *FindCache) Add(orgId uint32, pattern string, nodes []*Node, e error) {
 	c.RLock()
 	cache, ok := c.cache[orgId]
 	backoff := c.backoff
 	c.RUnlock()
+
+	cr := CacheResult{
+		nodes: nodes,
+		err:   e,
+	}
+
 	var err error
 	if !ok {
 		// don't init the cache if we are in backoff mode.
@@ -122,7 +133,7 @@ func (c *FindCache) Add(orgId uint32, pattern string, nodes []*Node) {
 		}
 		c.Unlock()
 	}
-	cache.Add(pattern, nodes)
+	cache.Add(pattern, cr)
 }
 
 // Purge clears the cache for the specified orgId
@@ -157,6 +168,9 @@ func (c *FindCache) PurgeAll() {
 // goroutines processing the invalidations, we purge the cache and
 // disable it for `backoffTime`. Future InvalidateFor calls made during
 // the backoff time will then return immediately.
+// Note: if we have a cached entry for a find that resulted in "too many series requested"
+// we shouldn't have to clear that when entries are added to the cache
+// (only when entries are removed). but that's an optimization for later.
 func (c *FindCache) InvalidateFor(orgId uint32, path string) {
 	c.Lock()
 	findCacheInvalidationsReceived.Inc()
@@ -275,7 +289,7 @@ func (c *FindCache) processInvalidateQueue() {
 			}
 
 			for _, k := range cache.Keys() {
-				matches, err := find((*Tree)(tree), k.(string))
+				matches, err := find((*Tree)(tree), k.(string), 0)
 				if err != nil {
 					log.Errorf("memory-idx: checking if cache key %q matches any of the %d invalid patterns resulted in error: %s", k, len(reqs), err)
 				}

--- a/idx/memory/find_cache_test.go
+++ b/idx/memory/find_cache_test.go
@@ -86,7 +86,7 @@ func TestFindCache(t *testing.T) {
 	Convey("when findCache is empty", t, func() {
 		c := NewFindCache(10, 5, 2, 100*time.Millisecond, time.Second*2)
 		Convey("0 results should be returned", func() {
-			result, ok := c.Get(1, "foo.bar.*")
+			result, ok := c.Get(1, "foo.bar.*", 0)
 			So(ok, ShouldBeFalse)
 			So(result.nodes, ShouldHaveLength, 0)
 		})
@@ -97,10 +97,10 @@ func TestFindCache(t *testing.T) {
 			results, err := find((*Tree)(tree), pattern, 0)
 			So(err, ShouldBeNil)
 			So(results, ShouldHaveLength, 1)
-			c.Add(1, "foo.bar.*", results, nil)
+			c.Add(1, "foo.bar.*", 0, results, nil)
 			So(c.cache[1].Len(), ShouldEqual, 1)
 			Convey("when getting cached pattern", func() {
-				result, ok := c.Get(1, "foo.bar.*")
+				result, ok := c.Get(1, "foo.bar.*", 0)
 				So(ok, ShouldBeTrue)
 				So(result.nodes, ShouldHaveLength, 1)
 				Convey("After invalidating path that matches pattern", func() {
@@ -114,25 +114,25 @@ func TestFindCache(t *testing.T) {
 				})
 			})
 			Convey("when findCache invalidation falls behind", func() {
-				c.Add(1, "foo.{a,b,c}*.*", results, nil)
-				c.Add(1, "foo.{a,b,e}*.*", results, nil)
-				c.Add(1, "foo.{a,b,f}*.*", results, nil)
+				c.Add(1, "foo.{a,b,c}*.*", 0, results, nil)
+				c.Add(1, "foo.{a,b,e}*.*", 0, results, nil)
+				c.Add(1, "foo.{a,b,f}*.*", 0, results, nil)
 				c.triggerBackoff()
 				c.InvalidateFor(1, "foo.baz.foo.a.b.c.d.e.f.g.h")
 
 				So(len(c.cache), ShouldEqual, 0)
 				Convey("when adding to cache in backoff", func() {
-					c.Add(1, "foo.*.*", results, nil)
+					c.Add(1, "foo.*.*", 0, results, nil)
 					So(len(c.cache), ShouldEqual, 0)
-					result, ok := c.Get(1, "foo.*.*")
+					result, ok := c.Get(1, "foo.*.*", 0)
 					So(ok, ShouldBeFalse)
 					So(result.nodes, ShouldHaveLength, 0)
 				})
 				Convey("when adding to cache after backoff time", func() {
 					time.Sleep(time.Millisecond * 2500)
-					c.Add(1, "foo.*.*", results, nil)
+					c.Add(1, "foo.*.*", 0, results, nil)
 					So(len(c.cache), ShouldEqual, 1)
-					result, ok := c.Get(1, "foo.*.*")
+					result, ok := c.Get(1, "foo.*.*", 0)
 					So(ok, ShouldBeTrue)
 					So(result.nodes, ShouldHaveLength, 1)
 				})

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1276,7 +1276,7 @@ func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, patte
 		return find(tree, pattern, limit)
 	}
 
-	cr, ok := m.findCache.Get(orgId, pattern)
+	cr, ok := m.findCache.Get(orgId, pattern, limit)
 	if ok {
 		return cr.nodes, cr.err
 	}
@@ -1290,7 +1290,7 @@ func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, patte
 			return nil, err
 		}
 	}
-	m.findCache.Add(orgId, pattern, matchedNodes, err)
+	m.findCache.Add(orgId, pattern, limit, matchedNodes, err)
 	return matchedNodes, err
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1289,7 +1289,7 @@ func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, patte
 	return matchedNodes, nil
 }
 
-func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, error) {
+func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit int64) ([]idx.Node, error) {
 	pre := time.Now()
 	var matchedNodes []*Node
 	var err error

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -1282,7 +1282,7 @@ func benchmarkTagsWithoutFilter(b *testing.B) {
 func ixFind(b *testing.B, org uint32, q int) {
 	b.Helper()
 
-	nodes, err := ix.Find(org, queries[q].Pattern, 0)
+	nodes, err := ix.Find(org, queries[q].Pattern, 0, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -338,7 +338,7 @@ func testFind(t *testing.T) {
 
 	Convey("When listing root nodes", t, func() {
 		Convey("root nodes for orgId 1", func() {
-			nodes, err := ix.Find(1, "*", 0)
+			nodes, err := ix.Find(1, "*", 0, 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 2)
 			So(nodes[0].Path, ShouldBeIn, "metric", "foo")
@@ -346,7 +346,7 @@ func testFind(t *testing.T) {
 			So(nodes[0].Leaf, ShouldBeFalse)
 		})
 		Convey("root nodes for orgId 2", func() {
-			nodes, err := ix.Find(2, "*", 0)
+			nodes, err := ix.Find(2, "*", 0, 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 1)
 			So(nodes[0].Path, ShouldEqual, "metric")
@@ -355,7 +355,7 @@ func testFind(t *testing.T) {
 	})
 
 	Convey("When searching with GLOB", t, func() {
-		nodes, err := ix.Find(2, "metric.{f*,demo}.*", 0)
+		nodes, err := ix.Find(2, "metric.{f*,demo}.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 10)
 		for _, n := range nodes {
@@ -364,7 +364,7 @@ func testFind(t *testing.T) {
 	})
 
 	Convey("When searching with multiple wildcards", t, func() {
-		nodes, err := ix.Find(1, "*.*", 0)
+		nodes, err := ix.Find(1, "*.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 2)
 		for _, n := range nodes {
@@ -373,24 +373,24 @@ func testFind(t *testing.T) {
 	})
 
 	Convey("When searching nodes not in public series", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.*", 0)
+		nodes, err := ix.Find(1, "foo.demo.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 		Convey("When searching for specific series", func() {
-			found, err := ix.Find(1, nodes[0].Path, 0)
+			found, err := ix.Find(1, nodes[0].Path, 0, 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 1)
 			So(found[0].Path, ShouldEqual, nodes[0].Path)
 		})
 		Convey("When searching nodes that are children of a leaf", func() {
-			found, err := ix.Find(1, nodes[0].Path+".*", 0)
+			found, err := ix.Find(1, nodes[0].Path+".*", 0, 0)
 			So(err, ShouldBeNil)
 			So(found, ShouldHaveLength, 0)
 		})
 	})
 
 	Convey("When searching with multiple wildcards mixed leaf/branch", t, func() {
-		nodes, err := ix.Find(1, "*.demo.*", 0)
+		nodes, err := ix.Find(1, "*.demo.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 15)
 		for _, n := range nodes {
@@ -403,26 +403,26 @@ func testFind(t *testing.T) {
 		}
 	})
 	Convey("When searching nodes for unknown orgId", t, func() {
-		nodes, err := ix.Find(4, "foo.demo.*", 0)
+		nodes, err := ix.Find(4, "foo.demo.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
 
 	Convey("When searching nodes that don't exist", t, func() {
-		nodes, err := ix.Find(1, "foo.demo.blah.*", 0)
+		nodes, err := ix.Find(1, "foo.demo.blah.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
 	})
 
 	Convey("When searching with from timestamp", t, func() {
-		nodes, err := ix.Find(1, "*.demo.*", 4*86400)
+		nodes, err := ix.Find(1, "*.demo.*", 4*86400, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 10)
 		for _, n := range nodes {
 			So(n.Path, ShouldNotContainSubstring, "foo.demo")
 		}
 		Convey("When searching with from timestamp on series with multiple defs.", func() {
-			nodes, err := ix.Find(1, "*.demo.*", 2*86400)
+			nodes, err := ix.Find(1, "*.demo.*", 2*86400, 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 15)
 			for _, n := range nodes {
@@ -476,13 +476,13 @@ func testDelete(t *testing.T) {
 			})
 
 			Convey("the deleted metrics should not be in the index", func() {
-				nodes, err := ix.Find(idx.OrgIdPublic, "metric.*", 0)
+				nodes, err := ix.Find(idx.OrgIdPublic, "metric.*", 0, 0)
 				So(err, ShouldBeNil)
 				So(nodes, ShouldHaveLength, 0)
 			})
 
 			Convey("metrics from different orgs should not be impacted", func() {
-				nodes, err := ix.Find(1, "metric.*", 0)
+				nodes, err := ix.Find(1, "metric.*", 0, 0)
 				So(err, ShouldBeNil)
 				So(nodes, ShouldHaveLength, 1)
 			})
@@ -719,10 +719,10 @@ func testMixedBranchLeafDelete(t *testing.T) {
 			_, ok := ix.Get(mkeys[0])
 			So(ok, ShouldEqual, false)
 			Convey("series should not be present in searches", func() {
-				found, err := ix.Find(1, "a.b.c", 0)
+				found, err := ix.Find(1, "a.b.c", 0, 0)
 				So(err, ShouldBeNil)
 				So(found, ShouldHaveLength, 0)
-				found, err = ix.Find(1, "a.b.c.d", 0)
+				found, err = ix.Find(1, "a.b.c.d", 0, 0)
 				So(err, ShouldBeNil)
 				So(found, ShouldHaveLength, 0)
 			})
@@ -740,10 +740,10 @@ func testMixedBranchLeafDelete(t *testing.T) {
 			_, ok := ix.Get(mkeys[3])
 			So(ok, ShouldEqual, false)
 			Convey("deleted series should not be present in searches", func() {
-				found, err := ix.Find(1, "a.b.c2.*", 0)
+				found, err := ix.Find(1, "a.b.c2.*", 0, 0)
 				So(err, ShouldBeNil)
 				So(found, ShouldHaveLength, 1)
-				found, err = ix.Find(1, "a.b.c2.d", 0)
+				found, err = ix.Find(1, "a.b.c2.d", 0, 0)
 				So(err, ShouldBeNil)
 				So(found, ShouldHaveLength, 0)
 			})
@@ -1013,10 +1013,10 @@ func testPrune(t *testing.T) {
 		pruned, err := ix.Prune(time.Unix(11, 0))
 		So(err, ShouldBeNil)
 		So(pruned, ShouldHaveLength, 5)
-		nodes, err := ix.Find(1, "metric.bah.*", 0)
+		nodes, err := ix.Find(1, "metric.bah.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 0)
-		nodes, err = ix.Find(1, "metric.foo.*", 0)
+		nodes, err = ix.Find(1, "metric.foo.*", 0, 0)
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 
@@ -1042,7 +1042,7 @@ func testPrune(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(pruned, ShouldHaveLength, 4)
 			ix.ForceInvalidationFindCache()
-			nodes, err := ix.Find(1, "metric.foo.*", 0)
+			nodes, err := ix.Find(1, "metric.foo.*", 0, 0)
 			So(err, ShouldBeNil)
 			So(nodes, ShouldHaveLength, 1)
 		})

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -173,13 +173,13 @@ func (p *PartitionedMemoryIdx) Delete(orgId uint32, pattern string) ([]idx.Archi
 // Find searches the index for matching nodes.
 // * orgId describes the org to search in (public data in orgIdPublic is automatically included)
 // * pattern is handled like graphite does. see https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards
-func (p *PartitionedMemoryIdx) Find(orgId uint32, pattern string, from int64) ([]idx.Node, error) {
+func (p *PartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit int64) ([]idx.Node, error) {
 	g, _ := errgroup.WithContext(context.Background())
 	resultChan := make(chan []idx.Node)
 	for _, m := range p.Partition {
 		m := m
 		g.Go(func() error {
-			found, err := m.Find(orgId, pattern, from)
+			found, err := m.Find(orgId, pattern, from, limit/int64(len(p.Partition)))
 			if err != nil {
 				return err
 			}

--- a/idx/memory/write_queue_test.go
+++ b/idx/memory/write_queue_test.go
@@ -34,7 +34,7 @@ func TestWriteQueue(t *testing.T) {
 		ix.AddOrUpdate(mkey, data, getPartition(data))
 	}
 
-	nodes, err := ix.Find(1, "some.metric.*", 0)
+	nodes, err := ix.Find(1, "some.metric.*", 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestWriteQueue(t *testing.T) {
 	// TODO - make this less flaky (add flush counter? Flush wait func?)
 	time.Sleep(100 * time.Millisecond)
 
-	nodes, err = ix.Find(1, "some.metric.*", 0)
+	nodes, err = ix.Find(1, "some.metric.*", 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestWriteQueueMultiThreads(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	nodes, err := ix.Find(1, "some.metric.*.*", 0)
+	nodes, err := ix.Find(1, "some.metric.*.*", 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`max-series-per-req` has been implemented for tagged queries for a quite a while, but wasn't implemented yet for non-tagged queries. We have seen customers do excessively large queries leading to lots of allocated memory, we want to reject the queries instead. fix #1916 

This PR does the following:

* implement a fractional limit. e.g. when a query node receives a query with a limit of 100, and the cluster has 10 shards and 5 shardgroups (meaning all read nodes own 2 shards out of the 10), then each read node will see a limit of `100 * 2 / 10 = 20`.
* the read nodes will try to detect limit breach as early as possible without first allocating a bunch of stuff. also, limit breaches are cached in the findCache
* some minor refactoring to make this possible and some small doc tweaks. In particular, fetchFunc now gets the full peersGroup map, so it has the awareness of the cluster it needs to give each peer its correct fractional limit (though there's a caveat here, is shardgroups are completely down - degraded cluster - then the fractional limit will be higher than it should. suboptimal but should be acceptable)
* add a "global" limit: on a query node, even if all individual fan-out requests somehow succeeded, but the aggregate still breached the limit (unlikely), return an error

see all individual commits for more details.
