### PR TITLE
Improve Slice pool hit rate

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -83,4 +83,5 @@ func ConfigProcess() {
 			log.Fatalf("API Cannot load timezone %q: %s", timeZoneStr, err.Error())
 		}
 	}
+	pointSlicePool.SetDefaultSize(int(minSliceSize))
 }

--- a/api/config.go
+++ b/api/config.go
@@ -32,6 +32,7 @@ var (
 	tagdbDefaultLimit     uint
 	speculationThreshold  float64
 	optimizations         expr.Optimizations
+	minSliceSize          uint
 
 	graphiteProxy *httputil.ReverseProxy
 	timeZone      *time.Location
@@ -57,6 +58,7 @@ func ConfigSetup() {
 	apiCfg.BoolVar(&optimizations.PreNormalization, "pre-normalization", true, "enable pre-normalization optimization")
 	apiCfg.BoolVar(&optimizations.MDP, "mdp-optimization", false, "enable MaxDataPoints optimization (experimental)")
 	apiCfg.BoolVar(&middleware.LogHeaders, "log-headers", false, "output query headers in logs")
+	apiCfg.UintVar(&minSliceSize, "min-slice-pool-size", 2000, "Minimum (and default) length of slice to allocate from pool")
 	globalconf.Register("http", apiCfg, flag.ExitOnError)
 }
 

--- a/api/init.go
+++ b/api/init.go
@@ -9,7 +9,7 @@ import (
 var pointSlicePool *pointslicepool.PointSlicePool
 
 func init() {
-	pointSlicePool = pointslicepool.New(pointslicepool.DefaultPointSliceSize)
+	pointSlicePool = pointslicepool.New(int(minSliceSize))
 	expr.Pool(pointSlicePool)
 	models.Pool(pointSlicePool)
 }

--- a/api/init.go
+++ b/api/init.go
@@ -9,7 +9,7 @@ import (
 var pointSlicePool *pointslicepool.PointSlicePool
 
 func init() {
-	pointSlicePool = pointslicepool.New(int(minSliceSize))
+	pointSlicePool = pointslicepool.New(0)
 	expr.Pool(pointSlicePool)
 	models.Pool(pointSlicePool)
 }

--- a/docker/docker-chaos/metrictank.ini
+++ b/docker/docker-chaos/metrictank.ini
@@ -262,6 +262,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 

--- a/docker/docker-cluster-query/metrictank.ini
+++ b/docker/docker-cluster-query/metrictank.ini
@@ -262,6 +262,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 

--- a/docker/docker-cluster/metrictank.ini
+++ b/docker/docker-cluster/metrictank.ini
@@ -262,6 +262,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 

--- a/docker/docker-dev-custom-cfg-kafka/metrictank.ini
+++ b/docker/docker-dev-custom-cfg-kafka/metrictank.ini
@@ -262,6 +262,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -311,6 +311,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 ```
 
 ## metric data inputs ##

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -272,12 +272,16 @@ how many times we could satisfy a get with a pointslice from the pool
 how many times there was nothing in the pool to satisfy a get
 * `pointslicepool.ops.get-candidate.unfit`:  
 how many times a pointslice from the pool was not large enough to satisfy a get
+* `pointslicepool.ops.get-make.default`:  
+how many times a pointslice is allocated that is equal to the default size
 * `pointslicepool.ops.get-make.large`:  
-how many times a pointslice is allocated that is larger or equal to the default size
+how many times a pointslice is allocated that is larger than the default size
 * `pointslicepool.ops.get-make.small`:  
 how many times a pointslice is allocated that is smaller than the default size
+* `pointslicepool.ops.put.default`:  
+how many times a pointslice is added to the pool that is equal to the default
 * `pointslicepool.ops.put.large`:  
-how many times a pointslice is added to the pool that is the same size or larger than the default
+how many times a pointslice is added to the pool that is larger than the default
 * `pointslicepool.ops.put.small`:  
 how many times a pointslice is added to the pool that is smaller than the default
 * `process.major_page_faults.counter64`:  

--- a/expr/func_absolute.go
+++ b/expr/func_absolute.go
@@ -35,7 +35,7 @@ func (s *FuncAbsolute) Exec(dataMap DataMap) ([]models.Series, error) {
 		serie.Target = fmt.Sprintf("absolute(%s)", serie.Target)
 		serie.Tags = serie.CopyTagsWith("absolute", "1")
 		serie.QueryPatt = fmt.Sprintf("absolute(%s)", serie.QueryPatt)
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, p := range serie.Datapoints {
 			p.Val = math.Abs(p.Val)
 			out = append(out, p)

--- a/expr/func_aggregate.go
+++ b/expr/func_aggregate.go
@@ -68,7 +68,7 @@ func aggregate(dataMap DataMap, series []models.Series, queryPatts []string, agg
 		series[0].QueryPatt = name
 		return series, nil
 	}
-	out := pointSlicePool.Get()
+	out := pointSlicePool.GetMin(len(series[0].Datapoints))
 
 	agg.function(series, &out)
 

--- a/expr/func_aspercent.go
+++ b/expr/func_aspercent.go
@@ -122,7 +122,7 @@ func (s *FuncAsPercent) execWithNodes(in, totals []models.Series, dataMap DataMa
 			nonesSerie.Tags = map[string]string{"name": nonesSerie.Target}
 
 			if nones == nil {
-				nones = pointSlicePool.Get()
+				nones = pointSlicePool.GetMin(len(totalSerieByKey[key].Datapoints))
 				for _, p := range totalSerieByKey[key].Datapoints {
 					p.Val = math.NaN()
 					nones = append(nones, p)
@@ -145,7 +145,7 @@ func (s *FuncAsPercent) execWithNodes(in, totals []models.Series, dataMap DataMa
 				nonesSerie.Meta = serie1.Meta.Copy()
 
 				if nones == nil {
-					nones = pointSlicePool.Get()
+					nones = pointSlicePool.GetMin(len(serie1.Datapoints))
 					for _, p := range serie1.Datapoints {
 						p.Val = math.NaN()
 						nones = append(nones, p)
@@ -158,7 +158,7 @@ func (s *FuncAsPercent) execWithNodes(in, totals []models.Series, dataMap DataMa
 			} else {
 				// key found in both inByKey and totalSerieByKey
 				serie1, serie2 := NormalizeTwo(serie1, totalSerieByKey[key], NewCOWCycler(dataMap))
-				serie1 = serie1.Copy(pointSlicePool.Get())
+				serie1 = serie1.Copy(pointSlicePool.GetMin(len(serie1.Datapoints)))
 
 				// this should not happen
 				if len(serie1.Datapoints) != len(serie2.Datapoints) {
@@ -227,7 +227,7 @@ func (s *FuncAsPercent) execWithoutNodes(in, totals []models.Series, dataMap Dat
 		}
 		if len(totalsSerie.Datapoints) > 0 {
 			serie, totalsSerie = NormalizeTwo(serie, totalsSerie, NewCOWCycler(dataMap))
-			serie = serie.Copy(pointSlicePool.Get())
+			serie = serie.Copy(pointSlicePool.GetMin(len(serie.Datapoints)))
 
 			// this should not happen
 			if len(serie.Datapoints) != len(totalsSerie.Datapoints) {
@@ -242,7 +242,7 @@ func (s *FuncAsPercent) execWithoutNodes(in, totals []models.Series, dataMap Dat
 				serie.Datapoints[i].Val = computeAsPercent(serie.Datapoints[i].Val, totalsSerie.Datapoints[i].Val)
 			}
 		} else {
-			serie = serie.Copy(pointSlicePool.Get())
+			serie = serie.Copy(pointSlicePool.GetMin(len(serie.Datapoints)))
 			for i := range serie.Datapoints {
 				serie.Datapoints[i].Val = computeAsPercent(serie.Datapoints[i].Val, s.totalFloat)
 			}
@@ -305,7 +305,7 @@ func sumSeries(in []models.Series, dataMap DataMap) models.Series {
 	if len(in) == 1 {
 		return in[0]
 	}
-	out := pointSlicePool.Get()
+	out := pointSlicePool.GetMin(len(in[0].Datapoints))
 	crossSeriesSum(in, &out)
 	var queryPatts []string
 	var meta models.SeriesMeta

--- a/expr/func_constantline.go
+++ b/expr/func_constantline.go
@@ -36,7 +36,7 @@ func (s *FuncConstantLine) Context(context Context) Context {
 }
 
 func (s *FuncConstantLine) Exec(dataMap DataMap) ([]models.Series, error) {
-	out := pointSlicePool.Get()
+	out := pointSlicePool.GetMin(3)
 
 	out = append(out, schema.Point{Val: s.value, Ts: s.first})
 	diff := s.last - s.first

--- a/expr/func_countseries.go
+++ b/expr/func_countseries.go
@@ -37,7 +37,7 @@ func (s *FuncCountSeries) Exec(dataMap DataMap) ([]models.Series, error) {
 
 	cons, queryCons := summarizeCons(series)
 	name := fmt.Sprintf("countSeries(%s)", strings.Join(queryPatts, ","))
-	out := pointSlicePool.Get()
+	out := pointSlicePool.GetMin(len(series[0].Datapoints))
 
 	// note: if series have different intervals, we could try to be clever and pick the one with highest resolution
 	// as it's more likely to be useful when combined with other functions, but that's too much hassle

--- a/expr/func_derivative.go
+++ b/expr/func_derivative.go
@@ -38,7 +38,7 @@ func (s *FuncDerivative) Exec(dataMap DataMap) ([]models.Series, error) {
 		serie.QueryPatt = fmt.Sprintf("derivative(%s)", serie.QueryPatt)
 		serie.Consolidator = consolidation.None
 		serie.QueryCons = consolidation.None
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 
 		prev := math.NaN()
 		for _, p := range serie.Datapoints {

--- a/expr/func_divideseries.go
+++ b/expr/func_divideseries.go
@@ -66,7 +66,6 @@ func (s *FuncDivideSeries) Exec(dataMap DataMap) ([]models.Series, error) {
 	divisorsByRes := make(map[uint32]models.Series)
 	divisorsByRes[divisors[0].Interval] = divisors[0]
 	for _, dividend := range dividends {
-		out := pointSlicePool.Get()
 		divisor := divisors[0]
 		if dividend.Interval != divisors[0].Interval {
 			lcm := util.Lcm([]uint32{dividend.Interval, divisor.Interval})
@@ -89,6 +88,8 @@ func (s *FuncDivideSeries) Exec(dataMap DataMap) ([]models.Series, error) {
 			}
 			divisor.Datapoints = divisor.Datapoints[:len(dividend.Datapoints)]
 		}
+
+		out := pointSlicePool.GetMin(len(dividend.Datapoints))
 
 		for i := 0; i < len(dividend.Datapoints); i++ {
 			p := schema.Point{

--- a/expr/func_divideserieslists.go
+++ b/expr/func_divideserieslists.go
@@ -64,7 +64,7 @@ func (s *FuncDivideSeriesLists) Exec(dataMap DataMap) ([]models.Series, error) {
 			divisor.Datapoints = divisor.Datapoints[:len(dividend.Datapoints)]
 		}
 
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(dividend.Datapoints))
 		for i := 0; i < len(dividend.Datapoints); i++ {
 			p := schema.Point{
 				Ts: dividend.Datapoints[i].Ts,

--- a/expr/func_groupbynodes.go
+++ b/expr/func_groupbynodes.go
@@ -95,7 +95,7 @@ func (s *FuncGroupByNodes) Exec(dataMap DataMap) ([]models.Series, error) {
 		group.s = Normalize(group.s, NewCOWCycler(dataMap))
 		outSeries.Interval = group.s[0].Interval
 		outSeries.SetTags()
-		outSeries.Datapoints = pointSlicePool.Get()
+		outSeries.Datapoints = pointSlicePool.GetMin(len(group.s[0].Datapoints))
 		aggFunc(group.s, &outSeries.Datapoints)
 		output = append(output, outSeries)
 	}

--- a/expr/func_groupbytags.go
+++ b/expr/func_groupbytags.go
@@ -130,7 +130,7 @@ func (s *FuncGroupByTags) Exec(dataMap DataMap) ([]models.Series, error) {
 		}
 		newSeries.SetTags()
 
-		newSeries.Datapoints = pointSlicePool.Get()
+		newSeries.Datapoints = pointSlicePool.GetMin(len(series[0].Datapoints))
 		group.s = Normalize(group.s, NewCOWCycler(dataMap))
 		aggFunc(group.s, &newSeries.Datapoints)
 		dataMap.Add(Req{}, newSeries)

--- a/expr/func_integral.go
+++ b/expr/func_integral.go
@@ -41,7 +41,7 @@ func (s *FuncIntegral) Exec(dataMap DataMap) ([]models.Series, error) {
 
 		current := 0.0
 
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, p := range serie.Datapoints {
 			if !math.IsNaN(p.Val) {
 				current += p.Val

--- a/expr/func_invert.go
+++ b/expr/func_invert.go
@@ -41,7 +41,7 @@ func (s *FuncInvert) Exec(dataMap DataMap) ([]models.Series, error) {
 	}
 
 	for i, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 
 		for _, p := range serie.Datapoints {
 			out = append(out, schema.Point{Val: newVal(p.Val), Ts: p.Ts})

--- a/expr/func_isnonnull.go
+++ b/expr/func_isnonnull.go
@@ -36,7 +36,7 @@ func (s *FuncIsNonNull) Exec(dataMap DataMap) ([]models.Series, error) {
 		serie.QueryPatt = fmt.Sprintf("isNonNull(%s)", serie.QueryPatt)
 		serie.Tags = serie.CopyTagsWith("isNonNull", "1")
 
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, p := range serie.Datapoints {
 			if math.IsNaN(p.Val) {
 				p.Val = 0

--- a/expr/func_keeplastvalue.go
+++ b/expr/func_keeplastvalue.go
@@ -49,7 +49,7 @@ func (s *FuncKeepLastValue) Exec(dataMap DataMap) ([]models.Series, error) {
 	for _, serie := range series {
 		serie.Target = fmt.Sprintf("keepLastValue(%s)", serie.Target)
 		serie.QueryPatt = serie.Target
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 
 		var consecutiveNaNs int
 		lastVal := math.NaN()

--- a/expr/func_minmax.go
+++ b/expr/func_minmax.go
@@ -52,7 +52,7 @@ func (s *FuncMinMax) Exec(dataMap DataMap) ([]models.Series, error) {
 	outputs := make([]models.Series, 0, len(series))
 
 	for _, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 
 		minVal := valOrDefault(batch.Min(serie.Datapoints), 0)
 		maxVal := valOrDefault(batch.Max(serie.Datapoints), 0)

--- a/expr/func_movingwindow.go
+++ b/expr/func_movingwindow.go
@@ -112,7 +112,7 @@ func (s *FuncMovingWindow) Exec(dataMap DataMap) ([]models.Series, error) {
 }
 
 func aggregateOnWindow(serie models.Series, aggFunc batch.AggFunc, shiftOffset uint32, xFilesFactor float64) (uint32, []schema.Point, error) {
-	out := pointSlicePool.Get()
+	out := pointSlicePool.GetMin(len(serie.Datapoints))
 
 	numPoints := len(serie.Datapoints)
 	serieStart, serieEnd := serie.QueryFrom, serie.QueryTo

--- a/expr/func_nonnegativederivative.go
+++ b/expr/func_nonnegativederivative.go
@@ -39,7 +39,7 @@ func (s *FuncNonNegativeDerivative) Exec(dataMap DataMap) ([]models.Series, erro
 	outSeries := make([]models.Series, 0, len(series))
 
 	for _, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 
 		prev := math.NaN()
 		for _, p := range serie.Datapoints {

--- a/expr/func_offset.go
+++ b/expr/func_offset.go
@@ -37,7 +37,7 @@ func (s *FuncOffset) Exec(dataMap DataMap) ([]models.Series, error) {
 
 	outSeries := make([]models.Series, 0, len(series))
 	for _, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, v := range serie.Datapoints {
 			out = append(out, schema.Point{Val: v.Val + s.factor, Ts: v.Ts})
 		}

--- a/expr/func_persecond.go
+++ b/expr/func_persecond.go
@@ -44,7 +44,7 @@ func (s *FuncPerSecond) Exec(dataMap DataMap) ([]models.Series, error) {
 
 	outSeries := make([]models.Series, 0, len(series))
 	for _, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for i, v := range serie.Datapoints {
 			out = append(out, schema.Point{Ts: v.Ts})
 			if i == 0 || math.IsNaN(v.Val) || math.IsNaN(serie.Datapoints[i-1].Val) {

--- a/expr/func_removeabovebelowpercentile.go
+++ b/expr/func_removeabovebelowpercentile.go
@@ -62,7 +62,7 @@ func (s *FuncRemoveAboveBelowPercentile) Exec(dataMap DataMap) ([]models.Series,
 			continue
 		}
 
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, p := range serie.Datapoints {
 			if s.above {
 				if p.Val > percentile {

--- a/expr/func_removeabovebelowvalue.go
+++ b/expr/func_removeabovebelowvalue.go
@@ -46,7 +46,7 @@ func (s *FuncRemoveAboveBelowValue) Exec(dataMap DataMap) ([]models.Series, erro
 		}
 		serie.QueryPatt = serie.Target
 
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, p := range serie.Datapoints {
 			if s.above {
 				if p.Val > s.n {

--- a/expr/func_round.go
+++ b/expr/func_round.go
@@ -41,7 +41,7 @@ func (s *FuncRound) Exec(dataMap DataMap) ([]models.Series, error) {
 	outputs := make([]models.Series, 0, len(series))
 	precisionMult := float64(math.Pow10(int(s.precision)))
 	for _, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 
 		for _, v := range serie.Datapoints {
 			out = append(out, schema.Point{Val: roundToPrecision(v.Val, precisionMult, int(s.precision)), Ts: v.Ts})

--- a/expr/func_scale.go
+++ b/expr/func_scale.go
@@ -37,7 +37,7 @@ func (s *FuncScale) Exec(dataMap DataMap) ([]models.Series, error) {
 
 	output := make([]models.Series, 0, len(series))
 	for _, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, v := range serie.Datapoints {
 			out = append(out, schema.Point{Val: v.Val * s.factor, Ts: v.Ts})
 		}

--- a/expr/func_scaletoseconds.go
+++ b/expr/func_scaletoseconds.go
@@ -37,7 +37,7 @@ func (s *FuncScaleToSeconds) Exec(dataMap DataMap) ([]models.Series, error) {
 	output := make([]models.Series, 0, len(series))
 	for _, serie := range series {
 
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		factor := float64(s.seconds) / float64(serie.Interval)
 		for _, p := range serie.Datapoints {
 			if !math.IsNaN(p.Val) {

--- a/expr/func_summarize.go
+++ b/expr/func_summarize.go
@@ -91,9 +91,8 @@ func (s *FuncSummarize) Exec(dataMap DataMap) ([]models.Series, error) {
 }
 
 func summarizeValues(serie models.Series, aggFunc batch.AggFunc, interval, start, end uint32) []schema.Point {
-	out := pointSlicePool.Get()
-
 	numPoints := len(serie.Datapoints)
+	out := pointSlicePool.GetMin(numPoints)
 
 	// graphite-compatible bit
 

--- a/expr/func_transformnull.go
+++ b/expr/func_transformnull.go
@@ -40,7 +40,7 @@ func (s *FuncTransformNull) Exec(dataMap DataMap) ([]models.Series, error) {
 
 	output := make([]models.Series, 0, len(series))
 	for _, serie := range series {
-		out := pointSlicePool.Get()
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
 		for _, p := range serie.Datapoints {
 			if math.IsNaN(p.Val) {
 				p.Val = s.def

--- a/expr/normalize.go
+++ b/expr/normalize.go
@@ -67,7 +67,7 @@ func NormalizeTo(in models.Series, interval uint32, sc seriescycle.SeriesCycler)
 	// so add nulls in front and at the back to make it pre-canonical.
 	// this may make points in front and at the back less accurate when consolidated (e.g. summing when some of the points are null results in a lower value)
 	// but this is what graphite does....
-	datapoints := pointSlicePool.Get()
+	datapoints := pointSlicePool.GetMin(len(in.Datapoints))
 	datapoints = makePreCanonicalCopy(in, interval, datapoints)
 
 	// series may have been created by a function that didn't know which consolidation function to default to.

--- a/metrictank-sample.ini
+++ b/metrictank-sample.ini
@@ -265,6 +265,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 

--- a/pointslicepool/pointslicepool.go
+++ b/pointslicepool/pointslicepool.go
@@ -30,15 +30,15 @@ func New(defaultSize int) *PointSlicePool {
 		getCandMiss: stats.NewCounterRate32("pointslicepool.ops.get-candidate.miss"),
 		// metric pointslicepool.ops.get-candidate.unfit is how many times a pointslice from the pool was not large enough to satisfy a get
 		getCandUnfit: stats.NewCounterRate32("pointslicepool.ops.get-candidate.unfit"),
-		// metric pointslicepool.ops.put.large is how many times a pointslice is added to the pool that is the same size or larger than the default
+		// metric pointslicepool.ops.put.large is how many times a pointslice is added to the pool that is larger than the default
 		putLarge: stats.NewCounterRate32("pointslicepool.ops.put.large"),
-		// metric pointslicepool.ops.put.small is how many times a pointslice is added to the pool that is equal to the default
+		// metric pointslicepool.ops.put.default is how many times a pointslice is added to the pool that is equal to the default
 		putDefault: stats.NewCounterRate32("pointslicepool.ops.put.default"),
 		// metric pointslicepool.ops.put.small is how many times a pointslice is added to the pool that is smaller than the default
 		putSmall: stats.NewCounterRate32("pointslicepool.ops.put.small"),
-		// metric pointslicepool.ops.get-make.large is how many times a pointslice is allocated that is larger or equal to the default size
+		// metric pointslicepool.ops.get-make.large is how many times a pointslice is allocated that is larger than the default size
 		getMakeLarge: stats.NewCounterRate32("pointslicepool.ops.get-make.large"),
-		// metric pointslicepool.ops.get-make.small is how many times a pointslice is allocated that is equal to the default size
+		// metric pointslicepool.ops.get-make.default is how many times a pointslice is allocated that is equal to the default size
 		getMakeDefault: stats.NewCounterRate32("pointslicepool.ops.get-make.default"),
 		// metric pointslicepool.ops.get-make.small is how many times a pointslice is allocated that is smaller than the default size
 		getMakeSmall: stats.NewCounterRate32("pointslicepool.ops.get-make.small"),

--- a/pointslicepool/pointslicepool.go
+++ b/pointslicepool/pointslicepool.go
@@ -7,10 +7,6 @@ import (
 	"github.com/grafana/metrictank/stats"
 )
 
-// default size is probably bigger than what most responses need, but it saves [re]allocations
-// also it's possible that occasionally more size is needed, causing a realloc of underlying array, and that extra space will stick around until next GC run.
-const DefaultPointSliceSize = 2000
-
 type PointSlicePool struct {
 	getCandHit   *stats.CounterRate32
 	getCandMiss  *stats.CounterRate32

--- a/pointslicepool/pointslicepool.go
+++ b/pointslicepool/pointslicepool.go
@@ -47,6 +47,12 @@ func New(defaultSize int) *PointSlicePool {
 	}
 }
 
+// SetDefaultSize - Change the default size for the point slice pool.
+// This function is not thread-safe and should only be called when pool is not being actively used.
+func (p *PointSlicePool) SetDefaultSize(size int) {
+	p.defaultSize = size
+}
+
 func (p *PointSlicePool) PutMaybeNil(s []schema.Point) {
 	if s != nil {
 		p.Put(s)

--- a/scripts/config/metrictank-docker-dev.ini
+++ b/scripts/config/metrictank-docker-dev.ini
@@ -262,6 +262,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 

--- a/scripts/config/metrictank-docker.ini
+++ b/scripts/config/metrictank-docker.ini
@@ -262,6 +262,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 

--- a/scripts/config/metrictank-package.ini
+++ b/scripts/config/metrictank-package.ini
@@ -262,6 +262,8 @@ pre-normalization = true
 mdp-optimization = false
 # output query headers in logs
 log-headers = false
+# Minimum (and default) length of slice to allocate from pool
+min-slice-pool-size = 2000
 
 ## metric data inputs ##
 


### PR DESCRIPTION
These changes are to try to improve the SlicePool hit rate. Our query nodes have a very disappointing hit rate of ~80%. 

I believe the reason is that most queries handle raw series that aren't 2000 datapoints long, yet will be added to the pool. Then most functions will be asking for 2000 (because they don't specify what they need). Because unfit slices are added back to the pool, we *could* (unverified) also be repeatedly grabbing the same low capacity slice over and over again.

So these changes:
1. Call `GetMin` everywhere we have a good idea of how many points we need
2. Make the min/default slice size configurable
3. Unbias PointSlicePool metrics - The metrics as they existed lumped `large` with default, making it difficult to know how often the default size was insufficiently large.