### PR TITLE
tszlong: make encoding more compact by conservatively resetting leading/trailing bitcount

### DIFF
--- a/mdata/chunk/tsz/tsz_test.go
+++ b/mdata/chunk/tsz/tsz_test.go
@@ -24,20 +24,68 @@ func BenchmarkPushSeries4h(b *testing.B) {
 	b.Logf("Series4h size: %dB", len(s.Bytes()))
 }
 
-func BenchmarkPushSeriesLong(b *testing.B) {
+func benchmarkSeriesLong(b *testing.B, generator func(uint32) float64) {
 	s := NewSeriesLong(0)
 	N := uint32(b.N)
 	for i := uint32(1); i <= N; i++ {
-		if i%10 == 0 {
-			s.Push(i, 0)
-		} else if i%10 == 1 {
-			s.Push(i, 1)
-		} else {
-			s.Push(i, float64(i)+123.45)
-		}
+		s.Push(i, generator(i))
 	}
 	s.Finish()
-	b.Logf("SeriesLong size: %dB", len(s.Bytes()))
+	b.Logf("SeriesLong size: %d points in %dB, avg %.2f bytes/point", N, len(s.Bytes()), float64(len(s.Bytes()))/float64(N))
+}
+
+func BenchmarkPushSeriesLong(b *testing.B) {
+	benchmarkSeriesLong(b, func(i uint32) float64 {
+		if i%10 == 0 {
+			return 0
+		} else if i%10 == 1 {
+			return 1
+		}
+		return float64(i) + 123.45
+	})
+}
+
+func BenchmarkPushSeriesLongMonotonicIncrease(b *testing.B) {
+	benchmarkSeriesLong(b, func(i uint32) float64 {
+		return float64(i) + 123.45
+	})
+}
+
+func BenchmarkPushSeriesLongSawtooth(b *testing.B) {
+	benchmarkSeriesLong(b, func(i uint32) float64 {
+		multiplier := 1.0
+		if i%2 == 0 {
+			multiplier = -1.0
+		}
+		return multiplier*123.45 + float64(i)/1000
+	})
+}
+
+func BenchmarkPushSeriesLongSawtoothWithFlats(b *testing.B) {
+	benchmarkSeriesLong(b, func(i uint32) float64 {
+		multiplier := 1.0
+		if i%2 == 0 && i%100 != 0 {
+			multiplier = -1.0
+		}
+		return multiplier*123.45 + float64(i)/1000
+	})
+}
+
+func BenchmarkPushSeriesLongSteps(b *testing.B) {
+	benchmarkSeriesLong(b, func(i uint32) float64 {
+		multiplier := 1.0
+		if (i/100)%2 == 0 {
+			multiplier = -1.0
+		}
+		return multiplier*123.45 + float64(i)/1000
+	})
+}
+
+func BenchmarkPushSeriesLongRealWorldCPU(b *testing.B) {
+	values := []float64{95.3, 95.7, 86.2, 95.0, 94.7, 95.4, 94.5, 94.0, 94.7, 95.0, 95.0, 93.8, 95.3, 95.4, 94.6, 83.8, 94.5, 94.5, 94.6, 92.0, 95.0, 89.6, 72.8, 72.1, 86.5, 94.9, 94.9, 93.9, 94.4, 95.4, 95.1, 93.7, 95.5, 95.4, 94.4, 93.2, 94.6, 95.5, 94.9, 94.1, 95.0, 95.5, 94.7, 93.7, 95.1, 96.6, 95.3, 94.0, 95.0, 95.2, 93.3, 94.2, 95.2, 94.9, 94.5, 95.3, 93.2, 95.4, 95.0, 95.2, 93.7}
+	benchmarkSeriesLong(b, func(i uint32) float64 {
+		return values[int(i)%len(values)]
+	})
 }
 
 func BenchmarkIterSeries4h(b *testing.B) {


### PR DESCRIPTION
While profiling memory usage for Metrictank we found that ~15% of memory usage came from the raw bstream. This wasn't surprisingly high, but we decided to look for possible optimizations. 

We found that 67% of those allocations came from [this one line](https://github.com/grafana/metrictank/blob/f587cec/mdata/chunk/tsz/tszlong.go#L122). This line is for writing the significant bits when the value isn't exactly the same as the previous, but falls within the leading/trailing zeroes that previously had been written. However, since the leading/trailing is never reset, a single errant value can cause a lot of significant bits to be written each time. This is especially true for floating point values. For example ([playground](https://play.golang.org/p/6w0l-yETG1r)):

`math.Float64bits(126.45) ^ math.Float64bits(127.45)` only has a difference of 1 bit (17 leading zeroes/46 trailing)
`math.Float64bits(127.45) ^ math.Float64bits(128.45)` has only 10 leading zeroes and 0 trailing.

So in a lot of cases we could end up writing many bits of extra sig figs (lots of leading/trailing zeroes) when it could be better to just re-encode the leading/trailing zeroes and write fewer sig figs for some amount of time.

I added some more scenarios to the benchmarks to test various data patterns, 120 datapoints each (chosen as that is the [recommended chunk size](https://github.com/grafana/metrictank/blob/cd09d04d4c784beecf3978016cda6695747c003c/docs/memory-server.md#compression-efficiency)):

|Pattern|Old Bytes|New Bytes|% of Old|
|-------|----------|-----------|---------------|
|Mono+reset|993|384|38.67%|
|Mono|843|162|19.2%|
|SawTooth|1008|1006|99.8%|
|SawTooth+Flat|1008|1004|99.6%|
|Steps|752|703|93.48%|
|Real World CPU|777|671|86.36%|

As seen, this approach performs no worse than the existing in terms of chunk size, however in some cases it is *significantly* better.  I have yet to plug this into a running MT instance and see if the result is true across a large range of real-world data.