### PR TITLE
Remove untagged find limits on read nodes

### DIFF
--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -300,7 +300,7 @@ func (c *FindCache) processInvalidateQueue() {
 			}
 
 			for _, k := range cache.Keys() {
-				matches, err := find((*Tree)(tree), k.(cacheKey).patt, 0)
+				matches, err := find((*Tree)(tree), k.(cacheKey).patt)
 				if err != nil {
 					log.Errorf("memory-idx: checking if cache key %q matches any of the %d invalid patterns resulted in error: %s", k, len(reqs), err)
 				}

--- a/idx/memory/find_cache_test.go
+++ b/idx/memory/find_cache_test.go
@@ -86,23 +86,23 @@ func TestFindCache(t *testing.T) {
 	Convey("when findCache is empty", t, func() {
 		c := NewFindCache(10, 5, 2, 100*time.Millisecond, time.Second*2)
 		Convey("0 results should be returned", func() {
-			result, ok := c.Get(1, "foo.bar.*", 0)
+			result, ok := c.Get(1, "foo.bar.*")
 			So(ok, ShouldBeFalse)
-			So(result.nodes, ShouldHaveLength, 0)
+			So(result, ShouldHaveLength, 0)
 		})
 		Convey("when adding entries to the cache", func() {
 			pattern := "foo.bar.*"
 			tree := newBareTree()
 			tree.add("foo.bar.foo")
-			results, err := find((*Tree)(tree), pattern, 0)
+			results, err := find((*Tree)(tree), pattern)
 			So(err, ShouldBeNil)
 			So(results, ShouldHaveLength, 1)
-			c.Add(1, "foo.bar.*", 0, results, nil)
+			c.Add(1, "foo.bar.*", results)
 			So(c.cache[1].Len(), ShouldEqual, 1)
 			Convey("when getting cached pattern", func() {
-				result, ok := c.Get(1, "foo.bar.*", 0)
+				result, ok := c.Get(1, "foo.bar.*")
 				So(ok, ShouldBeTrue)
-				So(result.nodes, ShouldHaveLength, 1)
+				So(result, ShouldHaveLength, 1)
 				Convey("After invalidating path that matches pattern", func() {
 					c.InvalidateFor(1, "foo.bar.baz")
 					time.Sleep(time.Second) // make sure we reach invalidateMaxWait
@@ -114,27 +114,27 @@ func TestFindCache(t *testing.T) {
 				})
 			})
 			Convey("when findCache invalidation falls behind", func() {
-				c.Add(1, "foo.{a,b,c}*.*", 0, results, nil)
-				c.Add(1, "foo.{a,b,e}*.*", 0, results, nil)
-				c.Add(1, "foo.{a,b,f}*.*", 0, results, nil)
+				c.Add(1, "foo.{a,b,c}*.*", results)
+				c.Add(1, "foo.{a,b,e}*.*", results)
+				c.Add(1, "foo.{a,b,f}*.*", results)
 				c.triggerBackoff()
 				c.InvalidateFor(1, "foo.baz.foo.a.b.c.d.e.f.g.h")
 
 				So(len(c.cache), ShouldEqual, 0)
 				Convey("when adding to cache in backoff", func() {
-					c.Add(1, "foo.*.*", 0, results, nil)
+					c.Add(1, "foo.*.*", results)
 					So(len(c.cache), ShouldEqual, 0)
-					result, ok := c.Get(1, "foo.*.*", 0)
+					result, ok := c.Get(1, "foo.*.*")
 					So(ok, ShouldBeFalse)
-					So(result.nodes, ShouldHaveLength, 0)
+					So(result, ShouldHaveLength, 0)
 				})
 				Convey("when adding to cache after backoff time", func() {
 					time.Sleep(time.Millisecond * 2500)
-					c.Add(1, "foo.*.*", 0, results, nil)
+					c.Add(1, "foo.*.*", results)
 					So(len(c.cache), ShouldEqual, 1)
-					result, ok := c.Get(1, "foo.*.*", 0)
+					result, ok := c.Get(1, "foo.*.*")
 					So(ok, ShouldBeTrue)
-					So(result.nodes, ShouldHaveLength, 1)
+					So(result, ShouldHaveLength, 1)
 				})
 			})
 		})

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1273,7 +1273,7 @@ func (m *UnpartitionedMemoryIdx) finalizeResult(res []string, limit uint, dedupl
 func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, pattern string, limit int64) ([]*Node, error) {
 
 	if m.findCache == nil {
-		return find(tree, pattern, limit)
+		return find(tree, pattern)
 	}
 
 	cr, ok := m.findCache.Get(orgId, pattern, limit)
@@ -1281,7 +1281,7 @@ func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, patte
 		return cr.nodes, cr.err
 	}
 
-	matchedNodes, err := find(tree, pattern, limit)
+	matchedNodes, err := find(tree, pattern)
 
 	// we want to cache bad requests from the user
 	if err != nil {
@@ -1390,7 +1390,7 @@ func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit 
 }
 
 // find returns all Nodes matching the pattern for the given tree
-func find(tree *Tree, pattern string, limit int64) ([]*Node, error) {
+func find(tree *Tree, pattern string) ([]*Node, error) {
 	var nodes []string
 	if strings.Index(pattern, ";") == -1 {
 		nodes = strings.Split(pattern, ".")
@@ -1450,10 +1450,6 @@ func find(tree *Tree, pattern string, limit int64) ([]*Node, error) {
 			}
 			log.Debugf("memory-idx: searching %d children of %s that match %s", len(c.Children), c.Path, nodes[i])
 			matches := matcher(c.Children)
-
-			if limit > 0 && int64(len(grandChildren)+len(matches)) > limit {
-				return nil, errors.NewBadRequest("limit exhausted")
-			}
 
 			for _, m := range matches {
 				newBranch := c.Path + "." + m
@@ -1576,7 +1572,7 @@ func (m *UnpartitionedMemoryIdx) Delete(orgId uint32, pattern string) ([]idx.Arc
 	if !ok {
 		return nil, nil
 	}
-	found, err := find(tree, pattern, 0)
+	found, err := find(tree, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1316,18 +1316,6 @@ func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit 
 	if orgId != idx.OrgIdPublic && idx.OrgIdPublic > 0 {
 		tree, ok = m.tree[idx.OrgIdPublic]
 		if ok {
-			if limit > 0 {
-				limit -= int64(len(matchedNodes))
-				// technically, this is off by one:
-				// if limit was 10 and we found 10 nodes, then the request will still be OK
-				// if the find for publicNodes doesn't find anything.
-				// but we already use 0 to mean unlimited, can't use it for "this may not match anything"
-				// but this seems like an acceptable edge case. What we certainly want to avoid is the limit
-				// going negative or being set to 0 which would mean unlimited.
-				if limit < 1 {
-					return nil, errors.NewBadRequest("limit exhausted")
-				}
-			}
 			publicNodes, err := m.findMaybeCached(tree, idx.OrgIdPublic, pattern)
 			if err != nil {
 				return nil, err

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1291,6 +1291,7 @@ func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, patte
 
 func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit int64) ([]idx.Node, error) {
 
+	// NOTE: `limit` checking temporarily disabled here. see #1930
 	// note that we apply the limit on the raw memory.Node count for find()
 	// if you have a metric with the same path both in the public tree as well as the tree for your org
 	// we count it each time, even though we would merge it by path before returning.

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -317,16 +317,18 @@ func TestFindLimit(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 	})
-	Convey("When searching with a breached limit", t, func() {
-		nodes, err := ix.Find(65, "metric.demo.*.*", 0, 4)
-		So(err, ShouldNotBeNil)
-		So(nodes, ShouldHaveLength, 0)
-	})
-	Convey("When searching with a breached limit", t, func() {
-		nodes, err := ix.Find(65, "metric.demo.*.*", 0, 3)
-		So(err, ShouldNotBeNil)
-		So(nodes, ShouldHaveLength, 0)
-	})
+	/*
+		Convey("When searching with a breached limit", t, func() {
+			nodes, err := ix.Find(65, "metric.demo.*.*", 0, 4)
+			So(err, ShouldNotBeNil)
+			So(nodes, ShouldHaveLength, 0)
+		})
+		Convey("When searching with a breached limit", t, func() {
+			nodes, err := ix.Find(65, "metric.demo.*.*", 0, 3)
+			So(err, ShouldNotBeNil)
+			So(nodes, ShouldHaveLength, 0)
+		})
+	*/
 }
 func testFind(t *testing.T) {
 	idx.OrgIdPublic = 100


### PR DESCRIPTION
1) remove limit support from index.Find and find() calls. while read nodes still get limit parameters from query nodes, they are effectively ignored (though the query pod still has its aggregate limit checking). see #1930 
2) reinstate findCache to how it was before we introduced limits
