### PR TITLE
Render format csv

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -359,6 +359,8 @@ func (s *Server) renderMetrics(ctx *middleware.Context, request models.GraphiteR
 		response.Write(ctx, response.NewMsgpack(200, models.SeriesByTarget(out).ForGraphite("msgpack")))
 	case "pickle":
 		response.Write(ctx, response.NewPickle(200, models.SeriesByTarget(out)))
+	case "csv":
+		response.Write(ctx, response.NewCsv(200, models.SeriesByTarget(out)))
 	default:
 		if request.Meta {
 			response.Write(ctx, response.NewFastJson(200, models.ResponseWithMeta{Series: models.SeriesByTarget(out), Meta: meta}))

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -51,7 +51,7 @@ type GraphiteRender struct {
 	MaxDataPoints uint32   `json:"maxDataPoints" form:"maxDataPoints" binding:"Default(800)"`
 	Targets       []string `json:"target" form:"target"`
 	TargetsRails  []string `form:"target[]"` // # Rails/PHP/jQuery common practice format: ?target[]=path.1&target[]=path.2 -> like graphite, we allow this.
-	Format        string   `json:"format" form:"format" binding:"In(,json,msgp,msgpack,pickle)"`
+	Format        string   `json:"format" form:"format" binding:"In(,json,csv,msgp,msgpack,pickle)"`
 	NoProxy       bool     `json:"local" form:"local"` //this is set to true by graphite-web when it passes request to cluster servers
 	Meta          bool     `json:"meta" form:"meta"`   // request for meta data, which will be returned as long as the format is compatible (json) and we don't have to go via graphite
 	Process       string   `json:"process" form:"process" binding:"In(,none,stable,any);Default(stable)"`

--- a/api/response/csv.go
+++ b/api/response/csv.go
@@ -1,0 +1,37 @@
+package response
+
+type Csvable interface {
+	Csv([]byte) ([]byte, error)
+}
+
+type Csv struct {
+	code int
+	body Csvable
+	buf  []byte
+}
+
+func NewCsv(code int, body Csvable) *Csv {
+	return &Csv{
+		code: code,
+		body: body,
+		buf:  BufferPool.Get(),
+	}
+}
+
+func (r *Csv) Code() int {
+	return r.code
+}
+
+func (r *Csv) Close() {
+	BufferPool.Put(r.buf)
+}
+
+func (r *Csv) Body() ([]byte, error) {
+	var err error
+	r.buf, err = r.body.Csv(r.buf)
+	return r.buf, err
+}
+
+func (r *Csv) Headers() (headers map[string]string) {
+	return map[string]string{"content-type": "text/csv"}
+}

--- a/api/response/csv_test.go
+++ b/api/response/csv_test.go
@@ -1,0 +1,135 @@
+package response
+
+import (
+	"math"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+)
+
+func TestCsv(t *testing.T) {
+	for _, c := range testSeries() {
+		w := httptest.NewRecorder()
+		Write(w, NewCsv(200, models.SeriesByTarget(c.in)))
+		got := w.Body.String()
+		if c.outCsv != got {
+			t.Fatalf("bad csv output.\nexpected:%s\ngot:%s\n", c.outCsv, got)
+		}
+	}
+}
+
+func BenchmarkHttpRespCsvEmptySeries(b *testing.B) {
+	data := []models.Series{
+		{
+			Target:     "an.empty.series",
+			Datapoints: make([]schema.Point, 0),
+			Interval:   10,
+		},
+	}
+	var resp *Csv
+	for n := 0; n < b.N; n++ {
+		resp = NewCsv(200, models.SeriesByTarget(data))
+		body, _ := resp.Body()
+		size = len(body)
+		resp.Close()
+	}
+	b.Log("body size", size)
+}
+
+func BenchmarkHttpRespCsvEmptySeriesNeedsEscaping(b *testing.B) {
+	data := []models.Series{
+		{
+			Target:     `an.empty\series`,
+			Datapoints: make([]schema.Point, 0),
+			Interval:   10,
+		},
+	}
+	var resp *Csv
+	for n := 0; n < b.N; n++ {
+		resp = NewCsv(200, models.SeriesByTarget(data))
+		body, _ := resp.Body()
+		size = len(body)
+		resp.Close()
+	}
+	b.Log("body size", size)
+}
+
+func BenchmarkHttpRespCsvIntegers(b *testing.B) {
+	points := make([]schema.Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		points[i] = schema.Point{Val: float64(10000 * i), Ts: uint32(baseTs + 10*i)}
+	}
+	data := []models.Series{
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.integers",
+			Datapoints: points,
+			Interval:   10,
+		},
+	}
+	b.SetBytes(int64(len(points) * 12))
+
+	b.ResetTimer()
+	var resp *Csv
+	for n := 0; n < b.N; n++ {
+		resp = NewCsv(200, models.SeriesByTarget(data))
+		body, _ := resp.Body()
+		size = len(body)
+		resp.Close()
+	}
+	b.Log("body size", size)
+}
+
+func BenchmarkHttpRespCsvFloats(b *testing.B) {
+	points := make([]schema.Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		points[i] = schema.Point{Val: 12.34 * float64(i), Ts: uint32(baseTs + 10*i)}
+	}
+	data := []models.Series{
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.floats",
+			Datapoints: points,
+			Interval:   10,
+		},
+	}
+	b.SetBytes(int64(len(points) * 12))
+
+	b.ResetTimer()
+	var resp *Csv
+	for n := 0; n < b.N; n++ {
+		resp = NewCsv(200, models.SeriesByTarget(data))
+		body, _ := resp.Body()
+		size = len(body)
+		resp.Close()
+	}
+	b.Log("body size", size)
+}
+
+func BenchmarkHttpRespCsvNulls(b *testing.B) {
+	points := make([]schema.Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		points[i] = schema.Point{Val: math.NaN(), Ts: uint32(baseTs + 10*i)}
+	}
+	data := []models.Series{
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.nulls",
+			Datapoints: points,
+			Interval:   10,
+		},
+	}
+	b.SetBytes(int64(len(points) * 12))
+
+	b.ResetTimer()
+	var resp *Csv
+	for n := 0; n < b.N; n++ {
+		resp = NewCsv(200, models.SeriesByTarget(data))
+		body, _ := resp.Body()
+		size = len(body)
+		resp.Close()
+	}
+	b.Log("body size", size)
+}

