### PR TITLE
Update Graphite tags models to include From and To fields

### DIFF
--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -85,12 +85,14 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 }
 
 type GraphiteTags struct {
+	FromTo
 	Filter string `json:"filter" form:"filter"`
 }
 
 type GraphiteTagsResp []GraphiteTagResp
 
 type GraphiteAutoCompleteTags struct {
+	FromTo
 	Prefix string   `json:"tagPrefix" form:"tagPrefix"`
 	Expr   []string `json:"expr" form:"expr"`
 	Limit  uint     `json:"limit" form:"limit"`


### PR DESCRIPTION
This PR updates the GraphiteTags and GraphiteAutoCompleteTags models to include a FromTo field. This will enable the tags query to include from and to fields. This is part of changes necessary for an issue in which no tags will appear in the UI if metrics have not been ingested in the last hour

Related PR: 
- Grafana main repo: https://github.com/grafana/grafana/pull/41319
