### PR TITLE
Reduce non-primary rollup log spew

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -918,11 +918,11 @@ func (s *Server) executePlan(ctx context.Context, orgId uint32, plan *expr.Plan)
 					metaTagEnrichmentData[metric.Defs[0].NameWithTags()] = metric.MetaTags
 				}
 			}
+		}
 
-			if len(nonPrimaryRollups) > 0 {
-				for tuple, cnt := range nonPrimaryRollups {
-					log.Infof("API: query uses non-primary rollup. orgid=%d query=%q primary=%q used=%q cnt=%d", orgId, r.Query, tuple.primary, tuple.used, cnt)
-				}
+		if len(nonPrimaryRollups) > 0 {
+			for tuple, cnt := range nonPrimaryRollups {
+				log.Infof("API: query uses non-primary rollup. orgid=%d query=%q primary=%q used=%q cnt=%d", orgId, r.Query, tuple.primary, tuple.used, cnt)
 			}
 		}
 


### PR DESCRIPTION
Looks like this log line is in the wrong for loop, so it ends up spewing for requests with many series with `cnt` going up by one each time.