--- a/api/response/response_test.go
+++ b/api/response/response_test.go
@@ -1,6 +1,8 @@
 package response
 
 import (
+	"math"
+
 	"github.com/grafana/metrictank/api/models"
 	"github.com/grafana/metrictank/schema"
 )
@@ -57,7 +59,7 @@ func testSeries() []series {
 					Target: "foo(bar)",
 					Datapoints: []schema.Point{
 						{123.456, 10},
-						{123.7, 20},
+						{math.NaN(), 20},
 						{124.10, 30},
 						{125.0, 40},
 						{126.0, 50},
@@ -65,7 +67,7 @@ func testSeries() []series {
 					Interval: 10,
 				},
 			},
-			out: `[{"target":"a","datapoints":[[123,60],[10000,120],[0,180],[1,240]]},{"target":"foo(bar)","datapoints":[[123.456,10],[123.7,20],[124.1,30],[125,40],[126,50]]}]`,
+			out: `[{"target":"a","datapoints":[[123,60],[10000,120],[0,180],[1,240]]},{"target":"foo(bar)","datapoints":[[123.456,10],[null,20],[124.1,30],[125,40],[126,50]]}]`,
 		},
 	}
 	return cases

--- a/api/response/response_test.go
+++ b/api/response/response_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 type series struct {
-	in  []models.Series
-	out string
+	in     []models.Series
+	out    string
+	outCsv string
 }
 
 func testSeries() []series {
@@ -26,7 +27,8 @@ func testSeries() []series {
 					Interval:   60,
 				},
 			},
-			out: `[{"target":"a","datapoints":[]}]`,
+			out:    `[{"target":"a","datapoints":[]}]`,
+			outCsv: ``,
 		},
 		{
 			in: []models.Series{
@@ -42,6 +44,11 @@ func testSeries() []series {
 				},
 			},
 			out: `[{"target":"a","datapoints":[[123,60],[10000,120],[0,180],[1,240]]}]`,
+			outCsv: `a,1970-01-01 00:01:00,123
+a,1970-01-01 00:02:00,10000
+a,1970-01-01 00:03:00,0
+a,1970-01-01 00:04:00,1
+`,
 		},
 		{
 			in: []models.Series{
@@ -68,6 +75,16 @@ func testSeries() []series {
 				},
 			},
 			out: `[{"target":"a","datapoints":[[123,60],[10000,120],[0,180],[1,240]]},{"target":"foo(bar)","datapoints":[[123.456,10],[null,20],[124.1,30],[125,40],[126,50]]}]`,
+			outCsv: `a,1970-01-01 00:01:00,123
+a,1970-01-01 00:02:00,10000
+a,1970-01-01 00:03:00,0
+a,1970-01-01 00:04:00,1
+foo(bar),1970-01-01 00:00:10,123.456
+foo(bar),1970-01-01 00:00:20,
+foo(bar),1970-01-01 00:00:30,124.1
+foo(bar),1970-01-01 00:00:40,125
+foo(bar),1970-01-01 00:00:50,126
+`,
 		},
 	}
 	return cases

