### PR TITLE
Support batching of MetricPoints

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -54,9 +54,15 @@ and rather just set it in configuration, this makes the message more compact, bu
 
 ### MetricPointArray
 
-This format supports multiple MetricPoint values in a single Kafka message. The message format is: a single prefixed format byte `FormatMetricPointArray` (5) followed by another byte for the MetricPoint sub-format (either `FormatMetricPoint` or `FormatMetricPointWithoutOrg`). After the format bytes comes a sequence of concatenated points (in the specified sub-format) with no delimiters.
+This format supports multiple MetricPoint values in a single Kafka message. The message format is:
 
-This format greatly reduces the message overhead from kafka (both for producers and Metrictank).
+1. a single prefixed format byte `FormatMetricPointArray` (`0x05`) followed by
+1. another byte for the MetricPoint sub-format, one of:
+   * `FormatMetricPoint` (`0x02`)
+   * `FormatMetricPointWithoutOrg` (`0x03`)
+1. a sequence of concatenated points (in the specified sub-format) with no delimiters.
+
+Effective batching greatly reduces the message overhead from kafka (both for producers and Metrictank).
 
 ### Future formats
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -3,23 +3,21 @@
 All input options - except for the carbon input - use the [metrics 2.0](http://metrics20.org/) format.
 See [schema](https://github.com/grafana/metrictank/schema) for more details.
 
-
 ## How to send data to MT
 
 see fakemetrics, tsdb-gw, carbon
 
-
 ## Carbon
+
 useful for traditional graphite plaintext protocol.  Does not support pickle format.
 
-** Important: this input requires a
+**Important: this input requires a
 [carbon storage-schemas.conf](http://graphite.readthedocs.io/en/latest/config-carbon.html#storage-schemas-conf) file.
 Metrictank uses this file to determine the raw interval of the metrics, but it ignores all retention durations
 as well as intervals after the first, raw one since metrictank already has its own config mechanism
-for retention and aggregation. **
+for retention and aggregation.**
 
 note: it does not implement [carbon2.0](http://metrics20.org/implementations/)
-
 
 ## Kafka-mdm (recommended)
 
@@ -54,8 +52,14 @@ Note that the implementation has encode/decode function for the standard MetricP
 part of the series id.  For single-tenant environments, you can configure your producers and metrictank to not encode an org-id in all messages
 and rather just set it in configuration, this makes the message more compact, but won't work in multi-tenant environments.
 
+### MetricPointArray
+
+This format supports multiple MetricPoint values in a single Kafka message. The message format is: a single prefixed format byte `FormatMetricPointArray` (5) followed by another byte for the MetricPoint sub-format (either `FormatMetricPoint` or `FormatMetricPointWithoutOrg`). After the format bytes comes a sequence of concatenated points (in the specified sub-format) with no delimiters.
+
+This format greatly reduces the message overhead from kafka (both for producers and Metrictank).
+
 ### Future formats
 
 In the future we plan to do more optimisations such as:
-* batch encoding instead of a kafka message per point.
+
 * further compression (e.g. multiple points with shared timestamp).

--- a/input/kafkamdm/kafkamdm.go
+++ b/input/kafkamdm/kafkamdm.go
@@ -324,8 +324,7 @@ func (k *KafkaMdm) handleMsg(data []byte, partition int32) {
 		for iter.Next() {
 			k.Handler.ProcessMetricPoint(iter.Value(), iter.Format(), partition)
 		}
-		err := iter.Err()
-		if err != nil {
+		if err := iter.Err(); err != nil {
 			metricsDecodeErr.Inc()
 			log.Errorf("kafkamdm: decode metricpoint array error, skipping message. %s", err)
 		}

--- a/schema/msg/format.go
+++ b/schema/msg/format.go
@@ -4,6 +4,24 @@ package msg
 
 type Format uint8
 
+// incoming messages in the mdm topic come in 3 flavors, and are mostly defined by the below constants
+
+// 1) MetricPoint observations and array variants
+// <FormatMetricPointWithoutOrg><28 more bytes>
+// <FormatMetricPoint><32 more bytes>
+// <FormatMetricPointAray><FormatMetricPoint|FormatMetricPointWithoutOrg><28 or more bytes>
+//
+// 2) index control messages
+//
+// <FormatIndexControlMessage><any other bytes>
+
+// 3) MetricData
+//
+// anything that has a first byte not matching any of the predefined constants.
+// in practice, the first byte of a MetricData will be 0x89,
+// though experts writing their own publishers and encoders may have found ways to
+// use bytes 0x85 through 0x89 as first byte, though this seems unlikely and discouraged
+// see https://github.com/grafana/metrictank/issues/2028
 // identifier of message format
 const (
 	FormatMetricDataArrayJson Format = iota

--- a/schema/msg/format.go
+++ b/schema/msg/format.go
@@ -11,4 +11,5 @@ const (
 	FormatMetricPoint
 	FormatMetricPointWithoutOrg
 	FormatIndexControlMessage
+	FormatMetricPointArray
 )

--- a/schema/msg/format.go
+++ b/schema/msg/format.go
@@ -22,7 +22,9 @@ type Format uint8
 // though experts writing their own publishers and encoders may have found ways to
 // use bytes 0x85 through 0x89 as first byte, though this seems unlikely and discouraged
 // see https://github.com/grafana/metrictank/issues/2028
+
 // identifier of message format
+// NOTE: None of these constants should be changed as external tasks may be using the absolute values.
 const (
 	FormatMetricDataArrayJson Format = iota
 	FormatMetricDataArrayMsgp

--- a/schema/msg/format_string.go
+++ b/schema/msg/format_string.go
@@ -13,11 +13,12 @@ func _() {
 	_ = x[FormatMetricPoint-2]
 	_ = x[FormatMetricPointWithoutOrg-3]
 	_ = x[FormatIndexControlMessage-4]
+	_ = x[FormatMetricPointArray-5]
 }
 
-const _Format_name = "FormatMetricDataArrayJsonFormatMetricDataArrayMsgpFormatMetricPointFormatMetricPointWithoutOrgFormatIndexControlMessage"
+const _Format_name = "FormatMetricDataArrayJsonFormatMetricDataArrayMsgpFormatMetricPointFormatMetricPointWithoutOrgFormatIndexControlMessageFormatMetricPointArray"
 
-var _Format_index = [...]uint8{0, 25, 50, 67, 94, 119}
+var _Format_index = [...]uint8{0, 25, 50, 67, 94, 119, 141}
 
 func (i Format) String() string {
 	if i >= Format(len(_Format_index)-1) {

--- a/schema/msg/msg.go
+++ b/schema/msg/msg.go
@@ -113,7 +113,7 @@ func WritePointMsg(point schema.MetricPoint, buf []byte, version Format) (o []by
 }
 
 // WritePointMsgArray is like CreateMsg, except optimized for MetricPoint and buffer re-use.
-// caller must assure a cap-len diff of at least:
+// caller must assure a cap-len diff of exactly:
 // 2 + 32B * len(points) (for FormatMetricPoint)
 // 2 + 28B * len(points) (for FormatMetricPointWithoutOrg)
 // no other formats supported.

--- a/schema/msg/msg.go
+++ b/schema/msg/msg.go
@@ -112,6 +112,41 @@ func WritePointMsg(point schema.MetricPoint, buf []byte, version Format) (o []by
 	return nil, fmt.Errorf(errFmtUnsupportedFormat, version)
 }
 
+// WritePointMsgArray is like CreateMsg, except optimized for MetricPoint and buffer re-use.
+// caller must assure a cap-len diff of at least:
+// 2 + 32B * len(points) (for FormatMetricPoint)
+// 2 + 28B * len(points) (for FormatMetricPointWithoutOrg)
+// no other formats supported.
+func WritePointMsgArray(points []schema.MetricPoint, buf []byte, version Format) (o []byte, err error) {
+	if len(points) == 0 {
+		return buf, errTooSmall
+	}
+
+	b := buf[:2]
+	b[0] = byte(FormatMetricPointArray)
+	b[1] = byte(version)
+
+	var formatter func(m *schema.MetricPoint, b []byte) (o []byte, err error)
+
+	switch version {
+	case FormatMetricPoint:
+		formatter = (*schema.MetricPoint).Marshal32
+	case FormatMetricPointWithoutOrg:
+		formatter = (*schema.MetricPoint).MarshalWithoutOrg28
+	default:
+		return nil, fmt.Errorf(errFmtUnsupportedFormat, version)
+	}
+
+	for _, p := range points {
+		b, err = formatter(&p, b)
+		if err != nil {
+			return b, err
+		}
+	}
+
+	return b, nil
+}
+
 func IsPointMsg(data []byte) (Format, bool) {
 	l := len(data)
 	if l == 0 {
@@ -124,22 +159,90 @@ func IsPointMsg(data []byte) (Format, bool) {
 	if l == 33 && version == FormatMetricPoint {
 		return FormatMetricPoint, true
 	}
+	if l >= 30 && version == FormatMetricPointArray {
+		subversion := Format(data[1])
+		if subversion == FormatMetricPointWithoutOrg || subversion == FormatMetricPoint {
+			// TODO - check length multiple?
+			return FormatMetricPointArray, true
+		}
+	}
 	return 0, false
 }
 
 func ReadPointMsg(data []byte, defaultOrg uint32) ([]byte, schema.MetricPoint, error) {
-	var point schema.MetricPoint
 	version := Format(data[0])
-	if len(data) == 29 && version == FormatMetricPointWithoutOrg {
-		o, err := point.UnmarshalWithoutOrg(data[1:])
+	return ReadPointMsgFormat(data[1:], defaultOrg, version)
+}
+
+func ReadPointMsgFormat(data []byte, defaultOrg uint32, version Format) ([]byte, schema.MetricPoint, error) {
+	var point schema.MetricPoint
+	if len(data) >= 28 && version == FormatMetricPointWithoutOrg {
+		o, err := point.UnmarshalWithoutOrg(data)
 		point.MKey.Org = defaultOrg
 		return o, point, err
 	}
-	if len(data) == 33 && version == FormatMetricPoint {
-		o, err := point.Unmarshal(data[1:])
+	if len(data) >= 32 && version == FormatMetricPoint {
+		o, err := point.Unmarshal(data)
 		return o, point, err
 	}
 	return data, point, fmt.Errorf(errFmtUnsupportedFormat, version)
+}
+
+type MetricPointIter struct {
+	data       []byte
+	defaultOrg uint32
+	point      schema.MetricPoint
+	format     Format
+	err        error
+}
+
+func NewMetricPointIter(data []byte, defaultOrg uint32) MetricPointIter {
+	var result MetricPointIter
+	if len(data) < 30 {
+		result.err = errTooSmall
+		return result
+	}
+	version := Format(data[0])
+	if version != FormatMetricPointArray {
+		result.err = fmt.Errorf(errFmtUnsupportedFormat, version)
+		return result
+	}
+	subversion := Format(data[1])
+	if subversion != FormatMetricPointWithoutOrg && subversion != FormatMetricPoint {
+		result.err = fmt.Errorf(errFmtUnsupportedFormat, version)
+		return result
+	}
+
+	result.data = data[2:]
+	result.defaultOrg = defaultOrg
+	result.format = subversion
+
+	return result
+}
+
+func (m *MetricPointIter) Next() bool {
+	if len(m.data) == 0 {
+		// All done
+		return false
+	}
+	if len(m.data) < 28 {
+		m.err = errTooSmall
+		return false
+	}
+	m.data, m.point, m.err = ReadPointMsgFormat(m.data, m.defaultOrg, m.format)
+	return m.err == nil
+}
+
+func (m *MetricPointIter) Value() schema.MetricPoint {
+	return m.point
+}
+
+func (m *MetricPointIter) Format() Format {
+	return m.format
+}
+
+func (m *MetricPointIter) Err() error {
+	return m.err
 }
 
 func IsIndexControlMsg(data []byte) bool {

--- a/schema/msg/msg_test.go
+++ b/schema/msg/msg_test.go
@@ -74,6 +74,105 @@ func TestWriteReadPointMsgWithoutOrg(t *testing.T) {
 	}
 }
 
+func TestWriteReadPointMsgArray(t *testing.T) {
+	mp := []schema.MetricPoint{
+		{
+			MKey: schema.MKey{
+				Org: 123,
+			},
+			Time:  math.MaxUint32,
+			Value: 123.45,
+		},
+		{
+			MKey: schema.MKey{
+				Org: 1,
+			},
+			Time:  math.MaxUint32,
+			Value: 1,
+		},
+		{
+			MKey: schema.MKey{
+				Org: 2,
+			},
+			Time:  math.MaxUint32,
+			Value: 12,
+		},
+	}
+	buf := make([]byte, 0, 2+32*3)
+	out, err := WritePointMsgArray(mp, buf, FormatMetricPoint)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	_, ok := IsPointMsg(out)
+	if !ok {
+		t.Fatal("IsPointMsg: exp true, got false")
+	}
+
+	var outPoints []schema.MetricPoint
+	iter := NewMetricPointIter(out, 6)
+	for iter.Next() {
+		outPoints = append(outPoints, iter.Value())
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("%s", iter.Err().Error())
+	}
+
+	if !reflect.DeepEqual(mp, outPoints) {
+		t.Fatalf("expected point %v, got %v", mp, outPoints)
+	}
+}
+
+func TestWriteReadPointMsgArrayWithoutOrg(t *testing.T) {
+	mp := []schema.MetricPoint{
+		{
+			MKey:  schema.MKey{},
+			Time:  math.MaxUint32,
+			Value: 123.45,
+		},
+		{
+			MKey:  schema.MKey{},
+			Time:  math.MaxUint32,
+			Value: 1,
+		},
+		{
+			MKey:  schema.MKey{},
+			Time:  math.MaxUint32,
+			Value: 12,
+		},
+	}
+	buf := make([]byte, 0, 2+28*3)
+	out, err := WritePointMsgArray(mp, buf, FormatMetricPointWithoutOrg)
+	if err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	_, ok := IsPointMsg(out)
+	if !ok {
+		t.Fatal("IsPointMsg: exp true, got false")
+	}
+
+	// iter will have to set the default org and we want to check it
+	for i := range mp {
+		mp[i].MKey.Org = 6
+	}
+
+	var outPoints []schema.MetricPoint
+	iter := NewMetricPointIter(out, 6)
+	for iter.Next() {
+		outPoints = append(outPoints, iter.Value())
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("%s", iter.Err().Error())
+	}
+
+	if !reflect.DeepEqual(mp, outPoints) {
+		t.Fatalf("expected point %v, got %v", mp, outPoints)
+	}
+}
+
 func TestWriteReadIndexControlMsg(t *testing.T) {
 	mp := schema.ControlMsg{
 		Op:   schema.OpArchive,

--- a/schema/msg/msg_test.go
+++ b/schema/msg/msg_test.go
@@ -98,6 +98,8 @@ func TestWriteReadPointMsgArray(t *testing.T) {
 			Value: 12,
 		},
 	}
+	// copy to make sure the function under test doesn't modify input
+	inputCopy := append(make([]schema.MetricPoint, 0, len(mp)), mp...)
 	buf := make([]byte, 0, 2+32*len(mp))
 	out, err := WritePointMsgArray(mp, buf, FormatMetricPoint)
 	if err != nil {
@@ -119,8 +121,8 @@ func TestWriteReadPointMsgArray(t *testing.T) {
 		t.Fatalf("%s", iter.Err().Error())
 	}
 
-	if !reflect.DeepEqual(mp, outPoints) {
-		t.Fatalf("expected point %v, got %v", mp, outPoints)
+	if !reflect.DeepEqual(inputCopy, outPoints) {
+		t.Fatalf("expected point %v, got %v", inputCopy, outPoints)
 	}
 }
 
@@ -142,6 +144,10 @@ func TestWriteReadPointMsgArrayWithoutOrg(t *testing.T) {
 			Value: 12,
 		},
 	}
+
+	// copy to make sure the function under test doesn't modify input
+	inputCopy := append(make([]schema.MetricPoint, 0, len(mp)), mp...)
+
 	buf := make([]byte, 0, 2+28*len(mp))
 	out, err := WritePointMsgArray(mp, buf, FormatMetricPointWithoutOrg)
 	if err != nil {
@@ -154,8 +160,8 @@ func TestWriteReadPointMsgArrayWithoutOrg(t *testing.T) {
 	}
 
 	// iter will have to set the default org and we want to check it
-	for i := range mp {
-		mp[i].MKey.Org = 6
+	for i := range inputCopy {
+		inputCopy[i].MKey.Org = 6
 	}
 
 	var outPoints []schema.MetricPoint
@@ -168,8 +174,8 @@ func TestWriteReadPointMsgArrayWithoutOrg(t *testing.T) {
 		t.Fatalf("%s", iter.Err().Error())
 	}
 
-	if !reflect.DeepEqual(mp, outPoints) {
-		t.Fatalf("expected point %v, got %v", mp, outPoints)
+	if !reflect.DeepEqual(inputCopy, outPoints) {
+		t.Fatalf("expected point %v, got %v", inputCopy, outPoints)
 	}
 }
 

--- a/schema/msg/msg_test.go
+++ b/schema/msg/msg_test.go
@@ -98,7 +98,7 @@ func TestWriteReadPointMsgArray(t *testing.T) {
 			Value: 12,
 		},
 	}
-	buf := make([]byte, 0, 2+32*3)
+	buf := make([]byte, 0, 2+32*len(mp))
 	out, err := WritePointMsgArray(mp, buf, FormatMetricPoint)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
@@ -142,7 +142,7 @@ func TestWriteReadPointMsgArrayWithoutOrg(t *testing.T) {
 			Value: 12,
 		},
 	}
-	buf := make([]byte, 0, 2+28*3)
+	buf := make([]byte, 0, 2+28*len(mp))
 	out, err := WritePointMsgArray(mp, buf, FormatMetricPointWithoutOrg)
 	if err != nil {
 		t.Fatalf("%s", err.Error())


### PR DESCRIPTION
Resolves #1002 

In our staging set up, this batching reduced allocation rate cluster wide from 620MB/s to 270MB/s. It also reduced CPU usage by ~8%. There was also a nominal reduction in RSS usage (probably due to fewer allocations) but is <4% and difficult to say is statistically significant.

Another nice benefit is that max start up ingest rate went from ~1 million to ~2 million dp/s. 

## Checklist 

- [ ] Update docs/inputs.md when format is finalized.