### PR TITLE
add mt-index-deleter tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /cmd/mt-fakemetrics/mt-fakemetrics
 /cmd/mt-gateway/mt-gateway
 /cmd/mt-index-cat/mt-index-cat
+/cmd/mt-index-deleter/mt-index-deleter
 /cmd/mt-index-migrate/mt-index-migrate
 /cmd/mt-index-prune/mt-index-prune
 /cmd/mt-indexdump-rules-analyzer/mt-indexdump-rules-analyzer

--- a/cmd/mt-index-deleter/btclient.go
+++ b/cmd/mt-index-deleter/btclient.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/bigtable"
+	btUtils "github.com/grafana/metrictank/bigtable"
+)
+
+const COLUMN_FAMILY = "idx"
+
+type btClient struct {
+	client *bigtable.Client
+	tbl    *bigtable.Table
+}
+
+func NewBtClient(project, instance, tableName string) (*btClient, error) {
+	ctx := context.Background()
+	adminClient, err := bigtable.NewAdminClient(ctx, project, instance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bigtable admin client: %s", err)
+	}
+	err = btUtils.EnsureTableExists(ctx, false, adminClient, tableName, map[string]bigtable.GCPolicy{
+		COLUMN_FAMILY: bigtable.MaxVersionsPolicy(1),
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure that table %q exists: %s", tableName, err)
+	}
+
+	client, err := bigtable.NewClient(ctx, project, instance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bigtable client: %s", err)
+	}
+
+	return &btClient{
+		client,
+		client.Open(tableName),
+	}, nil
+}

--- a/cmd/mt-index-deleter/main.go
+++ b/cmd/mt-index-deleter/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/grafana/metrictank/logger"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	formatter := &logger.TextFormatter{}
+	formatter.TimestampFormat = "2006-01-02 15:04:05.000"
+	log.SetFormatter(formatter)
+	log.SetLevel(log.InfoLevel)
+}
+
+func main() {
+	project := flag.String("gcp-project", "default", "Name of GCP project the bigtable cluster resides in")
+	instance := flag.String("bigtable-instance", "default", "Name of bigtable instance")
+	tableName := flag.String("bigtable-table", "metric_idx", "Name of bigtable table used for metricDefs")
+	concurrency := flag.Int("concurrency", 20, "number of concurrent delete workers")
+	batchSize := flag.Int("batch", 10, "batch size of each delete")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		fmt.Fprintln(flag.CommandLine.Output(), "reads rowkeys from stdin and deletes them from the index. only BigTable is supported right now")
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	btClient, err := NewBtClient(*project, *instance, *tableName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	deletes := make(chan string, *concurrency*8)
+	wg := &sync.WaitGroup{}
+
+	wg.Add(*concurrency)
+
+	workerStart = time.Now()
+
+	for i := 0; i < *concurrency; i++ {
+		go worker(wg, *btClient, *batchSize, deletes)
+	}
+
+	go func() {
+		for {
+			workerStats()
+			time.Sleep(time.Minute)
+		}
+	}()
+
+	read(os.Stdin, deletes)
+
+	log.Infof("finished reading input. waiting for all workers to finish...")
+	wg.Wait()
+	log.Infof("all workers finished. exiting")
+	workerStats()
+}
+
+func read(stream io.Reader, deletes chan string) {
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		rowKey := scanner.Text()
+		deletes <- rowKey
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+	close(deletes)
+}

--- a/cmd/mt-index-deleter/worker.go
+++ b/cmd/mt-index-deleter/worker.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	log "github.com/sirupsen/logrus"
+)
+
+var deleted uint64
+var workerStart time.Time
+
+func workerStats() {
+	dur := time.Since(workerStart)
+	del := atomic.LoadUint64(&deleted)
+	deletesPerSec := float64(del) / dur.Seconds()
+	log.Infof("workerstats: %d deleted in %v (%f deletes/s)", del, dur, deletesPerSec)
+
+}
+
+// deletes all keys seen on the channel, in batches of size batchSize
+// if an error occurs, it's printed and the function returns
+func worker(wg *sync.WaitGroup, c btClient, batchSize int, deletes chan string) {
+	defer wg.Done()
+	muts := make([]*bigtable.Mutation, 0, batchSize)
+	keys := make([]string, 0, batchSize)
+
+	flush := func() error {
+		if len(muts) == 0 {
+			return nil
+		}
+		errs, err := c.tbl.ApplyBulk(context.Background(), keys, muts)
+		l := len(muts)
+		muts = muts[:0]
+		keys = keys[:0]
+		if err != nil {
+			return err
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("saw %d errors. first one: %v", len(errs), errs[0])
+		}
+
+		atomic.AddUint64(&deleted, uint64(l))
+
+		return nil
+	}
+
+	for {
+		key, ok := <-deletes
+		if !ok {
+			log.Info("worker seeing deletes close. flushing last batch")
+			err := flush()
+			if err != nil {
+				log.Errorf("worker error: %v", err)
+			}
+			return
+		}
+		mut := bigtable.NewMutation()
+		mut.DeleteRow()
+		muts = append(muts, mut)
+		keys = append(keys, key)
+		if len(muts) == batchSize {
+			err := flush()
+			if err != nil {
+				log.Errorf("worker error: %v", err)
+				return
+			}
+		}
+	}
+}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -344,6 +344,26 @@ mt-index-cat -max-stale 768h -partitions 1,2,3 bt -gcp-project your_project -big
 ```
 
 
+## mt-index-deleter
+
+```
+Usage of ./mt-index-deleter:
+reads rowkeys from stdin and deletes them from the index. only BigTable is supported right now
+  -batch int
+    	batch size of each delete (default 10)
+  -bigtable-instance string
+    	Name of bigtable instance (default "default")
+  -bigtable-table string
+    	Name of bigtable table used for metricDefs (default "metric_idx")
+  -concurrency int
+    	number of concurrent delete workers (default 20)
+  -gcp-project string
+    	Name of GCP project the bigtable cluster resides in (default "default")
+  -log.level value
+    	Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal, panic].
+```
+
+
 ## mt-indexdump-rules-analyzer
 
 ```


### PR DESCRIPTION
deletes mkeys provided on stdin from bigtable index.

seems to work really fast, btw. first run was already super fast so i didn't even try to tweak the settings
```
/ # cat rowkeys.txt  | ./mt-index-deleter --gcp-project ... --bigtable-instance ...  --bigtable-table ... --batch 10000
2020-11-09 21:06:46.998 [INFO] bt-ensure-table-exists: table "..." exists.
INFO[0000] workerstats: 0 deleted in 50.158µs (0.000000 deletes/s)  file=worker.go line=21
INFO[0060] workerstats: 9350000 deleted in 1m0.000188811s (155832.842951 deletes/s)  file=worker.go line=21
INFO[0120] workerstats: 17470000 deleted in 2m0.000373848s (145582.879784 deletes/s)  file=worker.go line=21
```
