### PR TITLE
Add CHANGELOG.md entry for detailed plan errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * add some error checking in ccache metric search. #1961
 * track non-primary rollup reads #1968
 * Return 403 instead of 413 when limit exceeded #1970
+* errors returned by expr.NewPlan() now wrap the expr.Err* errors with detailed message about where the error happened,
+  so they have to be checked with errors.As()/errors.Is() #1996
 
 # 1.1 Jan 14, 2021.
 


### PR DESCRIPTION
See https://github.com/grafana/metrictank/pull/1996

I missed the CHANGELOG.md there.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>