### PR TITLE
Fix set tags for complex targets

### DIFF
--- a/api/models/series.go
+++ b/api/models/series.go
@@ -120,7 +120,8 @@ func (a SeriesMeta) CopyWithChange(fn func(in SeriesMetaProperties) SeriesMetaPr
 // SetTags fills in the Tags property with tags parsed out of s.Target
 // the "name" tag is always set from s.Target, overriding any attempted override
 func (s *Series) SetTags() {
-	numTags := strings.Count(s.Target, ";")
+	lastClosingParenthesis := strings.LastIndexByte(s.Target, ')')
+	numTags := strings.Count(s.Target[lastClosingParenthesis+1:], ";")
 
 	if s.Tags == nil {
 		// +1 for the name tag

--- a/api/models/series_test.go
+++ b/api/models/series_test.go
@@ -132,6 +132,14 @@ func TestSetTags(t *testing.T) {
 		},
 		{
 			in: Series{
+				Target: "func(a;b=c,d;e=f)",
+			},
+			out: map[string]string{
+				"name": "func(a;b=c,d;e=f)",
+			},
+		},
+		{
+			in: Series{
 				Target: "a;biglongtagkeyhere=andithasabiglongtagvaluetoo;c=d",
 			},
 			out: map[string]string{


### PR DESCRIPTION
When a target is more complex than just containing a raw series, ie. when it contains at least one function, then `SetTags` should consider as tags only the tag expressions (ie. `;tag=value`) that are found after the end of the last function of the target.

Fix #1917