### PR TITLE
Return 403 instead of 413 when limit exceeded

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -171,7 +171,7 @@ MainLoop:
 						leavesInResp++
 						if maxSeries > 0 && leavesTotal > maxSeries {
 							return nil, response.NewError(
-								http.StatusRequestEntityTooLarge,
+								http.StatusForbidden,
 								fmt.Sprintf("Request exceeds max-series-per-req limit (%d). Reduce the number of targets or ask your admin to increase the limit.", maxSeriesPerReq))
 						}
 					} else if leavesOnly {
@@ -929,7 +929,7 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan)
 		// if we already breached the limit, no point in doing any further finds
 		if int(reqs.cnt) > maxSeriesPerReq {
 			return nil, meta, response.NewError(
-				http.StatusRequestEntityTooLarge,
+				http.StatusForbidden,
 				fmt.Sprintf("Request exceeds max-series-per-req limit (%d). Reduce the number of targets or ask your admin to increase the limit.", maxSeriesPerReq))
 		}
 
@@ -1277,7 +1277,7 @@ func (s *Server) clusterFindByTag(ctx context.Context, orgId uint32, expressions
 			}
 			return nil,
 				response.NewError(
-					http.StatusRequestEntityTooLarge,
+					http.StatusForbidden,
 					fmt.Sprintf("Request exceeds max-series-per-req limit (%d). Reduce the number of targets or ask your admin to increase the limit.", maxSeriesPerReq))
 		}
 

--- a/api/query_engine.go
+++ b/api/query_engine.go
@@ -26,7 +26,7 @@ var (
 	reqRenderPointsReturned = stats.NewMeter32("api.request.render.points_returned", false)
 
 	errUnSatisfiable   = response.NewError(http.StatusNotFound, "request cannot be satisfied due to lack of available retentions")
-	errMaxPointsPerReq = response.NewError(http.StatusRequestEntityTooLarge, "request exceeds max-points-per-req-hard limit. Reduce the time range or number of targets or ask your admin to increase the limit.")
+	errMaxPointsPerReq = response.NewError(http.StatusForbidden, "request exceeds max-points-per-req-hard limit. Reduce the time range or number of targets or ask your admin to increase the limit.")
 )
 
 // planRequests updates the requests with all details for fetching.


### PR DESCRIPTION
HTTP response code 413 should be per RFC7231 returned when request
payload is too large and not when request causes dataset too large to process.

HTTP response 403 Forbidden is more appropriate here as it means that
server understood the request, but is refusing to fulfill it.

Closes: #1969