### PR TITLE
track non-primary rollup reads

### DIFF
--- a/consolidation/consolidation.go
+++ b/consolidation/consolidation.go
@@ -12,6 +12,8 @@ import (
 
 // consolidator is a highlevel description of a point consolidation method
 // mostly for use by the http api, but can also be used internally for data processing
+// note that the set of legal values is a superset of conf.Method, so you can cast from
+// conf.Method to Consolidator, but not back.
 //go:generate msgp
 type Consolidator int
 


### PR DESCRIPTION
multiple rollups is not a standard graphite feature
Tracking usage is a good signal that may help future conversations about
becoming more graphite-like.

Fix #57