### PR TITLE
storage-aggregation.conf parsing fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -319,6 +319,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:9ed757cafe0929abbd54fba5b5e50450b22b037bc3858e03cb975ea3214be333"
+  name = "github.com/grafana/configparser"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "f5c9e475c7f0f1f8ea64b45bd9c1d226d01d391f"
+
+[[projects]]
+  branch = "master"
   digest = "1:817bb03ae4cb923f024602aa1753f1dcea87c83e10fb3a175ca4fa7a088b1cc7"
   name = "github.com/grafana/globalconf"
   packages = ["."]
@@ -1217,6 +1225,7 @@
     "github.com/golang/snappy",
     "github.com/google/go-cmp/cmp",
     "github.com/gosuri/uilive",
+    "github.com/grafana/configparser",
     "github.com/grafana/globalconf",
     "github.com/hailocab/go-hostpool",
     "github.com/hashicorp/golang-lru",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -318,12 +318,11 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:9ed757cafe0929abbd54fba5b5e50450b22b037bc3858e03cb975ea3214be333"
+  digest = "1:01379e9ffd4d4756068566b7ee3834165301dde52dd41ad3f3addf4e4cf3417c"
   name = "github.com/grafana/configparser"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "f5c9e475c7f0f1f8ea64b45bd9c1d226d01d391f"
+  revision = "7fdb7669f3ec55c350a5b35e35c5f7c559de0060"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,6 +46,10 @@ unused-packages = true
   branch = "master"
 
 [[constraint]]
+  name = "github.com/grafana/configparser"
+  revision = "7fdb7669f3ec55c350a5b35e35c5f7c559de0060"
+
+[[constraint]]
   name = "github.com/davecgh/go-spew"
   version = "1.1.0"
 

--- a/conf/aggregations.go
+++ b/conf/aggregations.go
@@ -65,20 +65,24 @@ func ReadAggregations(file string) (Aggregations, error) {
 			return Aggregations{}, fmt.Errorf("[%s]: missing pattern", item.Name)
 		}
 
