### PR TITLE
QOL: sort JSON on metrics/find API endpoint

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -676,6 +676,7 @@ func FindTreejson(query string, nodes []idx.Node) models.SeriesTree {
 		}
 		tree.Add(&t)
 	}
+	sort.Sort(models.SeriesTree(tree))
 	return tree
 }
 

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -289,6 +289,10 @@ func NewSeriesPickleItem(path string, isLeaf bool, intervals [][]int64) SeriesPi
 
 type SeriesTree []SeriesTreeItem
 
+func (s SeriesTree) Len() int           { return len(s) }
+func (s SeriesTree) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s SeriesTree) Less(i, j int) bool { return s[i].Text < s[j].Text }
+
 func (s *SeriesTree) Add(i *SeriesTreeItem) {
 	*s = append(*s, *i)
 }


### PR DESCRIPTION
This quality of life PR aims to sort the JSON returned by the `metrics/find` API endpoint, as the original Graphite-Web API.

The sort algorithm uses the `Text` field of each `SeriesTree` item.

Thus, the metrics tree appears alphabetically sorted on frontends like Grafana while exploring metrics or editing visualizations.