--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -13,7 +13,7 @@ There are some small behavioral and functional differences with Graphite:
 * Graphite timezone defaults to Chicago, we default to server time
 * xFilesfactor is currently not supported for rollups. It is fairly easy to address, but we haven't had a need for it yet.
 * Graphite supports the following render formats: csv, json, dygraph, msgpack, pickle, png, pdf, raw, rickshaw, and svg.
-  Metrictank only implements json, msgp, msgpack, and pickle. Grafana only uses json. In particular, Metrictank does not render images, because Grafana renders great.
+  Metrictank only implements json, msgp, msgpack, csv and pickle. Grafana only uses json. In particular, Metrictank does not render images, because Grafana renders great.
 * Some less commonly used functions are not implemented yet in Metrictank itself, but Metrictank can seamlessly proxy those to graphite-web (see below for details)
   At Grafana Labs, 95 to 99 % of requests get handled by Metrictank without involving Graphite.
 * perl-style regex (pcre) are not supported in functions such as aliasSub, and if used, will return an error like so

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -250,7 +250,7 @@ POST /render
 * target: mandatory. one or more metric names or patterns, like graphite.
 * from: see [timespec format](#tspec) (default: 24h ago) (exclusive)
 * to/until : see [timespec format](#tspec)(default: now) (inclusive)
-* format: json, msgp, pickle, or msgpack (default: json). (note: msgp and msgpack are similar, but msgpack is for use with graphite)
+* format: json, msgp, pickle, csv or msgpack (default: json). (note: msgp and msgpack are similar, but msgpack is for use with graphite)
 * meta: use 'meta=true' to enable metadata in response (see below). Only supported for json responses.
 * process: all, stable, none (default: stable). Controls metrictank's eagerness of fulfilling the request with its built-in processing functions
   (as opposed to proxying to the fallback graphite).

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -251,7 +251,7 @@ POST /render
 * from: see [timespec format](#tspec) (default: 24h ago) (exclusive)
 * to/until : see [timespec format](#tspec)(default: now) (inclusive)
 * format: json, msgp, pickle, or msgpack (default: json). (note: msgp and msgpack are similar, but msgpack is for use with graphite)
-* meta: use 'meta=true' to enable metadata in response (see below).
+* meta: use 'meta=true' to enable metadata in response (see below). Only supported for json responses.
 * process: all, stable, none (default: stable). Controls metrictank's eagerness of fulfilling the request with its built-in processing functions
   (as opposed to proxying to the fallback graphite).
   - all: process request without fallback if we have all the needed functions, even if they are marked unstable (under development)
@@ -271,7 +271,7 @@ curl -H "X-Org-Id: 12345" "http://localhost:6060/render?target=statsd.fakesite.c
 
 #### Metadata
 
-The metadata of a render response (provided when `meta=true` is passed), includes:
+The metadata of a render response (provided when `meta=true` is passed and format is json), includes:
 
 * response global performance measurements
 * series-specific lineage information describing storage-schemas, read archive, archive interval and any consolidation and normalization applied.


### PR DESCRIPTION
most of the code is copy pasted from the json and pickle format (e.g. all the benchmarking boilerplate), so this should be easy to review (just focus on the csv specific bits)

tested with docker-dev. seems to work fine.
```
$ curl 'http://localhost:6060/render?target=metrictank.stats.docker-env.default.tank.metrics_active.gauge32&from=-10s&format=csv' 
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:46:54,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:46:55,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:46:56,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:46:57,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:46:58,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:46:59,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:47:00,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:47:01,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:47:02,614
metrictank.stats.docker-env.default.tank.metrics_active.gauge32,2021-05-04 12:47:03,614
$ curl 'http://localhost:6060/render?target=metrictank.stats.docker-env.default.tank.metrics_active.gauge32&from=-10s&format=json'
[{"target":"metrictank.stats.docker-env.default.tank.metrics_active.gauge32","tags":{"name":"metrictank.stats.docker-env.default.tank.metrics_active.gauge32"},"datapoints":[[614,1620132414],[614,1620132415],[614,1620132416],[614,1620132417],[614,1620132418],[614,1620132419],[614,1620132420],[614,1620132421],[614,1620132422],[614,1620132423]]}]
```