### PR TITLE
Add SASL Plaintext support to kafka

### DIFF
--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -318,7 +318,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -426,7 +426,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -318,7 +318,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -426,7 +426,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -318,7 +318,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -426,7 +426,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -318,7 +318,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -426,7 +426,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/docs/config.md
+++ b/docs/config.md
@@ -375,7 +375,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -492,7 +492,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -583,7 +583,7 @@ Flags:
   -sasl-enabled
     	Whether to enable SASL
   -sasl-mechanism string
-    	The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+    	The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
   -sasl-password string
     	Password for client authentication (use with -sasl-enabled and -sasl-user)
   -sasl-username string

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -91,7 +91,7 @@ func ConfigSetup() {
 	inKafkaMdm.StringVar(&tlsClientCert, "tls-client-cert", "", "Client cert for client authentication (use with -tls-enabled and -tls-client-key)")
 	inKafkaMdm.StringVar(&tlsClientKey, "tls-client-key", "", "Client key for client authentication (use with -tls-enabled and -tls-client-cert)")
 	inKafkaMdm.BoolVar(&saslEnabled, "sasl-enabled", false, "Whether to enable SASL")
-	inKafkaMdm.StringVar(&saslMechanism, "sasl-mechanism", "", "The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)")
+	inKafkaMdm.StringVar(&saslMechanism, "sasl-mechanism", "", "The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)")
 	inKafkaMdm.StringVar(&saslUsername, "sasl-username", "", "Username for client authentication (use with -sasl-enabled and -sasl-password)")
 	inKafkaMdm.StringVar(&saslPassword, "sasl-password", "", "Password for client authentication (use with -sasl-enabled and -sasl-user)")
 	globalconf.Register("kafka-mdm-in", inKafkaMdm, flag.ExitOnError)
@@ -156,6 +156,8 @@ func ConfigProcess(instance string) {
 		} else if saslMechanism == "SCRAM-SHA-512" {
 			config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+		} else if saslMechanism == "PLAINTEXT" {
+			config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		} else {
 			log.Fatalf("Failed to reconize saslMechanism: '%s'", saslMechanism)
 		}

--- a/mdata/notifierKafka/cfg.go
+++ b/mdata/notifierKafka/cfg.go
@@ -61,7 +61,7 @@ func init() {
 	FlagSet.StringVar(&tlsClientCert, "tls-client-cert", "", "Client cert for client authentication (use with -tls-enabled and -tls-client-key)")
 	FlagSet.StringVar(&tlsClientKey, "tls-client-key", "", "Client key for client authentication (use with -tls-enabled and -tls-client-cert)")
 	FlagSet.BoolVar(&saslEnabled, "sasl-enabled", false, "Whether to enable SASL")
-	FlagSet.StringVar(&saslMechanism, "sasl-mechanism", "", "The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)")
+	FlagSet.StringVar(&saslMechanism, "sasl-mechanism", "", "The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)")
 	FlagSet.StringVar(&saslUsername, "sasl-username", "", "Username for client authentication (use with -sasl-enabled and -sasl-password)")
 	FlagSet.StringVar(&saslPassword, "sasl-password", "", "Password for client authentication (use with -sasl-enabled and -sasl-user)")
 	globalconf.Register("kafka-cluster", FlagSet, flag.ExitOnError)
@@ -115,6 +115,8 @@ func ConfigProcess(instance string) {
 		} else if saslMechanism == "SCRAM-SHA-512" {
 			config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+		} else if saslMechanism == "PLAINTEXT" {
+			config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
 		} else {
 			log.Fatalf("Failed to reconize saslMechanism: '%s'", saslMechanism)
 		}

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -321,7 +321,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -429,7 +429,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -318,7 +318,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -426,7 +426,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -318,7 +318,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -426,7 +426,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -318,7 +318,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =
@@ -426,7 +426,7 @@ tls-client-cert =
 tls-client-key =
 # Whether to enable SASL
 sasl-enabled = false
-# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512)
+# The SASL mechanism configuration (possible values: SCRAM-SHA-256, SCRAM-SHA-512, PLAINTEXT)
 sasl-mechanism =
 # Username for client authentication (use with -sasl-enabled and -sasl-password)
 sasl-username =


### PR DESCRIPTION
Hi,
this PR implements support for the sasl mechanism plaintext.

The changes are pretty small and i've tested it with our kafka clusters which are using sasl plaintext.

If you have any questions just let me know. 