### PR TITLE
Fix parsing of storage-aggregation.conf patterns with special characters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -318,11 +318,12 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:01379e9ffd4d4756068566b7ee3834165301dde52dd41ad3f3addf4e4cf3417c"
+  branch = "fix-mt-1990"
+  digest = "1:51d3a77f55c39b5489b4a2eaee34d49e73bd4a82d750df9d0e7ec17c9053c91d"
   name = "github.com/grafana/configparser"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "7fdb7669f3ec55c350a5b35e35c5f7c559de0060"
+  revision = "99909c64fda9fddebf3f2f1732918103f069608b"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -318,12 +318,11 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "fix-mt-1990"
   digest = "1:51d3a77f55c39b5489b4a2eaee34d49e73bd4a82d750df9d0e7ec17c9053c91d"
   name = "github.com/grafana/configparser"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "99909c64fda9fddebf3f2f1732918103f069608b"
+  revision = "2593eb86a3ee3caf043cc07bca23ee7d8df15091"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@ unused-packages = true
 
 [[constraint]]
   name = "github.com/grafana/configparser"
-  branch = "fix-mt-1990"
+  revision = "2593eb86a3ee3caf043cc07bca23ee7d8df15091"
 
 [[constraint]]
   name = "github.com/davecgh/go-spew"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@ unused-packages = true
 
 [[constraint]]
   name = "github.com/grafana/configparser"
-  revision = "7fdb7669f3ec55c350a5b35e35c5f7c559de0060"
+  branch = "fix-mt-1990"
 
 [[constraint]]
   name = "github.com/davecgh/go-spew"

--- a/conf/aggregations_test.go
+++ b/conf/aggregations_test.go
@@ -50,7 +50,7 @@ func TestReadAggregations(t *testing.T) {
 		{
 			title: "commented out pattern is still missing",
 			in: `[foo]
-			;pattern = foo.*`,
+			#pattern = foo.*`,
 			expErr: true,
 		},
 		{
@@ -91,26 +91,43 @@ func TestReadAggregations(t *testing.T) {
 		},
 		{
 			title: "lots of comments",
-			in: `;[this is not a section]
+			in: `#[this is not a section]
 			[foo] # [commented]
 			pattern = fo#ooo;.* # another comment here. note that literal ; and # are allowed
-			; pattern = this-should-be-ignored
+			# pattern = this-should-be-ignored
 			xFilesFactor = 0.8 # comment
-			;xFilesFactor = 0.9
-			;aggregationMethod = min,avg
+			#xFilesFactor = 0.9
+			#aggregationMethod = min,avg
 			#aggregationMethod = min,avg
 			aggregationMethod = max
-			;aggregationMethod = min,avg
 			#aggregationMethod = min,avg
-			; and a final comment on its own line`,
+			# and a final comment on its own line`,
 			expErr: false,
 			expAgg: Aggregations{
 				Data: []Aggregation{
 					{
 						Name:              "foo",
-						Pattern:           regexp.MustCompile("fo#ooo;.*"),
+						Pattern:           regexp.MustCompile("fo"),
 						XFilesFactor:      0.8,
 						AggregationMethod: []Method{Max},
+					},
+				},
+				DefaultAggregation: defaultAggregation(),
+			},
+		},
+		{
+			title: "pattern with special characters",
+			in: `[foo]
+			pattern = [^ab](x|y)\p{Greek}.*,:;!@%&=+-_/?<>"'~$#ab
+			`,
+			expErr: false,
+			expAgg: Aggregations{
+				Data: []Aggregation{
+					{
+						Name:              "foo",
+						Pattern:           regexp.MustCompile(`[^ab](x|y)\p{Greek}.*,:;!@%&=+-_/?<>"'~$`),
+						XFilesFactor:      0.5,
+						AggregationMethod: []Method{Avg},
 					},
 				},
 				DefaultAggregation: defaultAggregation(),


### PR DESCRIPTION
This uses the patched config library (not merged yet) https://github.com/grafana/configparser/pull/1 (this PR includes more details, readme updates, test case updates, etc)

to fix #1990 

@shanson7 how does this look to you?