### PR TITLE
Use xxhash/v2 package, instead of plain xxhash

### DIFF
--- a/schema/partition.go
+++ b/schema/partition.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"github.com/cespare/xxhash"
+	"github.com/cespare/xxhash/v2"
 	jump "github.com/dgryski/go-jump"
 	"github.com/grafana/metrictank/util"
 )


### PR DESCRIPTION
Actually `xxhash` doesn't even have the `WriteString()` method because the
`New()` construct returns a `hash.Hash64` type.

This becomes an issue when importing this project from a project with go
modules that refuses to import xxhash version 2 without the /v2 suffix.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
