### PR TITLE
Set Host header for graphite-proxied requests to graphite host, not incoming host header

### DIFF
--- a/api/graphite_proxy.go
+++ b/api/graphite_proxy.go
@@ -41,6 +41,14 @@ func (s *graphiteProxyStats) Miss(fun string) {
 
 func NewGraphiteProxy(u *url.URL) *httputil.ReverseProxy {
 	graphiteProxy := httputil.NewSingleHostReverseProxy(u)
+
+	// workaround for net/http/httputil issue https://github.com/golang/go/issues/28168
+	originalDirector := graphiteProxy.Director
+	graphiteProxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Host = req.URL.Host
+	}
+
 	// remove these headers from upstream. we will set our own correct ones
 	graphiteProxy.ModifyResponse = func(resp *http.Response) error {
 		// if kept, would be duplicated. and duplicated headers are illegal)


### PR DESCRIPTION
Due to [an unresolved issue in the `net/http/httputil` package](https://github.com/golang/go/issues/28168), Metrictrank can't reach a Graphite-Web fallback hosted behind an AWS application load balancer configured to route requests based on their host header.

The request's `Host` attribute, sent by Metrictank and read by the application load balancer, should match the request's `URL.Host` attribute to be correctly routed.

Currently, the `Host` attribute is set to the original request's host (the request made to Metrictank, which need to be proxified to Graphite).

This workaround replace the request's *bad* `Host` attribute with the expected value stored in `URL.Host` attribute.