### PR TITLE
Add verbose CheckedClean to prevent point slice overlap

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -316,7 +316,7 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 	execCtx, execSpan := tracing.NewSpan(ctx.Req.Context(), s.Tracer, "executePlan")
 	defer execSpan.Finish()
 	out, meta, err := s.executePlan(execCtx, ctx.OrgId, &plan)
-	defer plan.Clean()
+	defer plan.CheckedClean(request.Targets)
 	if err != nil {
 		err := response.WrapError(err)
 		if err.HTTPStatusCode() == http.StatusBadRequest && !request.NoProxy && proxyBadRequests {


### PR DESCRIPTION
We still see some cases where we get overlapping point slices. Adding a checked version of clean that will not double return in this case *and* will output some useful information that can help us track down the issues.