### PR TITLE
Make number parsing stricter

### DIFF
--- a/expr/parse.go
+++ b/expr/parse.go
@@ -327,7 +327,7 @@ func parseArgList(e string, piped bool) (string, []*expr, map[string]*expr, stri
 
 		var arg *expr
 		var err error
-		arg, e, err = Parse(e, ParseContext{ Piped: false, IsFullArg: true} )
+		arg, e, err = Parse(e, ParseContext{Piped: false, IsFullArg: true})
 		if err != nil {
 			return "", nil, nil, e, err
 		}
@@ -341,7 +341,7 @@ func parseArgList(e string, piped bool) (string, []*expr, map[string]*expr, stri
 		// can't contain otherwise-valid-name chars like {, }, etc
 		if arg.etype == etName && e[0] == '=' {
 			e = e[1:]
-			argCont, eCont, errCont := Parse(e, ParseContext{ Piped: false, IsFullArg: true})
+			argCont, eCont, errCont := Parse(e, ParseContext{Piped: false, IsFullArg: true})
 			if errCont != nil {
 				return "", nil, nil, eCont, errCont
 			}

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -151,7 +151,14 @@ func Parse(e string, piped bool) (*expr, string, error) {
 	}
 
 	if '0' <= e[0] && e[0] <= '9' || e[0] == '-' || e[0] == '+' {
-		return parseConst(e)
+		constExpr, leftover, err := parseConst(e)
+		if err != nil {
+			return nil, "", err
+		}
+		leftover = skipWhitespace(leftover)
+		if leftover == "" || leftover[0] == ',' || leftover[0] == ')' {
+			return constExpr, leftover, nil
+		}
 	}
 
 	if val, ok := strToBool(e); ok {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -197,7 +197,7 @@ func Parse(e string, pCtx ParseContext) (*expr, string, error) {
 	var exp *expr
 	var err error
 
-	if e != "" && e[0] == '(' {
+	if e != "" && e[0] == '(' && isFnStartChar(name[0]) {
 		// in this case, our parsed name is a function
 		for i := range name {
 			if !isFnChar(name[i]) {
@@ -383,6 +383,11 @@ var nameChar = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#
 
 func isNameChar(r byte) bool {
 	return strings.IndexByte(nameChar, r) >= 0
+}
+
+func isFnStartChar(r byte) bool {
+	return 'a' <= r && r <= 'z' ||
+		'A' <= r && r <= 'Z'
 }
 
 func isFnChar(r byte) bool {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -163,8 +163,8 @@ func Parse(e string, pCtx ParseContext) (*expr, string, error) {
 		return nil, "", ErrMissingExpr
 	}
 
-	if pCtx.IsFullArg && ('0' <= e[0] && e[0] <= '9' || e[0] == '-' || e[0] == '+') {
-		constExpr, leftover, err := parseConst(e)
+	if pCtx.IsFullArg && isNumStartChar(e[0]) {
+		constExpr, leftover, err := parseNumber(e)
 		if err != nil {
 			return nil, "", err
 		}
@@ -397,7 +397,11 @@ func isFnChar(r byte) bool {
 		'0' <= r && r <= '9'
 }
 
-func parseConst(s string) (*expr, string, error) {
+func isNumStartChar(r byte) bool {
+	return '0' <= r && r <= '9' || r == '-' || r == '+'
+}
+
+func parseNumber(s string) (*expr, string, error) {
 
 	var i int
 	var float bool

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -133,7 +133,7 @@ func ParseMany(targets []string) ([]*expr, error) {
 }
 
 func skipWhitespace(s string) string {
-	for len(s) > 1 && s[0] == ' ' {
+	for len(s) >= 1 && s[0] == ' ' {
 		s = s[1:]
 	}
 	return s

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -11,9 +11,9 @@ import (
 func TestParse(t *testing.T) {
 
 	tests := []struct {
-		s   string
-		e   *expr
-		err error
+		s        string
+		e        *expr
+		err      error
 		leftover string
 	}{
 		{
@@ -242,7 +242,7 @@ func TestParse(t *testing.T) {
 				args: []*expr{
 					{int: 1, str: "1", etype: etInt},
 					{
-						str: "func2",
+						str:   "func2",
 						etype: etFunc,
 						args: []*expr{
 							{str: "10a"},

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -933,6 +933,12 @@ func TestParse(t *testing.T) {
 			nil,
 			"",
 		},
+		{
+			"3func()",
+			&expr{str: "3func"},
+			nil,
+			"()",
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -943,7 +943,7 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.s, func(t *testing.T) {
-			e, leftover, err := Parse(tt.s, ParseContext{Piped: false, IsFullArg: false})
+			e, leftover, err := Parse(tt.s, ParseContext{Piped: false, CanParseAsNumber: false})
 			if err != tt.err {
 				t.Errorf("case %+v expected err %v, got %v (leftover: %q)", tt.s, tt.err, err, leftover)
 				t.FailNow()


### PR DESCRIPTION
Compared to graphite-web, Metrictank attempts to parse a string as a number too eagerly. If it detects the first character in an expression string is a digit or `+`/`-`, it will parse the expression as a number, even if there are non-numerical trailing characters. 

In graphite-web, metric names can start with a digit. This means Metrictank can fail parsing for a valid metric.

---

In graphite-web:
* Numbers must be followed by `","`, `")"` or the end of a line
  * https://github.com/graphite-project/graphite-web/blob/9e3e4e0aed8edf82004afc12aa6c55f83c5cbf01/webapp/graphite/render/grammar_unsafe.py#L27-L28
* Numbers are only parsed as numbers when they're arguments
  * https://github.com/graphite-project/graphite-web/blob/9e3e4e0aed8edf82004afc12aa6c55f83c5cbf01/webapp/graphite/render/grammar_unsafe.py#L68-L75
  * https://github.com/graphite-project/graphite-web/blob/9e3e4e0aed8edf82004afc12aa6c55f83c5cbf01/webapp/graphite/render/grammar_unsafe.py#L123
* It is valid for metrics to start with a number
  *  https://github.com/graphite-project/graphite-web/blob/9e3e4e0aed8edf82004afc12aa6c55f83c5cbf01/webapp/graphite/render/grammar_unsafe.py#L102

---

This PR makes the Metrictank parsing logic more similar to the graphite-web logic. 

Main changes:
* If there are leftover characters after parsing a number, if the leftover characters don't start with a `,` or `)`, we rollback the parsed number and attempt to parse it as other expression types. 
  * Note that graphite-web also parses as a number if the leftover characters start with `\n`. I haven't implemented this in Metrictank, because there isn't any other newline handling logic in the Metrictank parser so I wasn't sure whether to handle this case as well.
* Metrictank won't attempt to parse an expression as a number if it's not an argument.
* If there is trailing whitespace after a number has been parsed, it's skipped.

Breaking changes:
* This PR makes a breaking change to the function signature of `Parse()`, in order to pass information on whether an expression is a function argument or not. I'm not sure if there are Metrictank consumers that this will impact?  

Additional changes (changes were made to implement the main goal of updating the number parsing logic, but have a larger impact than for just number parsing): 
* Trailing whitespace in queries are now skipped properly. Previously, skipping whitespace would not remove the last character even if it was another whitespace, leading to Metrictank marking some queries as invalid.
* When parsing a function name, we now check the first character of the function is not a digit, which is what graphite-web does: https://github.com/graphite-project/graphite-web/blob/9e3e4e0aed8edf82004afc12aa6c55f83c5cbf01/webapp/graphite/render/grammar_unsafe.py#L48

Added unit tests for all the changes.