### PR TITLE
Detailed query plan errors

### DIFF
--- a/api/graphite_proxy.go
+++ b/api/graphite_proxy.go
@@ -17,10 +17,13 @@ import (
 var proxyStats graphiteProxyStats
 
 func init() {
+	initProxyStats()
+}
+
+func initProxyStats() {
 	proxyStats = graphiteProxyStats{
 		funcMiss: make(map[string]*stats.Counter32),
 	}
-
 }
 
 type graphiteProxyStats struct {

--- a/api/response/error.go
+++ b/api/response/error.go
@@ -2,13 +2,14 @@ package response
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
 
 type Error interface {
-	//This could have just been `Code`, but that would make it accidentally share an interface with gocql and lead to nonsense HTTP codes
-	//See https://github.com/grafana/metrictank/issues/1678
+	// HTTPStatusCode could have just been `Code`, but that would make it accidentally share an interface with gocql and lead to nonsense HTTP codes
+	// See https://github.com/grafana/metrictank/issues/1678
 	HTTPStatusCode() int
 	Error() string
 }
@@ -26,8 +27,8 @@ func WrapError(e error) *ErrorResp {
 		err:  e.Error(),
 		code: http.StatusInternalServerError,
 	}
-	if _, ok := e.(Error); ok {
-		resp.code = e.(Error).HTTPStatusCode()
+	if err := Error(nil); errors.As(e, &err) {
+		resp.code = err.HTTPStatusCode()
 	}
 	return resp
 }
@@ -51,8 +52,8 @@ func WrapErrorForTagDB(e error) *ErrorResp {
 		code: http.StatusInternalServerError,
 	}
 
-	if _, ok := e.(Error); ok {
-		resp.code = e.(Error).HTTPStatusCode()
+	if err := Error(nil); errors.As(e, &err) {
+		resp.code = err.HTTPStatusCode()
 	}
 	return resp
 }

--- a/cmd/mt-explain/main.go
+++ b/cmd/mt-explain/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -82,7 +83,7 @@ func main() {
 
 	plan, err := expr.NewPlan(exps, fromUnix, toUnix, uint32(*mdp), *stable, optimizations)
 	if err != nil {
-		if fun, ok := err.(expr.ErrUnknownFunction); ok {
+		if fun := expr.ErrUnknownFunction(""); errors.As(err, &fun) {
 			fmt.Printf("Unsupported function %q: must defer query to graphite\n", string(fun))
 			plan.Dump(os.Stdout)
 			return

--- a/expr/plan_test.go
+++ b/expr/plan_test.go
@@ -213,7 +213,11 @@ func TestArgs(t *testing.T) {
 			namedArgs: c.namedArgs,
 		}
 		req, err := newplanFunc(e, fn, Context{from: from, to: to}, stable, nil)
-		if c.expErrMsg != "" {
+		if c.expErrMsg == "" {
+			if err != nil {
+				t.Errorf("case %d: %q, expected no error, but got '%s'", i, c.name, err.Error())
+			}
+		} else {
 			if !errors.Is(err, c.expErrIs) {
 				t.Errorf("case %d: %q, expected error %v in wrapped error chain", i, c.name, c.expErrIs)
 			}


### PR DESCRIPTION
Right now when we fail the plan we see an error message which is:

    argument bad type. expected int - got etString

If the query is not trivial (with nested function calls, for instancer), it becomes very complicated to understand which arg it's referring too.

This adds context to the errors returned by NewPlan() (specifically, newplanFunc()), telling which function and which arg caused the error. The error message is now:

    can't plan function "myfunction", arg 3: argument bad type. expected int - got etString

The original error is wrapped now so all the usages of NewPlan() now check the wrapped error rather than specific type. Additionally, added wrapping/unwrapping logic to the response.WrapError() (we could skip this, but since it says it wraps it, why not wrapping it for real).