### PR TITLE
ROB: Fix underflow bug and reduce allocations 

### DIFF
--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -468,12 +468,13 @@ func (a *AggMetric) Add(ts uint32, val float64) {
 		a.add(ts, val)
 	} else {
 		// write through reorder buffer
-		res, err := a.rob.Add(ts, val)
+		pt, res, err := a.rob.Add(ts, val)
 
 		if err == nil {
-			if len(res) == 0 {
+			if pt.Ts == 0 {
 				a.lastWrite = uint32(time.Now().Unix())
 			} else {
+				a.add(pt.Ts, pt.Val)
 				for _, p := range res {
 					a.add(p.Ts, p.Val)
 				}

--- a/mdata/reorder_buffer.go
+++ b/mdata/reorder_buffer.go
@@ -35,7 +35,7 @@ func (rob *ReorderBuffer) Add(ts uint32, val float64) (schema.Point, []schema.Po
 
 	newestTs := rob.buf[rob.newest].Ts
 	// out of order and too old
-	if newestTs != 0 && ts < newestTs && ts <= newestTs-(uint32(cap(rob.buf))*rob.interval) {
+	if newestTs != 0 && ts < newestTs && newestTs-ts >= (uint32(cap(rob.buf))*rob.interval) {
 		return schema.Point{}, nil, errors.ErrMetricTooOld
 	}
 

--- a/mdata/reorder_buffer_test.go
+++ b/mdata/reorder_buffer_test.go
@@ -376,7 +376,7 @@ func TestROBAvoidUnderflow(t *testing.T) {
 
 	expectedLen := len(data) - windowSize
 	if len(results) != expectedLen {
-		t.Fatalf("Expected %d results, got %d", len(results), expectedLen)
+		t.Fatalf("Expected %d results, got %d", expectedLen, len(results))
 	}
 
 	for i := 0; i < len(results); i++ {

--- a/mdata/reorder_buffer_test.go
+++ b/mdata/reorder_buffer_test.go
@@ -14,8 +14,12 @@ func testAddAndGet(t *testing.T, reorderWindow uint32, testData, expectedData []
 	metricsReordered.SetUint32(0)
 	addedCount := uint32(0)
 	for i, point := range testData {
-		addRes, err := b.Add(point.Ts, point.Val)
-		flushed = append(flushed, addRes...)
+		pt, addRes, err := b.Add(point.Ts, point.Val)
+
+		if pt.Ts != 0 {
+			flushed = append(flushed, pt)
+			flushed = append(flushed, addRes...)
+		}
 		if expectedErrors != nil && err != expectedErrors[i] {
 			t.Fatalf("Data point #%d: expected error '%v', but had '%v'", i, expectedErrors[i], err)
 		}
@@ -223,8 +227,8 @@ func TestROBAddAndGetDuplicateAllowUpdate(t *testing.T) {
 func TestROBOmitFlushIfNotEnoughData(t *testing.T) {
 	b := NewReorderBuffer(9, 1, false)
 	for i := uint32(1); i < 10; i++ {
-		flushed, _ := b.Add(i, float64(i*100))
-		if len(flushed) > 0 {
+		pt, _, _ := b.Add(i, float64(i*100))
+		if pt.Ts != 0 {
 			t.Fatalf("Expected no data to get flushed out")
 		}
 	}
@@ -276,11 +280,13 @@ func TestROBFlushSortedData(t *testing.T) {
 	var results []schema.Point
 	buf := NewReorderBuffer(600, 1, false)
 	for i := 1100; i < 2100; i++ {
-		flushed, err := buf.Add(uint32(i), float64(i))
+		pt, flushed, err := buf.Add(uint32(i), float64(i))
 		if err != nil {
 			t.Fatalf("Adding failed")
+		} else if pt.Ts != 0 {
+			results = append(results, pt)
+			results = append(results, flushed...)
 		}
-		results = append(results, flushed...)
 	}
 
 	for i := 0; i < 400; i++ {
@@ -305,10 +311,11 @@ func TestROBFlushUnsortedData1(t *testing.T) {
 	}
 	failedCount := 0
 	for _, p := range data {
-		flushed, err := buf.Add(p.Ts, p.Val)
+		pt, flushed, err := buf.Add(p.Ts, p.Val)
 		if err != nil {
 			failedCount++
-		} else {
+		} else if pt.Ts != 0 {
+			results = append(results, pt)
 			results = append(results, flushed...)
 		}
 	}
@@ -338,8 +345,11 @@ func TestROBFlushUnsortedData2(t *testing.T) {
 	}
 	unsortedData := unsort(data, 10)
 	for i := 0; i < len(data); i++ {
-		flushed, _ := buf.Add(unsortedData[i].Ts, unsortedData[i].Val)
-		results = append(results, flushed...)
+		pt, flushed, _ := buf.Add(unsortedData[i].Ts, unsortedData[i].Val)
+		if pt.Ts != 0 {
+			results = append(results, pt)
+			results = append(results, flushed...)
+		}
 	}
 	for i := 0; i < 400; i++ {
 		if results[i].Ts != uint32(i+1000) || results[i].Val != float64(i+1000) {
@@ -357,8 +367,11 @@ func TestROBAvoidUnderflow(t *testing.T) {
 		data[i] = schema.Point{Ts: uint32(i + 1), Val: float64(i + 1000)}
 	}
 	for i := 0; i < len(data); i++ {
-		flushed, _ := buf.Add(data[i].Ts, data[i].Val)
-		results = append(results, flushed...)
+		pt, flushed, _ := buf.Add(data[i].Ts, data[i].Val)
+		if pt.Ts != 0 {
+			results = append(results, pt)
+			results = append(results, flushed...)
+		}
 	}
 
 	expectedLen := len(data) - windowSize
@@ -498,7 +511,7 @@ func benchmarkROBAdd(b *testing.B, window, shufgroup int, allowUpdate bool) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		out, _ = rob.Add(data[i].Ts, data[i].Val)
+		_, out, _ = rob.Add(data[i].Ts, data[i].Val)
 	}
 	if len(out) > 1000 {
 		panic("this clause should never fire. only exists for compiler not to optimize away the results")


### PR DESCRIPTION
### Underflow Bug

This was not my main goal, but was breaking the benchmarks. This bug is unlikely in production because it requires very old timestamps.

The line `rob.buf[rob.newest].Ts-(uint32(cap(rob.buf))*rob.interval` can cause an underflow when `rob.buf[rob.newest].Ts` is smaller than `cap(rob.buf)*rob.interval` and will wrap around to a very large number. This incorrectly returns and error (metric too old). The benchmarks all start at Ts=1 so they were never actually getting beyond this check. I added a test case for this as well.

### Reduce Allocations

One of the top allocators in our Metrictank deploy is the ROB. It makes an allocation if any point is flushed during `Add`. This is due to how it returns the flushed values from `Add` in a slice. However, in the most common case data comes in order and will flush exactly 1 point. This change is to return a `schema.Point` along with the slice. If a single point needs to be flushed, no slice needs to be allocated. If more than one is flushed, then we still need to allocate the slice. However, I also pre-allocate the slice to the size needed, which speeds up even the out-of-order cases. 

This change does make the code a little uglier, but it is quite a bit faster and reduces allocations.

```
name                                   old time/op    new time/op    delta
ROB10AddDisallowUpdate-12                49.8ns ± 2%    20.7ns ± 7%   -58.43%  (p=0.000 n=18+20)
ROB120AddDisallowUpdate-12               50.5ns ± 3%    21.0ns ± 7%   -58.39%  (p=0.000 n=20+20)
ROB600AddDisallowUpdate-12               50.0ns ± 2%    19.7ns ± 2%   -60.55%  (p=0.000 n=20+17)
ROB10AddShuffled5DisallowUpdate-12       46.5ns ± 1%    26.4ns ± 6%   -43.18%  (p=0.000 n=17+18)
ROB120AddShuffled5DisallowUpdate-12      46.7ns ± 1%    26.1ns ± 1%   -44.08%  (p=0.000 n=19+20)
ROB600AddShuffled5DisallowUpdate-12      46.6ns ± 1%    26.1ns ± 2%   -44.10%  (p=0.000 n=19+20)
ROB10AddShuffled50DisallowUpdate-12      12.6ns ± 2%    10.5ns ± 6%   -16.87%  (p=0.000 n=17+20)
ROB120AddShuffled50DisallowUpdate-12     31.5ns ± 3%    26.3ns ± 2%   -16.41%  (p=0.000 n=19+18)
ROB600AddShuffled50DisallowUpdate-12     31.9ns ± 3%    26.1ns ± 3%   -18.18%  (p=0.000 n=19+20)
ROB10AddShuffled500DisallowUpdate-12     6.43ns ± 9%    6.34ns ± 6%      ~     (p=0.262 n=20+20)
ROB120AddShuffled500DisallowUpdate-12    11.5ns ± 6%    10.4ns ± 3%    -9.87%  (p=0.000 n=20+19)
ROB600AddShuffled500DisallowUpdate-12    28.3ns ± 6%    25.5ns ± 1%   -10.15%  (p=0.000 n=20+17)
ROB10AddAllowUpdate-12                   50.2ns ± 2%    19.6ns ± 1%   -60.91%  (p=0.000 n=19+19)
ROB120AddAllowUpdate-12                  50.4ns ± 1%    19.8ns ± 3%   -60.73%  (p=0.000 n=20+19)
ROB600AddAllowUpdate-12                  50.4ns ± 2%    19.8ns ± 2%   -60.67%  (p=0.000 n=20+18)
ROB10AddShuffled5AllowUpdate-12          47.1ns ± 3%    26.4ns ± 3%   -44.00%  (p=0.000 n=19+18)
ROB120AddShuffled5AllowUpdate-12         46.7ns ± 3%    26.2ns ± 1%   -44.00%  (p=0.000 n=20+19)
ROB600AddShuffled5AllowUpdate-12         47.1ns ± 3%    26.9ns ± 6%   -43.02%  (p=0.000 n=18+20)
ROB10AddShuffled50AllowUpdate-12         13.1ns ± 5%    10.9ns ±10%   -17.14%  (p=0.000 n=20+20)
ROB120AddShuffled50AllowUpdate-12        33.6ns ±10%    26.5ns ± 3%   -21.16%  (p=0.000 n=17+19)
ROB600AddShuffled50AllowUpdate-12        32.4ns ± 6%    26.4ns ± 3%   -18.67%  (p=0.000 n=20+20)
ROB10AddShuffled500AllowUpdate-12        6.25ns ± 3%    6.18ns ± 5%      ~     (p=0.072 n=17+20)
ROB120AddShuffled500AllowUpdate-12       11.2ns ± 4%    10.5ns ± 2%    -6.97%  (p=0.000 n=20+18)
ROB600AddShuffled500AllowUpdate-12       28.0ns ± 6%    25.7ns ± 3%    -8.41%  (p=0.000 n=19+20)

name                                   old alloc/op   new alloc/op   delta
ROB10AddDisallowUpdate-12                 15.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
ROB120AddDisallowUpdate-12                15.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
ROB600AddDisallowUpdate-12                15.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
ROB10AddShuffled5DisallowUpdate-12        47.0B ± 0%     12.0B ± 0%   -74.47%  (p=0.000 n=20+20)
ROB120AddShuffled5DisallowUpdate-12       47.0B ± 0%     12.0B ± 0%   -74.47%  (p=0.000 n=20+20)
ROB600AddShuffled5DisallowUpdate-12       47.0B ± 0%     12.0B ± 0%   -74.47%  (p=0.000 n=20+20)
ROB10AddShuffled50DisallowUpdate-12       9.00B ± 0%     2.00B ± 0%   -77.78%  (p=0.000 n=20+20)
ROB120AddShuffled50DisallowUpdate-12      40.0B ± 0%     17.0B ± 0%   -57.50%  (p=0.000 n=20+20)
ROB600AddShuffled50DisallowUpdate-12      40.0B ± 0%     17.0B ± 0%   -57.50%  (p=0.000 n=20+20)
ROB10AddShuffled500DisallowUpdate-12      0.00B          0.00B           ~     (all equal)
ROB120AddShuffled500DisallowUpdate-12     8.00B ± 0%     4.00B ± 0%   -50.00%  (p=0.000 n=20+20)
ROB600AddShuffled500DisallowUpdate-12     32.0B ± 0%     16.0B ± 0%   -50.00%  (p=0.000 n=20+20)
ROB10AddAllowUpdate-12                    15.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
ROB120AddAllowUpdate-12                   15.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
ROB600AddAllowUpdate-12                   15.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
ROB10AddShuffled5AllowUpdate-12           47.0B ± 0%     12.0B ± 0%   -74.47%  (p=0.000 n=20+20)
ROB120AddShuffled5AllowUpdate-12          47.0B ± 0%     12.0B ± 0%   -74.47%  (p=0.000 n=20+20)
ROB600AddShuffled5AllowUpdate-12          47.0B ± 0%     12.0B ± 0%   -74.47%  (p=0.000 n=20+20)
ROB10AddShuffled50AllowUpdate-12          9.00B ± 0%     2.00B ± 0%   -77.78%  (p=0.000 n=20+20)
ROB120AddShuffled50AllowUpdate-12         40.0B ± 0%     17.0B ± 0%   -57.50%  (p=0.000 n=20+20)
ROB600AddShuffled50AllowUpdate-12         40.0B ± 0%     17.0B ± 0%   -57.50%  (p=0.000 n=20+20)
ROB10AddShuffled500AllowUpdate-12         0.00B          0.00B           ~     (all equal)
ROB120AddShuffled500AllowUpdate-12        8.00B ± 0%     4.00B ± 0%   -50.00%  (p=0.000 n=20+20)
ROB600AddShuffled500AllowUpdate-12        32.0B ± 0%     16.0B ± 0%   -50.00%  (p=0.000 n=20+20)
```
