### PR TITLE
DRAFT/Experimental Fix limit from filter cleanup stateful iterator

### DIFF
--- a/idx/memory/find_cache.go
+++ b/idx/memory/find_cache.go
@@ -275,7 +275,7 @@ func (c *FindCache) processInvalidateQueue() {
 			}
 
 			for _, k := range cache.Keys() {
-				matches, err := find((*Tree)(tree), k.(string))
+				matches, err := findOneShot((*Tree)(tree), k.(string))
 				if err != nil {
 					log.Errorf("memory-idx: checking if cache key %q matches any of the %d invalid patterns resulted in error: %s", k, len(reqs), err)
 				}

--- a/idx/memory/find_cache_test.go
+++ b/idx/memory/find_cache_test.go
@@ -94,7 +94,7 @@ func TestFindCache(t *testing.T) {
 			pattern := "foo.bar.*"
 			tree := newBareTree()
 			tree.add("foo.bar.foo")
-			results, err := find((*Tree)(tree), pattern)
+			results, err := findOneShot((*Tree)(tree), pattern)
 			So(err, ShouldBeNil)
 			So(results, ShouldHaveLength, 1)
 			c.Add(1, "foo.bar.*", results)

--- a/idx/memory/find_iter.go
+++ b/idx/memory/find_iter.go
@@ -1,0 +1,90 @@
+package memory
+
+import log "github.com/sirupsen/logrus"
+
+type Iter interface {
+	Next() (*Node, error)
+	Close()
+}
+
+// NodesIterator returns nodes from a predefined slice
+// it does not add data to the cache
+type NodesIterator struct {
+	next  int
+	nodes []*Node
+}
+
+func (n *NodesIterator) Next() (*Node, error) {
+	if n.next < len(n.nodes) {
+		node := n.nodes[n.next]
+		n.next++
+		return node, nil
+	}
+	return nil, nil
+}
+
+func (n *NodesIterator) Close() {}
+
+// FindIter is an iterator that provides all nodes from the index matching a certain pattern
+// callers should hold the lock on the index while creating the iterator, calling Next(), and calling Close()
+type FindIter struct {
+	// config
+	tree      *Tree
+	orgID     uint32 // only used for caching
+	pattern   string
+	findCache *FindCache // may be nil to disable caching
+
+	// iteration config & state
+	out    chan *Node
+	errors chan error
+	done   bool // wether there's any more items to process
+
+	// all returned responses (without 'from' filtering), which upon Close() will get added to the findcache
+	found []*Node
+}
+
+// NewFindIter creates a new Find iterator. findCache can be nil to disable caching. orgID is only used for caching
+func NewFindIter(tree *Tree, orgID uint32, pattern string, findCache *FindCache) *FindIter {
+	f := FindIter{
+		tree:      tree,
+		orgID:     orgID,
+		pattern:   pattern,
+		findCache: findCache,
+		out:       make(chan *Node),
+		errors:    make(chan error),
+	}
+	go findWorker(f.tree, f.pattern, f.out, f.errors)
+	return &f
+}
+
+// Next returns the next node (if any), and an error (if any)
+// the iteration is complete when both are nil
+func (f *FindIter) Next() (*Node, error) {
+	select {
+	case n, ok := <-f.out:
+		if !ok {
+			f.done = true
+			return nil, nil
+		}
+		f.found = append(f.found, n)
+		return n, nil
+	case err := <-f.errors:
+		f.done = true
+		// handles both receiving an err and channel close
+		return nil, err
+	}
+}
+
+// Close closes the iterator and adds the results to the findcache
+// Callers may only call Close() once, after the iteration completed
+// but they not need to call Close(), for example when the results should not be cached
+func (f *FindIter) Close() {
+	if !f.done {
+		panic("Close called on !done FindIter")
+	}
+	log.Debugf("memory-idx: reached pattern length. %d nodes matched", len(f.found))
+	if f.findCache == nil {
+		return
+	}
+	f.findCache.Add(f.orgID, f.pattern, f.found)
+}

--- a/idx/memory/find_iter.go
+++ b/idx/memory/find_iter.go
@@ -1,6 +1,11 @@
 package memory
 
-import log "github.com/sirupsen/logrus"
+import (
+	"strings"
+
+	"github.com/grafana/metrictank/errors"
+	log "github.com/sirupsen/logrus"
+)
 
 type Iter interface {
 	Next() (*Node, error)
@@ -35,43 +40,207 @@ type FindIter struct {
 	findCache *FindCache // may be nil to disable caching
 
 	// iteration config & state
-	out    chan *Node
-	errors chan error
-	done   bool // wether there's any more items to process
+	nodes    []string        // foo.bar.z* becomes ["foo", "bar", "z*"]
+	matchers []matcher       // match functions (only set for those nodes that lie in the "search space" e.g. for nodes[start:]
+	start    int             // start marks the beginning of the search space. e.g. for foo.bar.z*, start=2
+	pos      int             // position within nodes that we're currently working on. start <= pos <= len(nodes).
+	branch   string          // the branch we're currently working on
+	stack    []*stackElement // stack[0] corresponds to node[start]
+	done     bool            // wether there's any more items to process
 
 	// all returned responses (without 'from' filtering), which upon Close() will get added to the findcache
 	found []*Node
 }
 
 // NewFindIter creates a new Find iterator. findCache can be nil to disable caching. orgID is only used for caching
-func NewFindIter(tree *Tree, orgID uint32, pattern string, findCache *FindCache) *FindIter {
+func NewFindIter(tree *Tree, orgID uint32, pattern string, findCache *FindCache) (*FindIter, error) {
 	f := FindIter{
 		tree:      tree,
 		orgID:     orgID,
 		pattern:   pattern,
 		findCache: findCache,
-		out:       make(chan *Node),
-		errors:    make(chan error),
 	}
-	go findWorker(f.tree, f.pattern, f.out, f.errors)
-	return &f
+	return &f, f.init()
+}
+
+type stackElement struct {
+	node     *Node
+	children []string // every time we look at our node, we don't want to re-evaluate the matchers on the node's children
+	next     int      // child position that needs to be looked at next
+}
+
+func (f *FindIter) init() error {
+	if strings.Index(f.pattern, ";") == -1 {
+		f.nodes = strings.Split(f.pattern, ".")
+	} else {
+		pieces := strings.SplitN(f.pattern, ";", 2)
+		f.nodes = strings.Split(pieces[0], ".")
+		tags := pieces[1]
+		f.nodes[len(f.nodes)-1] += ";" + tags
+	}
+
+	// start is the index of the first node with special chars, or one past the last node if exact
+	// for a query like foo.bar.baz, start is 3
+	// for a query like foo.bar.* or foo.bar, start is 2
+	// for a query like foo.b*.baz, start is 1
+	f.start = len(f.nodes)
+	for i := 0; i < len(f.nodes); i++ {
+		if strings.ContainsAny(f.nodes[i], "*{}[]?") {
+			log.Debugf("memory-idx: found first pattern sequence at node %s pos %d", f.nodes[i], i)
+			f.start = i
+			break
+		}
+	}
+	f.pos = f.start
+
+	f.matchers = make([]matcher, 0, len(f.nodes))
+	for i := f.start; i < len(f.nodes); i++ {
+		matcher, err := getMatcher(f.nodes[i])
+
+		if err != nil {
+			return err
+		}
+
+		f.matchers[i] = matcher
+	}
+
+	if f.start != 0 { // f.branch = "" if f.start = 0
+		f.branch = strings.Join(f.nodes[:f.start], ".")
+	}
+
+	log.Debugf("memory-idx: starting search at node %q", f.branch)
+	node, ok := f.tree.Items[f.branch]
+
+	if !ok {
+		log.Debugf("memory-idx: branch %q does not exist in the index", f.branch)
+		f.done = true
+		return nil
+	}
+
+	if node == nil {
+		corruptIndex.Inc()
+		log.Errorf("memory-idx: startNode is nil. patt=%q,start=%d,branch=%q", f.pattern, f.start, f.branch)
+		return errors.NewInternal("hit an empty path in the index")
+	}
+
+	// pos=len(nodes) is a special case where pattern=static string. the only output is our starting node, we don't need to find its children
+	var children []string
+	if f.pos < len(f.nodes) {
+		if !node.HasChildren() {
+			log.Debugf("memory-idx: end of branch reached at %s with no match found for %s", node.Path, f.pattern)
+			f.done = true
+			return nil
+		}
+		log.Debugf("memory-idx: searching %d children of %s that match %s", len(node.Children), node.Path, f.nodes[f.pos]) // note we know f.pos is always 0 here
+		children = f.matchers[f.pos](node.Children)
+		if len(children) == 0 {
+			f.done = true
+			return nil
+		}
+	}
+	f.stack = append(f.stack, &stackElement{
+		node:     node,
+		children: children,
+	})
+
+	return nil
 }
 
 // Next returns the next node (if any), and an error (if any)
 // the iteration is complete when both are nil
 func (f *FindIter) Next() (*Node, error) {
-	select {
-	case n, ok := <-f.out:
-		if !ok {
+	if f.done {
+		return nil, nil
+	}
+	node, err := f.next()
+	if err != nil {
+		return node, err
+	}
+	f.found = append(f.found, node)
+	return node, err
+}
+
+func (f *FindIter) lookup(parent, child string) (*Node, error) {
+	branch := child
+	if parent != "" {
+		branch = parent + "." + child
+	}
+	node := f.tree.Items[branch]
+	if node == nil {
+		corruptIndex.Inc()
+		log.Errorf("memory-idx: child is nil. patt=%q,pos=%d,p=%q,path=%q", f.pattern, f.pos, f.nodes[f.pos], f.branch)
+		return nil, errors.NewInternal("hit an empty path in the index")
+	}
+	return node, nil
+}
+
+// next will do a depth-first-search for the next node that matches the pattern
+func (f *FindIter) next() (*Node, error) {
+	e := f.stack[f.pos-f.start]
+	if f.pos == len(f.nodes) {
+		// special case. the query was a.static.string which only resolves to a single node
+		f.done = true
+		return e.node, nil
+	}
+	if f.pos == len(f.nodes)-1 {
+		// we are looking as deep down the tree as we're willing to go
+		goto TryNextSibling
+	}
+	// we're somewhere halfway down the tree
+	goto Grow
+
+TryNextSibling:
+	if e.next < len(e.children) {
+		if f.pos == len(f.nodes)-1 {
+			node, err := f.lookup(e.node.Path, e.children[e.next])
+			e.next++
+			if err != nil {
+				f.done = true
+			}
+			return node, err
+		}
+		// implied that f.pos < len(e.nodes)-1
+		goto Grow
+	} else {
+		goto Unwind
+	}
+Unwind:
+	for {
+		if f.pos == f.start {
 			f.done = true
 			return nil, nil
 		}
-		f.found = append(f.found, n)
-		return n, nil
-	case err := <-f.errors:
-		f.done = true
-		// handles both receiving an err and channel close
-		return nil, err
+		f.pos--
+		f.stack = f.stack[:f.pos-f.start]
+		e := f.stack[f.pos-1]
+		if e.next < len(e.children) {
+			// we have children to process. we know we can't be at the end of the tree, so we must grow again
+			goto Grow
+		}
+	}
+Grow:
+	for {
+		node, err := f.lookup(e.node.Path, e.children[e.next])
+		if err != nil {
+			f.done = true
+			return nil, err
+		}
+		e.next++
+		if !node.HasChildren() {
+			log.Debugf("memory-idx: end of branch reached at %s with no match found for %s", node.Path, f.pattern)
+			goto TryNextSibling
+		}
+		log.Debugf("memory-idx: searching %d children of %s that match %s", len(node.Children), node.Path, f.nodes[f.pos])
+		matches := f.matchers[f.pos](node.Children)
+		if len(matches) == 0 {
+			goto TryNextSibling
+		}
+		// we have matches! grow our stack again
+		f.pos++
+		f.stack = append(f.stack, &stackElement{
+			node:     node,
+			children: matches,
+		})
 	}
 }
 

--- a/idx/memory/memory.go
+++ b/idx/memory/memory.go
@@ -1270,23 +1270,35 @@ func (m *UnpartitionedMemoryIdx) finalizeResult(res []string, limit uint, dedupl
 	return res
 }
 
-func (m *UnpartitionedMemoryIdx) findMaybeCached(tree *Tree, orgId uint32, pattern string) ([]*Node, error) {
-
-	if m.findCache == nil {
-		return find(tree, pattern)
+func (m *UnpartitionedMemoryIdx) getCachedIterator(orgId uint32, pattern string) (Iter, bool) {
+	var iter Iter
+	if m.findCache != nil {
+		nodes, ok := m.findCache.Get(orgId, pattern)
+		if ok {
+			iter = &NodesIterator{nodes: nodes}
+			return iter, true
+		}
 	}
-
-	matchedNodes, ok := m.findCache.Get(orgId, pattern)
-	if ok {
-		return matchedNodes, nil
+	iter, ok := m.newFindIterator(orgId, pattern)
+	if !ok {
+		log.Debugf("memory-idx: orgId %d has no metrics indexed.", orgId)
 	}
+	return iter, ok
+}
 
-	matchedNodes, err := find(tree, pattern)
-	if err != nil {
-		return nil, err
+func (m *UnpartitionedMemoryIdx) newFindIterator(orgID uint32, pattern string) (*FindIter, bool) {
+	tree, ok := m.tree[orgID]
+	if !ok {
+		return nil, false
 	}
-	m.findCache.Add(orgId, pattern, matchedNodes)
-	return matchedNodes, err
+	return NewFindIter(tree, orgID, pattern, m.findCache), true
+}
+
+type findProgress struct {
+	foundNodes          int // number of nodes coming from the find iterators (prior to from filtering)
+	foundFilteredLeaves int // number of nodes coming from the find iterators that passed the from filter and are leaves
+	results             []idx.Node
+	seenByPath          map[string]struct{}
 }
 
 func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit int64) ([]idx.Node, error) {
@@ -1298,40 +1310,52 @@ func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit 
 	// as one
 
 	pre := time.Now()
-	var matchedNodes []*Node
-	var err error
 	bc := m.RLockLow()
 	defer bc.RUnlockLow("Find", func() interface{} {
 		return pattern
 	})
-	tree, ok := m.tree[orgId]
-	if !ok {
-		log.Debugf("memory-idx: orgId %d has no metrics indexed.", orgId)
-	} else {
-		matchedNodes, err = m.findMaybeCached(tree, orgId, pattern)
+
+	fp := &findProgress{
+		seenByPath: make(map[string]struct{}),
+	}
+
+	if iter, ok := m.getCachedIterator(orgId, pattern); ok {
+		err := m.consumeIter(fp, iter, from, limit)
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	if orgId != idx.OrgIdPublic && idx.OrgIdPublic > 0 {
-		tree, ok = m.tree[idx.OrgIdPublic]
-		if ok {
-			publicNodes, err := m.findMaybeCached(tree, idx.OrgIdPublic, pattern)
+		if iter, ok := m.getCachedIterator(idx.OrgIdPublic, pattern); ok {
+			err := m.consumeIter(fp, iter, from, limit)
 			if err != nil {
 				return nil, err
 			}
-			matchedNodes = append(matchedNodes, publicNodes...)
 		}
 	}
-	log.Debugf("memory-idx: %d nodes matching pattern %s found", len(matchedNodes), pattern)
-	results := make([]idx.Node, 0)
-	byPath := make(map[string]struct{})
+	log.Debugf("memory-idx: %d nodes has %d unique paths.", fp.foundNodes, len(fp.results))
+	statFindDuration.Value(time.Since(pre))
+	return fp.results, nil
+}
+
+// consumeIter drains an iterator, applying the limit and closing the iterator if everything succeeded without issues
+func (m *UnpartitionedMemoryIdx) consumeIter(fp *findProgress, iter Iter, from, limit int64) error {
 	// construct the output slice of idx.Node's such that there is only 1 idx.Node
-	// for each path, and it holds all defs that the Node refers too.
+	// for each path, and it holds all defs that the Node refers to.
 	// if there are public (orgId OrgIdPublic) and private leaf nodes with the same series
 	// path, then the public metricDefs will be excluded.
-	for _, n := range matchedNodes {
-		if _, ok := byPath[n.Path]; ok {
+	for {
+		n, err := iter.Next()
+		if err != nil {
+			return err
+		}
+		if n == nil {
+			iter.Close()
+			return nil
+		}
+		fp.foundNodes++
+		if _, ok := fp.seenByPath[n.Path]; ok {
 			log.Debugf("memory-idx: path %s already seen", n.Path)
 			continue
 		}
@@ -1363,17 +1387,23 @@ func (m *UnpartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit 
 			if len(idxNode.Defs) == 0 {
 				continue
 			}
+			fp.foundFilteredLeaves++
+			if limit > 0 && fp.foundFilteredLeaves == int(limit)+1 {
+				return errors.NewBadRequest("limit exhausted")
+			}
 		}
-		results = append(results, idxNode)
-		byPath[n.Path] = struct{}{}
+
+		fp.results = append(fp.results, idxNode)
+		fp.seenByPath[n.Path] = struct{}{}
 	}
-	log.Debugf("memory-idx: %d nodes has %d unique paths.", len(matchedNodes), len(results))
-	statFindDuration.Value(time.Since(pre))
-	return results, nil
 }
 
-// find returns all Nodes matching the pattern for the given tree
-func find(tree *Tree, pattern string) ([]*Node, error) {
+// findWorker returns all Nodes matching the pattern for the given tree and feeds them on the channel
+func findWorker(tree *Tree, pattern string, out chan *Node, errChan chan error) {
+
+	defer close(errChan)
+	defer close(out)
+
 	var nodes []string
 	if strings.Index(pattern, ";") == -1 {
 		nodes = strings.Split(pattern, ".")
@@ -1396,68 +1426,96 @@ func find(tree *Tree, pattern string) ([]*Node, error) {
 			break
 		}
 	}
+
+	matchers := make([]matcher, len(nodes))
+	for i := pos; i < len(nodes); i++ {
+		var err error
+		matchers[i], err = getMatcher(nodes[i])
+
+		if err != nil {
+			errChan <- err
+			return
+		}
+	}
+
 	var branch string
 	if pos != 0 {
 		branch = strings.Join(nodes[:pos], ".")
 	}
+
 	log.Debugf("memory-idx: starting search at node %q", branch)
 	startNode, ok := tree.Items[branch]
 
 	if !ok {
 		log.Debugf("memory-idx: branch %q does not exist in the index", branch)
-		return nil, nil
+		return
 	}
 
 	if startNode == nil {
 		corruptIndex.Inc()
 		log.Errorf("memory-idx: startNode is nil. patt=%q,pos=%d,branch=%q", pattern, pos, branch)
-		return nil, errors.NewInternal("hit an empty path in the index")
+		errChan <- errors.NewInternal("hit an empty path in the index")
+		return
 	}
 
-	children := []*Node{startNode}
-	for i := pos; i < len(nodes); i++ {
-		p := nodes[i]
+	var search func(node *Node, pos int) error
+	search = func(node *Node, pos int) error {
+		if pos >= len(nodes) {
+			return nil
+		}
+		if !node.HasChildren() {
+			log.Debugf("memory-idx: end of branch reached at %s with no match found for %s", node.Path, pattern)
+			return nil
+		}
+		log.Debugf("memory-idx: searching %d children of %s that match %s", len(node.Children), node.Path, nodes[pos])
+		matches := matchers[pos](node.Children)
 
-		matcher, err := getMatcher(p)
+		for _, m := range matches {
+			newBranch := node.Path + "." + m
+			if node.Path == "" {
+				newBranch = m
+			}
+			child := tree.Items[newBranch]
+			if child == nil {
+				corruptIndex.Inc()
+				log.Errorf("memory-idx: child is nil. patt=%q,pos=%d,p=%q,path=%q", pattern, pos, nodes[pos], newBranch)
+				return errors.NewInternal("hit an empty path in the index")
+			}
 
+			// we reached the full length of the pattern. don't traverse any deeper.
+			if pos == len(nodes)-1 {
+				out <- child
+				continue
+			}
+			err := search(child, pos+1)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	err := search(startNode, pos)
+	if err != nil {
+		errChan <- err
+	}
+}
+
+// findOneShot mimics the legacy "find" behavior: returns all raw results (unfiltered) and without adding to the cache
+func findOneShot(tree *Tree, pattern string) ([]*Node, error) {
+	// note: we don't use caching and the orgID will be ignored
+	iter := NewFindIter(tree, 0, pattern, nil)
+
+	for {
+		n, err := iter.Next()
 		if err != nil {
 			return nil, err
 		}
-
-		var grandChildren []*Node
-		for _, c := range children {
-			if !c.HasChildren() {
-				log.Debugf("memory-idx: end of branch reached at %s with no match found for %s", c.Path, pattern)
-				// expecting a branch
-				continue
-			}
-			log.Debugf("memory-idx: searching %d children of %s that match %s", len(c.Children), c.Path, nodes[i])
-			matches := matcher(c.Children)
-
-			for _, m := range matches {
-				newBranch := c.Path + "." + m
-				if c.Path == "" {
-					newBranch = m
-				}
-				grandChild := tree.Items[newBranch]
-				if grandChild == nil {
-					corruptIndex.Inc()
-					log.Errorf("memory-idx: grandChild is nil. patt=%q,i=%d,pos=%d,p=%q,path=%q", pattern, i, pos, p, newBranch)
-					return nil, errors.NewInternal("hit an empty path in the index")
-				}
-
-				grandChildren = append(grandChildren, grandChild)
-			}
-		}
-		children = grandChildren
-		if len(children) == 0 {
-			log.Debug("memory-idx: pattern does not match any series.")
+		if n == nil {
 			break
 		}
 	}
-
-	log.Debugf("memory-idx: reached pattern length. %d nodes matched", len(children))
-	return children, nil
+	return iter.found, nil
 }
 
 func (m *UnpartitionedMemoryIdx) List(orgId uint32) []idx.Archive {
@@ -1555,7 +1613,7 @@ func (m *UnpartitionedMemoryIdx) Delete(orgId uint32, pattern string) ([]idx.Arc
 	if !ok {
 		return nil, nil
 	}
-	found, err := find(tree, pattern)
+	found, err := findOneShot(tree, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -95,6 +95,7 @@ var tagQueries = []testQuery{
 	{Expressions: []string{"dc=dc1", "host!=~host10[0-9]{2}", "device!=~c.*"}, ExpectedResults: 4000},
 }
 
+// cpuMetrics returns dcCount*hostCount*cpuCount*8 metrics mimicing cpu metrics with tags
 func cpuMetrics(dcCount, hostCount, hostOffset, cpuCount int, prefix string) []metric {
 	var series []metric
 	for dc := 0; dc < dcCount; dc++ {
@@ -119,6 +120,7 @@ func cpuMetrics(dcCount, hostCount, hostOffset, cpuCount int, prefix string) []m
 	return series
 }
 
+// diskMetrics returns dcCount*hostCount*diskCount*8 metrics mimicking disk metrics with tags
 func diskMetrics(dcCount, hostCount, hostOffset, diskCount int, prefix string) []metric {
 	var series []metric
 	for dc := 0; dc < dcCount; dc++ {


### PR DESCRIPTION
see #1935 for more information
this builds upon #1935 , but tries to do so in a more streamlined way.
Instead of reusing the old find() logic and "yielding out of it and into an iterator" using a channel, this chops find iterations into independent Next() calls on the iterator directly without a separate worker and channel communications.  this does overthrow the existing logic extensively, so i'm concerned about the risk of such an invasive chance. For now I'm not pursuing this, but wanted to document it as a draft PR anyway.