-		item.Pattern, err = regexp.Compile(s.ValueOf("pattern"))
+		// people may want to use # and ; in general as part of the metric name and regex (not a good idea but that's up to them)
+		// but seems safe to assume that ' ;' and ' #' initiate a comment
+		patt := s.ValueOfWithoutComments("pattern")
+		item.Pattern, err = regexp.Compile(patt)
 		if err != nil {
-			return Aggregations{}, fmt.Errorf("[%s]: failed to parse pattern %q: %s", item.Name, s.ValueOf("pattern"), err.Error())
+			return Aggregations{}, fmt.Errorf("[%s]: failed to parse pattern %q: %s", item.Name, patt, err.Error())
 		}
 
 		if s.Exists("xFilesFactor") {
-			item.XFilesFactor, err = strconv.ParseFloat(s.ValueOf("xFilesFactor"), 64)
+			xff := s.ValueOfWithoutComments("xFilesFactor")
+			item.XFilesFactor, err = strconv.ParseFloat(xff, 64)
 			if err != nil {
-				return Aggregations{}, fmt.Errorf("[%s]: failed to parse xFilesFactor %q: %s", item.Name, s.ValueOf("xFilesFactor"), err.Error())
+				return Aggregations{}, fmt.Errorf("[%s]: failed to parse xFilesFactor %q: %s", item.Name, xff, err.Error())
 			}
 		}
 
 		if s.Exists("aggregationMethod") {
-			aggregationMethodStr := s.ValueOf("aggregationMethod")
+			aggregationMethodStr := s.ValueOfWithoutComments("aggregationMethod")
 			methodStrs := strings.Split(aggregationMethodStr, ",")
 			item.AggregationMethod = []Method{}
 			for _, methodStr := range methodStrs {

--- a/conf/aggregations.go
+++ b/conf/aggregations.go
@@ -10,11 +10,13 @@ import (
 	"github.com/grafana/configparser"
 )
 
-var defaultAggregation = Aggregation{
-	Name:              "default",
-	Pattern:           regexp.MustCompile(".*"),
-	XFilesFactor:      0.5,
-	AggregationMethod: []Method{Avg},
+func defaultAggregation() Aggregation {
+	return Aggregation{
+		Name:              "default",
+		Pattern:           regexp.MustCompile(".*"),
+		XFilesFactor:      0.5,
+		AggregationMethod: []Method{Avg},
+	}
 }
 
 // Aggregations holds the aggregation definitions
@@ -34,7 +36,7 @@ type Aggregation struct {
 func NewAggregations() Aggregations {
 	return Aggregations{
 		Data:               make([]Aggregation, 0),
-		DefaultAggregation: defaultAggregation,
+		DefaultAggregation: defaultAggregation(),
 	}
 }
 
@@ -53,10 +55,7 @@ func ReadAggregations(file string) (Aggregations, error) {
 	result := NewAggregations()
 
 	for _, s := range sections {
-		item := Aggregation{
-			XFilesFactor:      0.5,
-			AggregationMethod: []Method{Avg},
-		}
+		item := defaultAggregation()
 		item.Name = s.Name()
 		if item.Name == "" {
 			return Aggregations{}, errors.New("encountered a storage-aggregation.conf section name with empty name")

--- a/conf/aggregations.go
+++ b/conf/aggregations.go
@@ -116,8 +116,8 @@ func (a Aggregations) Get(i uint16) Aggregation {
 	return a.Data[i]
 }
 
-func (a Aggregations) Equals(b Aggregations) bool {
-	if !a.DefaultAggregation.Equals(b.DefaultAggregation) {
+func (a Aggregations) Equal(b Aggregations) bool {
+	if !a.DefaultAggregation.Equal(b.DefaultAggregation) {
 		return false
 	}
 
@@ -126,14 +126,14 @@ func (a Aggregations) Equals(b Aggregations) bool {
 	}
 
 	for i := range a.Data {
-		if !a.Data[i].Equals(b.Data[i]) {
+		if !a.Data[i].Equal(b.Data[i]) {
 			return false
 		}
 	}
 	return true
 }
 
-func (a Aggregation) Equals(b Aggregation) bool {
+func (a Aggregation) Equal(b Aggregation) bool {
 	if a.Name != b.Name || a.Pattern.String() != b.Pattern.String() {
 		return false
 	}

--- a/conf/aggregations_test.go
+++ b/conf/aggregations_test.go
@@ -1,0 +1,271 @@
+package conf
+
+import (
+	"io/ioutil"
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestReadAggregations(t *testing.T) {
+	type testCase struct {
+		title  string
+		in     string
+		expAgg Aggregations
+		expErr bool
+	}
+
+	testCases := []testCase{
+		{
+			title:  "completely empty", // should result in just the default
+			in:     "",
+			expErr: false,
+			expAgg: NewAggregations(),
+		},
+		{
+			title:  "empty name ",
+			in:     `[]`,
+			expErr: true,
+		},
+		{
+			title: "bad name format",
+			in: `foo[]
+			`,
+			expErr: true,
+		},
+		{
+			title: "missing pattern",
+			in: `[foo]
+			`,
+			expErr: true,
+		},
+		{
+			title: "invalid pattern",
+			in: `[foo]
+			pattern = "((("`,
+			expErr: true,
+		},
+		{
+			title: "defaults",
+			in: `[foo]
+			pattern = foo.*`,
+			expErr: false,
+			expAgg: Aggregations{
+				Data: []Aggregation{
+					{
+						Name:              "foo",
+						Pattern:           regexp.MustCompile("foo.*"),
+						XFilesFactor:      0.5,
+						AggregationMethod: []Method{Avg},
+					},
+				},
+				DefaultAggregation: defaultAggregation,
+			},
+		},
+		{
+			title: "grafanacloud_default",
+			in: `[default]
+pattern = .*
+xFilesFactor = 0.1
+aggregationMethod = avg,sum`,
+			expErr: false,
+			expAgg: Aggregations{
+				Data: []Aggregation{
+					{
+						Name:              "default",
+						Pattern:           regexp.MustCompile(".*"),
+						XFilesFactor:      0.1,
+						AggregationMethod: []Method{Avg, Sum},
+					},
+				},
+				DefaultAggregation: defaultAggregation,
+			},
+		},
+		{
+			title: "graphite upstream storage-aggregation.conf example",
+			in: `
+# Aggregation methods for whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds
+#
+#  [name]
+#  pattern = <regex>
+#  xFilesFactor = <float between 0 and 1>
+#  aggregationMethod = <average|sum|last|max|min>
+#
+#  name: Arbitrary unique name for the rule
+#  pattern: Regex pattern to match against the metric name
+#  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
+#  aggregationMethod: function to apply to data points for aggregation
+#
+[min]
+pattern = \.min$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.max$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[sum]
+pattern = \.count$
+xFilesFactor = 0
+# for monotonically increasing counters
+aggregationMethod = max
+# for counters that reset every interval (statsd-style)
+#aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.5
+aggregationMethod = average
+			`,
+			expErr: false,
+			expAgg: Aggregations{
+				Data: []Aggregation{
+					{
+						Name:              "min",
+						Pattern:           regexp.MustCompile("\\.min$"),
+						XFilesFactor:      0.1,
+						AggregationMethod: []Method{Min},
+					},
+					{
+						Name:              "max",
+						Pattern:           regexp.MustCompile("\\.max$"),
+						XFilesFactor:      0.1,
+						AggregationMethod: []Method{Max},
+					},
+					{
+						Name:              "sum",
+						Pattern:           regexp.MustCompile("\\.count$"),
+						XFilesFactor:      0,
+						AggregationMethod: []Method{Max},
+					},
+					{
+						Name:              "default_average",
+						Pattern:           regexp.MustCompile(".*"),
+						XFilesFactor:      0.5,
+						AggregationMethod: []Method{Avg},
+					},
+				},
+				DefaultAggregation: defaultAggregation,
+			},
+		},
+		{
+			title: "graphite upstream default storage-aggregation.conf",
+			in: `
+		# Aggregation methods for whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds
+#
+#  [name]
+#  pattern = <regex>
+#  xFilesFactor = <float between 0 and 1>
+#  aggregationMethod = <average|sum|last|max|min>
+#
+#  name: Arbitrary unique name for the rule
+#  pattern: Regex pattern to match against the metric name
+#  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
+#  aggregationMethod: function to apply to data points for aggregation
+#
+[min]
+pattern = \.lower$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.upper(_\d+)?$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[sum]
+pattern = \.sum$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[count]
+pattern = \.count$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[count_legacy]
+pattern = ^stats_counts.*
+xFilesFactor = 0
+aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.3
+aggregationMethod = average
+`,
+			expErr: false,
+			expAgg: Aggregations{
+				Data: []Aggregation{
+					{
+						Name:              "min",
+						Pattern:           regexp.MustCompile("\\.lower$"),
+						XFilesFactor:      0.1,
+						AggregationMethod: []Method{Min},
+					},
+					{
+						Name:              "max",
+						Pattern:           regexp.MustCompile("\\.upper(_\\d+)?$"),
+						XFilesFactor:      0.1,
+						AggregationMethod: []Method{Max},
+					},
+					{
+						Name:              "sum",
+						Pattern:           regexp.MustCompile("\\.sum$"),
+						XFilesFactor:      0,
+						AggregationMethod: []Method{Sum},
+					},
+					{
+						Name:              "count",
+						Pattern:           regexp.MustCompile("\\.count$"),
+						XFilesFactor:      0,
+						AggregationMethod: []Method{Sum},
+					},
+					{
+						Name:              "count_legacy",
+						Pattern:           regexp.MustCompile("^stats_counts.*"),
+						XFilesFactor:      0,
+						AggregationMethod: []Method{Sum},
+					},
+					{
+						Name:              "default_average",
+						Pattern:           regexp.MustCompile(".*"),
+						XFilesFactor:      0.3,
+						AggregationMethod: []Method{Avg},
+					},
+				},
+				DefaultAggregation: defaultAggregation,
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		file, err := ioutil.TempFile("", "metrictank-TestReadAggregations")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(file.Name())
+		if _, err := file.Write([]byte(c.in)); err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("testing %q", c.title)
+		agg, err := ReadAggregations(file.Name())
+		if !c.expErr && err != nil {
+			t.Fatalf("testcase %q expected no error but got error %s", c.title, err.Error())
+		}
+		if c.expErr && err == nil {
+			t.Fatalf("testcase %q expected error but got no error", c.title)
+		}
+		if err == nil {
+			if !agg.Equals(c.expAgg) {
+				t.Fatalf("testcase %q expected\nexp agg %+v\ngot agg %+v", c.title, c.expAgg, agg)
+			}
+		}
+	}
+}

--- a/conf/aggregations_test.go
+++ b/conf/aggregations_test.go
@@ -59,7 +59,7 @@ func TestReadAggregations(t *testing.T) {
 						AggregationMethod: []Method{Avg},
 					},
 				},
-				DefaultAggregation: defaultAggregation,
+				DefaultAggregation: defaultAggregation(),
 			},
 		},
 		{
@@ -78,7 +78,7 @@ aggregationMethod = avg,sum`,
 						AggregationMethod: []Method{Avg, Sum},
 					},
 				},
-				DefaultAggregation: defaultAggregation,
+				DefaultAggregation: defaultAggregation(),
 			},
 		},
 		{
@@ -148,7 +148,7 @@ aggregationMethod = average
 						AggregationMethod: []Method{Avg},
 					},
 				},
-				DefaultAggregation: defaultAggregation,
+				DefaultAggregation: defaultAggregation(),
 			},
 		},
 		{
@@ -237,7 +237,7 @@ aggregationMethod = average
 						AggregationMethod: []Method{Avg},
 					},
 				},
-				DefaultAggregation: defaultAggregation,
+				DefaultAggregation: defaultAggregation(),
 			},
 		},
 	}

--- a/conf/aggregations_test.go
+++ b/conf/aggregations_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestReadAggregations(t *testing.T) {
@@ -315,8 +317,8 @@ aggregationMethod = average
 			t.Fatalf("testcase %q expected error but got no error", c.title)
 		}
 		if err == nil {
-			if !agg.Equals(c.expAgg) {
-				t.Fatalf("testcase %q expected\nexp agg %+v\ngot agg %+v", c.title, c.expAgg, agg)
+			if diff := cmp.Diff(c.expAgg, agg); diff != "" {
+				t.Errorf("testcase %q mismatch (-want +got):\n%s", c.title, diff)
 			}
 		}
 	}

--- a/conf/aggregations_test.go
+++ b/conf/aggregations_test.go
@@ -93,7 +93,7 @@ func TestReadAggregations(t *testing.T) {
 			title: "lots of comments",
 			in: `;[this is not a section]
 			[foo] # [commented]
-			pattern = foo.* # another comment here
+			pattern = fo#ooo;.* # another comment here. note that literal ; and # are allowed
 			; pattern = this-should-be-ignored
 			xFilesFactor = 0.8 # comment
 			;xFilesFactor = 0.9
@@ -108,7 +108,7 @@ func TestReadAggregations(t *testing.T) {
 				Data: []Aggregation{
 					{
 						Name:              "foo",
-						Pattern:           regexp.MustCompile("foo.*"),
+						Pattern:           regexp.MustCompile("fo#ooo;.*"),
 						XFilesFactor:      0.8,
 						AggregationMethod: []Method{Max},
 					},

--- a/vendor/github.com/grafana/configparser/LICENSE
+++ b/vendor/github.com/grafana/configparser/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2013, Alex Yu <alex@alexyu.se>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Alex Yu nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL Alex Yu <alex@alexyu.se> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/vendor/github.com/grafana/configparser/configparser.go
+++ b/vendor/github.com/grafana/configparser/configparser.go
@@ -1,0 +1,483 @@
+// Copyright (c) 2013 - Alex Yu <alex@alexyu.se>. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package configparser provides a simple parser for reading/writing configuration (INI) files.
+//
+// Supports reading/writing the INI file format in addition to:
+//
+//  - Reading/writing duplicate section names (ex: MySQL NDB engine's config.ini)
+//  - Options without values (ex: can be used to group a set of hostnames)
+//  - Options without a named section (ex: a simple option=value file)
+//  - Find sections with regexp pattern matching on section names, ex: dc1.east.webservers where regex is '.webservers'
+//  - # or ; as comment delimiter
+//  - = or : as value delimiter
+//
+package configparser
+
+import (
+	"bufio"
+	"container/list"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Delimiter is the delimiter to be used between section key and values when rendering an option string
+var Delimiter = "="
+
+// Configuration represents a configuration file with its sections and options.
+type Configuration struct {
+	filePath        string                // configuration file
+	global          *Section              // for settings that don't go into a named section
+	sections        map[string]*list.List // fully qualified section name as key. the list serves to support many repeated (same name) sections
+	orderedSections []string              // track the order of section names as they are parsed
+	mutex           sync.RWMutex
+}
+
+// A Section in a configuration.
+type Section struct {
+	fqn            string
+	isGlobal       bool
+	options        map[string]string
+	orderedOptions []string // track the order of the options as they are parsed
+	mutex          sync.RWMutex
+}
+
+// NewConfiguration returns a new Configuration instance with an empty file path.
+func NewConfiguration() *Configuration {
+	return newConfiguration("")
+}
+
+// ReadFile parses a specified configuration file and returns a Configuration instance.
+func ReadFile(filePath string) (*Configuration, error) {
+	filePath = path.Clean(filePath)
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return Read(file, filePath)
+}
+
+// Read reads the given reader into a new Configuration
+// filePath is set for any future persistency but is not used for reading
+func Read(fd io.Reader, filePath string) (*Configuration, error) {
+
+	config := newConfiguration(filePath)
+	activeSection := config.global
+
+	scanner := bufio.NewScanner(bufio.NewReader(fd))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if len(line) < 0 {
+			continue
+		}
+
+		if isSection(line) {
+			line = strings.Trim(line, "[")
+			i := strings.Index(line, "]")
+			if i == -1 {
+				return nil, fmt.Errorf("invalid section header %q", line)
+			}
+			fqn := line[:i]
+			activeSection = config.addSection(fqn)
+			continue
+		}
+
+		// [ and ] may not appear after other content (we already checked if it's a prefix above) unless it's a comment
+		if strings.Contains(line, "[") || strings.Contains(line, "]") {
+			if !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, ";") {
+				return nil, fmt.Errorf("invalid line %q: [ and ] are reserved for section headers and this contains additional non-section header data", line)
+			}
+		}
+		// save options and comments
+		addOption(activeSection, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// Save the Configuration to file. Creates a backup (.bak) if file already exists.
+func Save(c *Configuration, filePath string) (err error) {
+	err = os.Rename(filePath, filePath+".bak")
+	if err != nil {
+		if !os.IsNotExist(err) { // fine if the file does not exists
+			return err
+		}
+	}
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = f.Close()
+	}()
+
+	return c.Write(f)
+}
+
+func (c *Configuration) Write(fd io.Writer) error {
+
+	global, s, err := c.AllSections()
+	if err != nil {
+		return err
+	}
+
+	w := bufio.NewWriter(fd)
+
+	_, err = w.WriteString(global.String())
+	if err != nil {
+		return err
+	}
+	for _, v := range s {
+		_, err = w.WriteString(v.String())
+		if err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// NewSection creates and adds a new non-global Section with the specified name.
+func (c *Configuration) NewSection(fqn string) *Section {
+	return c.addSection(fqn)
+}
+
+// FilePath returns the configuration file path.
+func (c *Configuration) FilePath() string {
+	return c.filePath
+}
+
+// SetFilePath sets the Configuration file path.
+func (c *Configuration) SetFilePath(filePath string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.filePath = filePath
+}
+
+// StringValue returns the string value for the specified non-global section and option.
+func (c *Configuration) StringValue(section, option string) (value string, err error) {
+	s, err := c.Section(section)
+	if err != nil {
+		return
+	}
+	value = s.ValueOf(option)
+	return
+}
+
+// Delete deletes the specified non-global sections matched by a regex name and returns the deleted sections.
+func (c *Configuration) Delete(regex string) (sections []*Section, err error) {
+	sections, err = c.Find(regex)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if err == nil {
+		for _, s := range sections {
+			delete(c.sections, s.fqn)
+		}
+		// remove also from ordered list
+		var matched bool
+		for i := len(c.orderedSections) - 1; i >= 0; i-- {
+			if matched, err = regexp.MatchString(regex, c.orderedSections[i]); matched {
+				c.orderedSections = append(c.orderedSections[:i], c.orderedSections[i+1:]...)
+			} else {
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return sections, err
+}
+
+// GlobalSection returns the global section
+func (c *Configuration) GlobalSection() *Section {
+	return c.global
+}
+
+// Section returns the first non-global section matching the fully qualified section name.
+func (c *Configuration) Section(fqn string) (*Section, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if l, ok := c.sections[fqn]; ok {
+		for e := l.Front(); e != nil; e = e.Next() {
+			s := e.Value.(*Section)
+			return s, nil
+		}
+	}
+	return nil, errors.New("Unable to find " + fqn)
+}
+
+// AllSections returns the global, as well as a slice of all non-global sections.
+func (c *Configuration) AllSections() (*Section, []*Section, error) {
+	s, err := c.Sections("")
+	return c.global, s, err
+}
+
+// Sections returns a slice of non-global Sections matching the fully qualified section name.
+func (c *Configuration) Sections(fqn string) ([]*Section, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	var sections []*Section
+
+	f := func(lst *list.List) {
+		for e := lst.Front(); e != nil; e = e.Next() {
+			s := e.Value.(*Section)
+			sections = append(sections, s)
+		}
+	}
+
+	if fqn == "" {
+		// Get all sections.
+		for _, fqn := range c.orderedSections {
+			if lst, ok := c.sections[fqn]; ok {
+				f(lst)
+			}
+		}
+	} else {
+		if lst, ok := c.sections[fqn]; ok {
+			f(lst)
+		} else {
+			return nil, errors.New("Unable to find " + fqn)
+		}
+	}
+
+	return sections, nil
+}
+
+// Find returns a slice of non-global Sections matching the regexp against the section name.
+func (c *Configuration) Find(regex string) ([]*Section, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	var sections []*Section
+	for key, lst := range c.sections {
+		if matched, err := regexp.MatchString(regex, key); matched {
+			for e := lst.Front(); e != nil; e = e.Next() {
+				s := e.Value.(*Section)
+				sections = append(sections, s)
+			}
+		} else {
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return sections, nil
+}
+
+// PrintSection prints a text representation of all non-global sections matching the fully qualified section name.
+func (c *Configuration) PrintSection(fqn string) error {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	sections, err := c.Sections(fqn)
+	if err != nil {
+		return err
+	}
+	for _, section := range sections {
+		fmt.Print(section)
+	}
+	return nil
+}
+
+// String returns the text representation of a parsed configuration file.
+func (c *Configuration) String() string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	var parts []string
+	parts = append(parts, c.global.String())
+	for _, fqn := range c.orderedSections {
+		sections, _ := c.Sections(fqn)
+		for _, section := range sections {
+			parts = append(parts, section.String())
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// Name returns the name of the section
+func (s *Section) Name() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.fqn
+}
+
+// Exists returns true if the option exists
+func (s *Section) Exists(option string) (ok bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	_, ok = s.options[option]
+	return
+}
+
+// ValueOf returns the value of specified option.
+func (s *Section) ValueOf(option string) string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.options[option]
+}
+
+// SetValueFor sets the value for the specified option and returns the old value.
+func (s *Section) SetValueFor(option string, value string) string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	oldValue := s.options[option]
+	s.options[option] = value
+
+	return oldValue
+}
+
+// Add adds a new option to the section. Adding an existing option will overwrite the old one.
+// The old value is returned
+func (s *Section) Add(option string, value string) (oldValue string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	var ok bool
+	if oldValue, ok = s.options[option]; !ok {
+		s.orderedOptions = append(s.orderedOptions, option)
+	}
+	s.options[option] = value
+
+	return oldValue
+}
+
+// Delete removes the specified option from the section and returns the deleted option's value.
+func (s *Section) Delete(option string) (value string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	value = s.options[option]
+	delete(s.options, option)
+	for i, opt := range s.orderedOptions {
+		if opt == option {
+			s.orderedOptions = append(s.orderedOptions[:i], s.orderedOptions[i+1:]...)
+		}
+	}
+	return value
+}
+
+// Options returns a map of options for the section.
+func (s *Section) Options() map[string]string {
+	return s.options
+}
+
+// OptionNames returns a slice of option names in the same order as they were parsed.
+func (s *Section) OptionNames() []string {
+	return s.orderedOptions
+}
+
+// String returns the text representation of a section with its options.
+func (s *Section) String() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var parts []string
+
+	if !s.isGlobal {
+		parts = append(parts, "["+s.fqn+"]\n")
+	}
+
+	for _, opt := range s.orderedOptions {
+		value := s.options[opt]
+		if value != "" {
+			parts = append(parts, opt, Delimiter, value, "\n")
+		} else {
+			parts = append(parts, opt, "\n")
+		}
+	}
+
+	return strings.Join(parts, "")
+}
+
+//
+// Private
+//
+
+// newSection creates a new, blank section
+func newSection(fqn string, isGlobal bool) *Section {
+	return &Section{
+		fqn:      fqn,
+		isGlobal: isGlobal,
+		options:  make(map[string]string),
+	}
+}
+
+// newConfiguration creates a new Configuration instance.
+func newConfiguration(filePath string) *Configuration {
+	return &Configuration{
+		filePath: filePath,
+		global:   newSection("", true),
+		sections: make(map[string]*list.List),
+	}
+}
+
+func isSection(section string) bool {
+	return strings.HasPrefix(section, "[")
+}
+
+func addOption(s *Section, option string) {
+	opt, value := parseOption(option)
+	s.options[opt] = value
+
+	s.orderedOptions = append(s.orderedOptions, opt)
+}
+
+// parseOption parses a string like "opt=value", "opt:value" or "opt", removing extraneous whitespace
+// (in the 3rd case only opt is set and value is "")
+func parseOption(option string) (opt, value string) {
+
+	split := func(i int, delim string) (opt, value string) {
+		// strings.Split cannot handle wsrep_provider_options settings
+		opt = strings.Trim(option[:i], " ")
+		value = strings.Trim(option[i+1:], " ")
+		return
+	}
+
+	if i := strings.Index(option, "="); i != -1 {
+		opt, value = split(i, "=")
+	} else if i := strings.Index(option, ":"); i != -1 {
+		opt, value = split(i, ":")
+	} else {
+		opt = option
+	}
+	return
+}
+
+// addSection adds a new non-global section with the given name
+func (c *Configuration) addSection(fqn string) *Section {
+	section := newSection(fqn, false)
+
+	var lst *list.List
+	if lst = c.sections[fqn]; lst == nil {
+		lst = list.New()
+		c.sections[fqn] = lst
+		c.orderedSections = append(c.orderedSections, fqn)
+	}
+
+	lst.PushBack(section)
+
+	return section
+}

--- a/vendor/github.com/grafana/configparser/configparser.go
+++ b/vendor/github.com/grafana/configparser/configparser.go
@@ -338,6 +338,23 @@ func (s *Section) ValueOf(option string) string {
 	return s.options[option]
 }
 
+// ValueOf returns the value of specified option without any trailing comments (denoted by ' #' or ' ;')
+func (s *Section) ValueOfWithoutComments(option string) string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	val := s.options[option]
+	pos := strings.Index(val, " #")
+	if pos != -1 {
+		val = val[:pos]
+	}
+	pos = strings.Index(val, " ;")
+	if pos != -1 {
+		val = val[:pos]
+	}
+	return val
+}
+
 // SetValueFor sets the value for the specified option and returns the old value.
 func (s *Section) SetValueFor(option string, value string) string {
 	s.mutex.Lock()


### PR DESCRIPTION
1) use grafana fork of configparser library.
why fork it? well, to review this properly, you'll have to look at all the commits that https://github.com/grafana/configparser adds on top of upstream, but in particular
* https://github.com/alyu/configparser/issues/11 (fix section name parsing)
* https://github.com/alyu/configparser/issues/8 (remove ambiguity between global section and a possible section named "global"). due to this ambiguity we couldn't properly check whether the name of sections was properly set (because we couldn't know if the section was real or just the global one)
* I added a bunch more unit tests (to configparser repo) and notes about how it works

2) add a bunch of unit tests (to test our storage-aggregation.conf use case on top of configparser)

3) thanks to the fork, fix a bunch of issues:
* implement defaults like in carbon:
  - xFilesFactor of 0.5 (note that metrictank didn't actually implement xFF so us incorrectly setting this field was not a problem)
  - aggregationMethod avg (note that on grafanacloud and everywhere else that I know of, people always explicitly set this field, but let's be correct and do it like carbon)
* handle special cases better (e.g. empty file -> use defaults), without needing to do ugly hacks


Why do we need this now?
it's not critical to fix this for metrictank now, however i'ld like to use this library in carbon-relay-ng, and there we must accommodate whatever files the user throw at us.