### PR TITLE
Fix corrext limit setting on read nodes (in index find)

### DIFF
--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -275,7 +275,7 @@ func (c *FindCache) processInvalidateQueue() {
 			}
 
 			for _, k := range cache.Keys() {
-				matches, err := find((*Tree)(tree), k.(string))
+				matches, err := findOneShot((*Tree)(tree), k.(string))
 				if err != nil {
 					log.Errorf("memory-idx: checking if cache key %q matches any of the %d invalid patterns resulted in error: %s", k, len(reqs), err)
 				}

--- a/idx/memory/find_cache_test.go
+++ b/idx/memory/find_cache_test.go
@@ -94,7 +94,7 @@ func TestFindCache(t *testing.T) {
 			pattern := "foo.bar.*"
 			tree := newBareTree()
 			tree.add("foo.bar.foo")
-			results, err := find((*Tree)(tree), pattern)
+			results, err := findOneShot((*Tree)(tree), pattern)
 			So(err, ShouldBeNil)
 			So(results, ShouldHaveLength, 1)
 			c.Add(1, "foo.bar.*", results)

--- a/idx/memory/find_iter.go
+++ b/idx/memory/find_iter.go
@@ -1,0 +1,90 @@
+package memory
+
+import log "github.com/sirupsen/logrus"
+
+type Iter interface {
+	Next() (*Node, error)
+	Close()
+}
+
+// NodesIterator returns nodes from a predefined slice
+// it does not add data to the cache
+type NodesIterator struct {
+	next  int
+	nodes []*Node
+}
+
+func (n *NodesIterator) Next() (*Node, error) {
+	if n.next < len(n.nodes) {
+		node := n.nodes[n.next]
+		n.next++
+		return node, nil
+	}
+	return nil, nil
+}
+
+func (n *NodesIterator) Close() {}
+
+// FindIter is an iterator that provides all nodes from the index matching a certain pattern
+// callers should hold the lock on the index while creating the iterator, calling Next(), and calling Close()
+type FindIter struct {
+	// config
+	tree      *Tree
+	orgID     uint32 // only used for caching
+	pattern   string
+	findCache *FindCache // may be nil to disable caching
+
+	// iteration config & state
+	out    chan *Node
+	errors chan error
+	done   bool // wether there's any more items to process
+
+	// all returned responses (without 'from' filtering), which upon Close() will get added to the findcache
+	found []*Node
+}
+
+// NewFindIter creates a new Find iterator. findCache can be nil to disable caching. orgID is only used for caching
+func NewFindIter(tree *Tree, orgID uint32, pattern string, findCache *FindCache) *FindIter {
+	f := FindIter{
+		tree:      tree,
+		orgID:     orgID,
+		pattern:   pattern,
+		findCache: findCache,
+		out:       make(chan *Node),
+		errors:    make(chan error),
+	}
+	go findWorker(f.tree, f.pattern, f.out, f.errors)
+	return &f
+}
+
+// Next returns the next node (if any), and an error (if any)
+// the iteration is complete when both are nil
+func (f *FindIter) Next() (*Node, error) {
+	select {
+	case n, ok := <-f.out:
+		if !ok {
+			f.done = true
+			return nil, nil
+		}
+		f.found = append(f.found, n)
+		return n, nil
+	case err := <-f.errors:
+		f.done = true
+		// handles both receiving an err and channel close
+		return nil, err
+	}
+}
+
+// Close closes the iterator and adds the results to the findcache
+// Callers may only call Close() once, after the iteration completed
+// but they not need to call Close(), for example when the results should not be cached
+func (f *FindIter) Close() {
+	if !f.done {
+		panic("Close called on !done FindIter")
+	}
+	log.Debugf("memory-idx: reached pattern length. %d nodes matched", len(f.found))
+	if f.findCache == nil {
+		return
+	}
+	f.findCache.Add(f.orgID, f.pattern, f.found)
+}

--- a/idx/memory/find_iter.go
+++ b/idx/memory/find_iter.go
@@ -82,7 +82,9 @@ func (f *FindIter) Close() {
 	if !f.done {
 		panic("Close called on !done FindIter")
 	}
-	log.Debugf("memory-idx: reached pattern length. %d nodes matched", len(f.found))
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debugf("memory-idx: reached pattern length. %d nodes matched", len(f.found))
+	}
 	if f.findCache == nil {
 		return
 	}

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1291,7 +1291,6 @@ func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, patte
 
 func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit int64) ([]idx.Node, error) {
 
-	// NOTE: `limit` checking temporarily disabled here. see #1930
 	// note that we apply the limit on the raw memory.Node count for find()
 	// if you have a metric with the same path both in the public tree as well as the tree for your org
 	// we count it each time, even though we would merge it by path before returning.

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1824,7 +1824,9 @@ ORGS:
 	return pruned, nil
 }
 
-func getMatcher(path string) (func([]string) []string, error) {
+type matcher func([]string) []string
+
+func getMatcher(path string) (matcher, error) {
 	// Matches everything
 	if path == "*" {
 		return func(children []string) []string {

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -95,6 +95,7 @@ var tagQueries = []testQuery{
 	{Expressions: []string{"dc=dc1", "host!=~host10[0-9]{2}", "device!=~c.*"}, ExpectedResults: 4000},
 }
 
+// cpuMetrics returns dcCount*hostCount*cpuCount*8 metrics mimicing cpu metrics with tags
 func cpuMetrics(dcCount, hostCount, hostOffset, cpuCount int, prefix string) []metric {
 	var series []metric
 	for dc := 0; dc < dcCount; dc++ {
@@ -119,6 +120,7 @@ func cpuMetrics(dcCount, hostCount, hostOffset, cpuCount int, prefix string) []m
 	return series
 }
 
+// diskMetrics returns dcCount*hostCount*diskCount*8 metrics mimicking disk metrics with tags
 func diskMetrics(dcCount, hostCount, hostOffset, diskCount int, prefix string) []metric {
 	var series []metric
 	for dc := 0; dc < dcCount; dc++ {

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -317,18 +317,16 @@ func TestFindLimit(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(nodes, ShouldHaveLength, 5)
 	})
-	/*
-		Convey("When searching with a breached limit", t, func() {
-			nodes, err := ix.Find(65, "metric.demo.*.*", 0, 4)
-			So(err, ShouldNotBeNil)
-			So(nodes, ShouldHaveLength, 0)
-		})
-		Convey("When searching with a breached limit", t, func() {
-			nodes, err := ix.Find(65, "metric.demo.*.*", 0, 3)
-			So(err, ShouldNotBeNil)
-			So(nodes, ShouldHaveLength, 0)
-		})
-	*/
+	Convey("When searching with a breached limit", t, func() {
+		nodes, err := ix.Find(65, "metric.demo.*.*", 0, 4)
+		So(err, ShouldNotBeNil)
+		So(nodes, ShouldHaveLength, 0)
+	})
+	Convey("When searching with a breached limit", t, func() {
+		nodes, err := ix.Find(65, "metric.demo.*.*", 0, 3)
+		So(err, ShouldNotBeNil)
+		So(nodes, ShouldHaveLength, 0)
+	})
 }
 func testFind(t *testing.T) {
 	idx.OrgIdPublic = 100


### PR DESCRIPTION
this implements the proposal from #1930 by trying to make only minimal changes to the core existing find logic, and use channels to "yield" (as in python) values out of that function.
For an alternative approach, see #1936 

review this commit by commit.




