### PR TITLE
timeShift function: adequately set QueryFrom/QueryTo on output series 

### DIFF
--- a/expr/func_timeshift.go
+++ b/expr/func_timeshift.go
@@ -71,6 +71,8 @@ func (s *FuncTimeShift) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 
 		serie.Target = newName(serie.Target)
+		serie.QueryFrom = uint32(int(serie.QueryFrom) + negativeOffset)
+		serie.QueryTo = uint32(int(serie.QueryTo) + negativeOffset)
 		serie.QueryPatt = newName(serie.QueryPatt)
 		serie.Tags = serie.CopyTagsWith("timeShift", s.timeShift)
 		serie.Datapoints = out

--- a/expr/func_timeshift_test.go
+++ b/expr/func_timeshift_test.go
@@ -134,6 +134,13 @@ func TestTimeShiftPositive(t *testing.T) {
 }
 
 func testTimeShift(name string, in []models.Series, out []models.Series, t *testing.T, expectedOffset int, shift string, resetEnd, alignDST bool) {
+	for i := range in {
+		in[i].QueryFrom = in[i].Datapoints[0].Ts
+		in[i].QueryTo = in[i].Datapoints[len(in[i].Datapoints)-1].Ts
+		out[i].QueryFrom = uint32(int(in[i].QueryFrom) - expectedOffset)
+		out[i].QueryTo = uint32(int(in[i].QueryTo) - expectedOffset)
+	}
+
 	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
 
 	f := NewTimeShift()


### PR DESCRIPTION
`timeShift` function: adequately set QueryFrom/QueryTo on output series (a5144cd) which were previously passed as is.
The unit tests were updated to check on that (b225ccb) which also required moving and generalising the check for input not being changed by the function execution (0bdd9e0)

Fix #1939