### PR TITLE
Fix partition find

### DIFF
--- a/idx/memory/memory_find_test.go
+++ b/idx/memory/memory_find_test.go
@@ -360,7 +360,7 @@ func queryAndCompareTagValues(t *testing.T, key, filter string, expected map[str
 }
 
 func TestTagDetailsWithoutFilter(t *testing.T) {
-	withAndWithoutPartitonedIndex(testTagDetailsWithoutFilter)(t)
+	withAndWithoutPartitionedIndex(testTagDetailsWithoutFilter)(t)
 }
 
 func testTagDetailsWithoutFilter(t *testing.T) {
@@ -377,7 +377,7 @@ func testTagDetailsWithoutFilter(t *testing.T) {
 }
 
 func TestTagDetailsWithFilter(t *testing.T) {
-	withAndWithoutPartitonedIndex(testTagDetailsWithFilter)(t)
+	withAndWithoutPartitionedIndex(testTagDetailsWithFilter)(t)
 }
 
 func testTagDetailsWithFilter(t *testing.T) {
@@ -395,7 +395,7 @@ func TestTagDetailsWithMetaTagSupportWithoutFilter(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testTagDetailsWithMetaTagSupportWithoutFilter)(t)
+	withAndWithoutPartitionedIndex(testTagDetailsWithMetaTagSupportWithoutFilter)(t)
 }
 
 func testTagDetailsWithMetaTagSupportWithoutFilter(t *testing.T) {
@@ -428,7 +428,7 @@ func TestTagDetailsWithMetaTagSupportWithFilter(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testTagDetailsWithMetaTagSupportWithFilter)(t)
+	withAndWithoutPartitionedIndex(testTagDetailsWithMetaTagSupportWithFilter)(t)
 }
 
 func testTagDetailsWithMetaTagSupportWithFilter(t *testing.T) {
@@ -477,7 +477,7 @@ func queryAndCompareTagKeys(t testing.TB, filter string, expected []string) {
 }
 
 func TestTagKeysWithoutFilters(t *testing.T) {
-	withAndWithoutPartitonedIndex(testTagKeysWithoutFilters)(t)
+	withAndWithoutPartitionedIndex(testTagKeysWithoutFilters)(t)
 }
 
 func testTagKeysWithoutFilters(t *testing.T) {
@@ -489,7 +489,7 @@ func testTagKeysWithoutFilters(t *testing.T) {
 }
 
 func TestTagKeysWithFilter(t *testing.T) {
-	withAndWithoutPartitonedIndex(testTagKeysWithFilter)(t)
+	withAndWithoutPartitionedIndex(testTagKeysWithFilter)(t)
 }
 
 func testTagKeysWithFilter(t *testing.T) {
@@ -507,7 +507,7 @@ func TestTagKeysWithMetaTagSupportWithFilter(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testTagKeysWithMetaTagSupportWithFilter)(t)
+	withAndWithoutPartitionedIndex(testTagKeysWithMetaTagSupportWithFilter)(t)
 }
 
 func testTagKeysWithMetaTagSupportWithFilter(t *testing.T) {
@@ -541,7 +541,7 @@ func TestTagKeysWithMetaTagSupportWithoutFilters(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testTagKeysWithMetaTagSupportWithoutFilters)(t)
+	withAndWithoutPartitionedIndex(testTagKeysWithMetaTagSupportWithoutFilters)(t)
 }
 
 func testTagKeysWithMetaTagSupportWithoutFilters(t *testing.T) {
@@ -565,7 +565,7 @@ func testTagKeysWithMetaTagSupportWithoutFilters(t *testing.T) {
 }
 
 func TestTagSortingInFindByTag(t *testing.T) {
-	withAndWithoutPartitonedIndex(testTagSortingInFindByTag)(t)
+	withAndWithoutPartitionedIndex(testTagSortingInFindByTag)(t)
 }
 
 func testTagSortingInFindByTag(t *testing.T) {
@@ -632,7 +632,7 @@ func testTagSortingInFindByTag(t *testing.T) {
 }
 
 func TestAutoCompleteTags(t *testing.T) {
-	withAndWithoutPartitonedIndex(testAutoCompleteTags)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTags)(t)
 }
 
 func testAutoCompleteTags(t *testing.T) {
@@ -674,7 +674,7 @@ func TestAutoCompleteTagsWithMetaTagSupport(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testAutoCompleteTagsWithMetaTagSupport)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTagsWithMetaTagSupport)(t)
 }
 
 func testAutoCompleteTagsWithMetaTagSupport(t *testing.T) {
@@ -757,7 +757,7 @@ func autoCompleteTagsAndCompare(t testing.TB, tcIdx int, prefix string, limit ui
 }
 
 func TestAutoCompleteTagsWithQuery(t *testing.T) {
-	withAndWithoutPartitonedIndex(testAutoCompleteTagsWithQuery)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTagsWithQuery)(t)
 }
 
 func testAutoCompleteTagsWithQuery(t *testing.T) {
@@ -804,7 +804,7 @@ func TestAutoCompleteTagsWithQueryWithMetaTagSupport(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testAutoCompleteTagsWithQueryWithMetaTagSupport)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTagsWithQueryWithMetaTagSupport)(t)
 }
 
 func testAutoCompleteTagsWithQueryWithMetaTagSupport(t *testing.T) {
@@ -875,7 +875,7 @@ func autoCompleteTagsWithQueryAndCompare(t testing.TB, tcIdx int, prefix string,
 }
 
 func TestAutoCompleteTagValues(t *testing.T) {
-	withAndWithoutPartitonedIndex(testAutoCompleteTagValues)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTagValues)(t)
 }
 
 func testAutoCompleteTagValues(t *testing.T) {
@@ -918,7 +918,7 @@ func TestAutoCompleteTagValuesWithMetaTagSupport(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testAutoCompleteTagValuesWithMetaTagSupport)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTagValuesWithMetaTagSupport)(t)
 }
 
 func testAutoCompleteTagValuesWithMetaTagSupport(t *testing.T) {
@@ -1009,7 +1009,7 @@ func autoCompleteTagValuesAndCompare(t testing.TB, tag, prefix string, limit uin
 }
 
 func TestAutoCompleteTagValuesWithQuery(t *testing.T) {
-	withAndWithoutPartitonedIndex(testAutoCompleteTagValuesWithQuery)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTagValuesWithQuery)(t)
 }
 
 func testAutoCompleteTagValuesWithQuery(t *testing.T) {
@@ -1067,7 +1067,7 @@ func TestAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {
 	reset := enableMetaTagSupport()
 	defer reset()
 
-	withAndWithoutPartitonedIndex(testAutoCompleteTagValuesWithQueryWithMetaTagSupport)(t)
+	withAndWithoutPartitionedIndex(testAutoCompleteTagValuesWithQueryWithMetaTagSupport)(t)
 }
 
 func testAutoCompleteTagValuesWithQueryWithMetaTagSupport(t *testing.T) {

--- a/idx/memory/memory_test.go
+++ b/idx/memory/memory_test.go
@@ -187,10 +187,10 @@ func withAndWithoutTagSupport(f func(*testing.T)) func(*testing.T) {
 	}
 }
 
-// withAndWithoutPartitonedIndex calls a test with the Partitioned setting
+// withAndWithoutPartitionedIndex calls a test with the Partitioned setting
 // turned on and off. This is to verify that something works as expected
 // no for both the partitioned and non-partitioned index versions.
-func withAndWithoutPartitonedIndex(f func(*testing.T)) func(*testing.T) {
+func withAndWithoutPartitionedIndex(f func(*testing.T)) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 		_partitioned := Partitioned
@@ -219,7 +219,7 @@ func withAndWithoutMetaTagSupport(f func(*testing.T)) func(*testing.T) {
 }
 
 func TestGetAddKey(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(withAndWithoutTagSupport(testGetAddKey)))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(withAndWithoutTagSupport(testGetAddKey)))(t)
 }
 
 func testGetAddKey(t *testing.T) {
@@ -283,7 +283,7 @@ func testGetAddKey(t *testing.T) {
 }
 
 func TestFind(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutTagSupport(testFind))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutTagSupport(testFind))(t)
 }
 
 // note: currently no testing for partitionedIndex
@@ -480,7 +480,7 @@ func testFind(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutTagSupport(testDelete))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutTagSupport(testDelete))(t)
 }
 
 func testDelete(t *testing.T) {
@@ -535,7 +535,7 @@ func testDelete(t *testing.T) {
 }
 
 func TestDeleteTagged(t *testing.T) {
-	withAndWithoutPartitonedIndex(testDeleteTagged)(t)
+	withAndWithoutPartitionedIndex(testDeleteTagged)(t)
 }
 
 func testDeleteTagged(t *testing.T) {
@@ -591,7 +591,7 @@ func testDeleteTagged(t *testing.T) {
 }
 
 func TestDeleteNodeWith100kChildren(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutTagSupport(testDeleteNodeWith100kChildren))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutTagSupport(testDeleteNodeWith100kChildren))(t)
 }
 
 func testDeleteNodeWith100kChildren(t *testing.T) {
@@ -641,7 +641,7 @@ func testDeleteNodeWith100kChildren(t *testing.T) {
 }
 
 func TestMixedBranchLeaf(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutTagSupport(testMixedBranchLeaf))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutTagSupport(testMixedBranchLeaf))(t)
 }
 
 func testMixedBranchLeaf(t *testing.T) {
@@ -703,7 +703,7 @@ func testMixedBranchLeaf(t *testing.T) {
 }
 
 func TestMixedBranchLeafDelete(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutTagSupport(testMixedBranchLeafDelete))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutTagSupport(testMixedBranchLeafDelete))(t)
 }
 
 func testMixedBranchLeafDelete(t *testing.T) {
@@ -796,7 +796,7 @@ func testMixedBranchLeafDelete(t *testing.T) {
 }
 
 func TestPruneTaggedSeries(t *testing.T) {
-	withAndWithoutPartitonedIndex(testPruneTaggedSeries)(t)
+	withAndWithoutPartitionedIndex(testPruneTaggedSeries)(t)
 }
 
 func testPruneTaggedSeries(t *testing.T) {
@@ -922,7 +922,7 @@ func testPruneTaggedSeries(t *testing.T) {
 // it does not test matching over different rules or tag matching
 // we have other tests for that
 func TestPruneTaggedSeriesWithCollidingTagSets(t *testing.T) {
-	withAndWithoutPartitonedIndex(testPruneTaggedSeriesWithCollidingTagSets)(t)
+	withAndWithoutPartitionedIndex(testPruneTaggedSeriesWithCollidingTagSets)(t)
 }
 
 func testPruneTaggedSeriesWithCollidingTagSets(t *testing.T) {
@@ -1003,7 +1003,7 @@ func testPruneTaggedSeriesWithCollidingTagSets(t *testing.T) {
 }
 
 func TestPrune(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutTagSupport(testPrune))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutTagSupport(testPrune))(t)
 }
 
 func testPrune(t *testing.T) {
@@ -1095,7 +1095,7 @@ func testPrune(t *testing.T) {
 }
 
 func TestSingleNodeMetric(t *testing.T) {
-	withAndWithoutPartitonedIndex(testSingleNodeMetric)(t)
+	withAndWithoutPartitionedIndex(testSingleNodeMetric)(t)
 }
 
 func testSingleNodeMetric(t *testing.T) {
@@ -1195,7 +1195,7 @@ func TestUpsertingMetaRecordsIntoIndex(t *testing.T) {
 }
 
 func TestMetricNameStartingWithTilde(t *testing.T) {
-	withAndWithoutPartitonedIndex(testMetricNameStartingWithTilde)(t)
+	withAndWithoutPartitionedIndex(testMetricNameStartingWithTilde)(t)
 }
 
 func testMetricNameStartingWithTilde(t *testing.T) {
@@ -1472,7 +1472,7 @@ func benchmarkPruneLongSeriesNames(b *testing.B) {
 }
 
 func TestMatchSchemaWithTags(t *testing.T) {
-	withAndWithoutPartitonedIndex(testMatchSchemaWithTags)(t)
+	withAndWithoutPartitionedIndex(testMatchSchemaWithTags)(t)
 }
 
 func testMatchSchemaWithTags(t *testing.T) {

--- a/idx/memory/partitioned_idx.go
+++ b/idx/memory/partitioned_idx.go
@@ -193,10 +193,10 @@ func (p *PartitionedMemoryIdx) Find(orgId uint32, pattern string, from, limit in
 	done := make(chan struct{})
 	go func() {
 		for found := range resultChan {
-			for _, node := range found {
+			for i, node := range found {
 				n, ok := byPath[node.Path]
 				if !ok {
-					byPath[node.Path] = &node
+					byPath[node.Path] = &found[i]
 				} else {
 					if node.HasChildren {
 						n.HasChildren = true

--- a/idx/memory/tag_query_id_filter_test.go
+++ b/idx/memory/tag_query_id_filter_test.go
@@ -96,7 +96,7 @@ func TestSliceContainsElements(t *testing.T) {
 }
 
 func TestFilterByMetricTag(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetricTag))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetricTag))(t)
 }
 
 func testFilterByMetricTag(t *testing.T) {
@@ -114,7 +114,7 @@ func testFilterByMetricTag(t *testing.T) {
 }
 
 func TestFilterByMetaTagWithEqual(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithEqual))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithEqual))(t)
 }
 
 func testFilterByMetaTagWithEqual(t *testing.T) {
@@ -155,7 +155,7 @@ func testFilterByMetaTagWithEqual(t *testing.T) {
 }
 
 func TestFilterByMetaTagWithNotEqualAndWithNotHasTag(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithNotEqualAndWithNotHasTag))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithNotEqualAndWithNotHasTag))(t)
 }
 
 func testFilterByMetaTagWithNotEqualAndWithNotHasTag(t *testing.T) {
@@ -205,7 +205,7 @@ func testFilterByMetaTagWithNotEqualAndWithNotHasTag(t *testing.T) {
 }
 
 func TestFilterByMetaTagOfMultipleExpressionsWithNotEqualAndWithNotHasTag(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagOfMultipleExpressionsWithNotEqualAndWithNotHasTag))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagOfMultipleExpressionsWithNotEqualAndWithNotHasTag))(t)
 }
 
 func testFilterByMetaTagOfMultipleExpressionsWithNotEqualAndWithNotHasTag(t *testing.T) {
@@ -275,7 +275,7 @@ func testFilterByMetaTagOfMultipleExpressionsWithNotEqualAndWithNotHasTag(t *tes
 }
 
 func TestFilterByMetaTagWithEqualAndWithHasTag(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithEqualAndWithHasTag))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithEqualAndWithHasTag))(t)
 }
 
 func testFilterByMetaTagWithEqualAndWithHasTag(t *testing.T) {
@@ -325,7 +325,7 @@ func testFilterByMetaTagWithEqualAndWithHasTag(t *testing.T) {
 }
 
 func TestFilterByMetaTagWithSingleUnderlyingEqualExpression(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithSingleUnderlyingEqualExpression))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithSingleUnderlyingEqualExpression))(t)
 }
 
 func testFilterByMetaTagWithSingleUnderlyingEqualExpression(t *testing.T) {
@@ -362,7 +362,7 @@ func testFilterByMetaTagWithSingleUnderlyingEqualExpression(t *testing.T) {
 }
 
 func TestFilterByMetaTagWithMultipleUnderlyingEqualExpression(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithMultipleUnderlyingEqualExpression))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithMultipleUnderlyingEqualExpression))(t)
 }
 
 func testFilterByMetaTagWithMultipleUnderlyingEqualExpression(t *testing.T) {
@@ -399,7 +399,7 @@ func testFilterByMetaTagWithMultipleUnderlyingEqualExpression(t *testing.T) {
 }
 
 func TestFilterByMetaTagWithPatternMatching(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithPatternMatching))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithPatternMatching))(t)
 }
 
 func testFilterByMetaTagWithPatternMatching(t *testing.T) {
@@ -474,7 +474,7 @@ func testFilterByMetaTagWithPatternMatching(t *testing.T) {
 }
 
 func TestFilterByMetaTagWithTagOperators(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithTagOperators))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMetaTagWithTagOperators))(t)
 }
 
 func testFilterByMetaTagWithTagOperators(t *testing.T) {
@@ -536,7 +536,7 @@ func testFilterByMetaTagWithTagOperators(t *testing.T) {
 }
 
 func TestFilterByMultipleOfManyMetaTagValues(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMultipleOfManyMetaTagValues))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMultipleOfManyMetaTagValues))(t)
 }
 
 func testFilterByMultipleOfManyMetaTagValues(t *testing.T) {
@@ -619,7 +619,7 @@ func testFilterByMultipleOfManyMetaTagValues(t *testing.T) {
 }
 
 func TestFilterByMultipleOfManyMetaTags(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByMultipleOfManyMetaTags))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByMultipleOfManyMetaTags))(t)
 }
 
 func testFilterByMultipleOfManyMetaTags(t *testing.T) {
@@ -703,7 +703,7 @@ func testFilterByMultipleOfManyMetaTags(t *testing.T) {
 }
 
 func TestFilterByOverlappingMetaTags(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterByOverlappingMetaTags))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterByOverlappingMetaTags))(t)
 }
 
 func testFilterByOverlappingMetaTags(t *testing.T) {
@@ -768,7 +768,7 @@ func testFilterByOverlappingMetaTags(t *testing.T) {
 }
 
 func TestFilterSubtractingMetricTagsFromMetaTag(t *testing.T) {
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testFilterSubtractingMetricTagsFromMetaTag))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testFilterSubtractingMetricTagsFromMetaTag))(t)
 }
 
 func testFilterSubtractingMetricTagsFromMetaTag(t *testing.T) {

--- a/idx/memory/tag_query_id_selector_test.go
+++ b/idx/memory/tag_query_id_selector_test.go
@@ -84,7 +84,7 @@ func TestSelectByMetricTag(t *testing.T) {
 	_tagSupport := TagSupport
 	TagSupport = true
 	defer func() { TagSupport = _tagSupport }()
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testSelectByMetricTag))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testSelectByMetricTag))(t)
 }
 
 func testSelectByMetricTag(t *testing.T) {
@@ -104,7 +104,7 @@ func TestSelectByMetaTag(t *testing.T) {
 	_tagSupport := TagSupport
 	TagSupport = true
 	defer func() { TagSupport = _tagSupport }()
-	withAndWithoutPartitonedIndex(withAndWithoutMetaTagSupport(testSelectByMetaTag))(t)
+	withAndWithoutPartitionedIndex(withAndWithoutMetaTagSupport(testSelectByMetaTag))(t)
 }
 
 func testSelectByMetaTag(t *testing.T) {

--- a/idx/memory/tag_query_test.go
+++ b/idx/memory/tag_query_test.go
@@ -483,7 +483,7 @@ TEST_CASES:
 }
 
 func TestGetByTag(t *testing.T) {
-	withAndWithoutPartitonedIndex(testGetByTag)(t)
+	withAndWithoutPartitionedIndex(testGetByTag)(t)
 }
 
 func testGetByTag(t *testing.T) {


### PR DESCRIPTION
While working on a solution for #1976 I found an issue with the partitioned index. It looks like it was taking the address of a local temp variable, so results were being duplicated.

I also renamed a function that had a typo in it.