### PR TITLE
fix Server.findSeries() limit application

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -145,7 +145,10 @@ MainLoop:
 		case <-ctx.Done():
 			//request canceled
 			return nil, nil
-		case err := <-errorChan:
+		case err, ok := <-errorChan:
+			if !ok {
+				break MainLoop
+			}
 			return nil, err
 		case r, ok := <-responseChan:
 			if !ok {


### PR DESCRIPTION
* the limit was incorrectly applied on the number of api.Series.
  these structures represent a full find result (with possibly many
  timeseries) for each given combination of pattern and peer.
  Instead, we have to look inside of these at the actual amount
  of idx.Node structures they contain, and only consider those
  that are leaf nodes (as they represent timeseries) and not
  branch nodes
* make it "streaming" based: as soon as we detect a per-req limit
  breach, cancel all pending requests (similar to the mechanism
  we already had, where if a peer reports a limit breach on its
  proportional request, we also cancel the others)
* while we're at it, we may as well filter out unneeded branches
  centrally/earlier too