### PR TITLE
Fix benchmarks

### DIFF
--- a/api/dataprocessor_test.go
+++ b/api/dataprocessor_test.go
@@ -919,7 +919,7 @@ func BenchmarkFix1M(b *testing.B) {
 	var l int
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		in := test.RandFloats1M()
+		in, _ := test.RandFloats1M()
 		l = len(in)
 		b.StartTimer()
 		out := Fix(in, 0, 1000001, 1)
@@ -932,8 +932,8 @@ func BenchmarkDivide1M(b *testing.B) {
 	var l int
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		ina := test.RandFloats1M()
-		inb := test.RandFloats1M()
+		ina, _ := test.RandFloats1M()
+		inb, _ := test.RandFloats1M()
 		l = len(ina)
 		b.StartTimer()
 		out := divide(ina, inb)

--- a/consolidation/consolidate_test.go
+++ b/consolidation/consolidate_test.go
@@ -495,11 +495,11 @@ func BenchmarkConsolidateSumRandWithNulls1M_100(b *testing.B) {
 
 var dummy []schema.Point
 
-func benchmarkConsolidate(fn func() []schema.Point, aggNum uint32, consolidator Consolidator, b *testing.B) {
+func benchmarkConsolidate(fn test.DataFunc, aggNum uint32, consolidator Consolidator, b *testing.B) {
 	var l int
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		in := fn()
+		in, _ := fn()
 		l = len(in)
 		b.StartTimer()
 		ret := Consolidate(in, 0, aggNum, consolidator)

--- a/expr/func_absolute_test.go
+++ b/expr/func_absolute_test.go
@@ -124,16 +124,16 @@ func BenchmarkAbsolute10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkAbsolute10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkAbsolute(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkAbsolute(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkAbsolute(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_aggregate_test.go
+++ b/expr/func_aggregate_test.go
@@ -331,16 +331,16 @@ func BenchmarkAggregate10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkAggregate(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkAggregate(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkAggregate(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			Target: strconv.Itoa(i),
 		}
 		if i%1 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_aspercent_test.go
+++ b/expr/func_aspercent_test.go
@@ -701,16 +701,16 @@ func BenchmarkAsPercent10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkAsPercent(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkAsPercent(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkAsPercent(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_constantline_test.go
+++ b/expr/func_constantline_test.go
@@ -224,16 +224,16 @@ func BenchmarkConstantLine10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkConstantLine(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkConstantLine(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkConstantLine(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_countseries_test.go
+++ b/expr/func_countseries_test.go
@@ -120,16 +120,16 @@ func BenchmarkCountSeries10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkCountSeries(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkCountSeries(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkCountSeries(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_derivative_test.go
+++ b/expr/func_derivative_test.go
@@ -142,16 +142,16 @@ func BenchmarkDerivative10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkDerivative10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkDerivative(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkDerivative(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkDerivative(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_divideseries_test.go
+++ b/expr/func_divideseries_test.go
@@ -145,23 +145,23 @@ func BenchmarkDivideSeries10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkDivideSeries(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkDivideSeries(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkDivideSeries(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var dividends []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			Target: strconv.Itoa(i),
 		}
 		if i%1 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		dividends = append(dividends, series)
 	}
 	divisor := models.Series{
-		Target:     "divisor",
-		Datapoints: fn0(),
+		Target: "divisor",
 	}
+	divisor.Datapoints, divisor.Interval = fn0()
 	b.ResetTimer()
 	var err error
 	for i := 0; i < b.N; i++ {

--- a/expr/func_divideserieslists_test.go
+++ b/expr/func_divideserieslists_test.go
@@ -163,16 +163,16 @@ func BenchmarkDivideSeriesLists10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkDivideSeriesLists(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkDivideSeriesLists(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkDivideSeriesLists(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var dividends []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			Target: strconv.Itoa(i),
 		}
 		if i%1 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		dividends = append(dividends, series)
 	}
@@ -182,9 +182,9 @@ func benchmarkDivideSeriesLists(b *testing.B, numSeries int, fn0, fn1 func() []s
 			Target: strconv.Itoa(i) + "-divisor",
 		}
 		if i%1 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		divisors = append(divisors, series)
 	}

--- a/expr/func_filterseries_test.go
+++ b/expr/func_filterseries_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
-	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
 )
 
@@ -205,16 +204,16 @@ func BenchmarkFilterSeries10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkFilterSeries(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkFilterSeries(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkFilterSeries(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_group_test.go
+++ b/expr/func_group_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
-	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
 )
 
@@ -108,16 +107,16 @@ func BenchmarkGroup10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkGroup10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkGroup(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkGroup(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkGroup(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_groupbynodes_test.go
+++ b/expr/func_groupbynodes_test.go
@@ -331,7 +331,7 @@ func benchmarkGroupByNodes(b *testing.B, numIn, numOut int) {
 			for _, tag := range tagValues {
 				series.Target += ";" + tag + "=" + strconv.Itoa(j%numOut)
 			}
-			series.Datapoints = test.RandFloats100()
+			series.Datapoints, series.Interval = test.RandFloats100()
 			input = append(input, series)
 		}
 	}

--- a/expr/func_groupbytags_test.go
+++ b/expr/func_groupbytags_test.go
@@ -337,7 +337,7 @@ func benchmarkGroupByTags(b *testing.B, numInputSeries, numOutputSeries int) {
 			series.Target += ";" + tag + "=" + strconv.Itoa(i%numOutputSeries)
 		}
 
-		series.Datapoints = test.RandFloats100()
+		series.Datapoints, series.Interval = test.RandFloats100()
 		input = append(input, series)
 	}
 	b.ResetTimer()

--- a/expr/func_highestlowest_test.go
+++ b/expr/func_highestlowest_test.go
@@ -341,16 +341,16 @@ func BenchmarkHighestLowest10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkHighestLowest(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkHighestLowest(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkHighestLowest(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_integral_test.go
+++ b/expr/func_integral_test.go
@@ -118,16 +118,16 @@ func BenchmarkIntegral10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkIntegral10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkIntegral(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkIntegral(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkIntegral(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_invert_test.go
+++ b/expr/func_invert_test.go
@@ -184,16 +184,16 @@ func BenchmarkInvert10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkInvert10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkInvert(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkInvert(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkInvert(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_isnonnull_test.go
+++ b/expr/func_isnonnull_test.go
@@ -146,16 +146,16 @@ func BenchmarkIsNonNull10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkIsNonNull(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkIsNonNull(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkIsNonNull(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_keeplastvalue_test.go
+++ b/expr/func_keeplastvalue_test.go
@@ -139,16 +139,16 @@ func BenchmarkKeepLastValue10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkKeepLastValue(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkKeepLastValue(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkKeepLastValue(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_minmax_test.go
+++ b/expr/func_minmax_test.go
@@ -195,16 +195,16 @@ func BenchmarkMinMax10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkMinMax(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkMinMax(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkMinMax(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_movingwindow_test.go
+++ b/expr/func_movingwindow_test.go
@@ -312,7 +312,7 @@ func BenchmarkMovingWindow10k_1SomeSeriesHalfNulls(b *testing.B) {
 func BenchmarkMovingWindow10k_1AllSeriesHalfNulls(b *testing.B) {
 	benchmarkMovingWindow(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkMovingWindow(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkMovingWindow(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
@@ -320,9 +320,9 @@ func benchmarkMovingWindow(b *testing.B, numSeries int, fn0, fn1 func() []schema
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_nonnegativederivative_test.go
+++ b/expr/func_nonnegativederivative_test.go
@@ -184,16 +184,16 @@ func BenchmarkNonNegativeDerivative10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkNonNegativeDerivative10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkNonNegativeDerivative(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkNonNegativeDerivative(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkNonNegativeDerivative(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_offset_test.go
+++ b/expr/func_offset_test.go
@@ -136,16 +136,16 @@ func BenchmarkOffset10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkOffset(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkOffset(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkOffset(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_offsettozero_test.go
+++ b/expr/func_offsettozero_test.go
@@ -210,16 +210,16 @@ func BenchmarkOffsetToZero10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkOffsetToZero(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkOffsetToZero(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkOffsetToZero(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_removeabovebelowpercentile_test.go
+++ b/expr/func_removeabovebelowpercentile_test.go
@@ -196,16 +196,16 @@ func BenchmarkRemoveAboveBelowPercentile10k_100AllSeriesHalfNulls(b *testing.B) 
 func BenchmarkRemoveAboveBelowPercentile10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkRemoveAboveBelowPercentile(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkRemoveAboveBelowPercentile(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkRemoveAboveBelowPercentile(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_removeabovebelowvalue_test.go
+++ b/expr/func_removeabovebelowvalue_test.go
@@ -163,16 +163,16 @@ func BenchmarkRemoveAboveBelowValue10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkRemoveAboveBelowValue10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkRemoveAboveBelowValue(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkRemoveAboveBelowValue(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkRemoveAboveBelowValue(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_round_test.go
+++ b/expr/func_round_test.go
@@ -305,16 +305,16 @@ func BenchmarkRound10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkRound(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkRound(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkRound(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_scale_test.go
+++ b/expr/func_scale_test.go
@@ -128,16 +128,16 @@ func BenchmarkScale10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkScale(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkScale(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkScale(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_scaletoseconds_test.go
+++ b/expr/func_scaletoseconds_test.go
@@ -145,16 +145,16 @@ func BenchmarkScaleToSeconds10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkScaleToSeconds(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkScaleToSeconds(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkScaleToSeconds(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_sortby_test.go
+++ b/expr/func_sortby_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
-	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
 )
 
@@ -194,16 +193,16 @@ func BenchmarkSortBy10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkSortBy(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkSortBy(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkSortBy(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_substr_test.go
+++ b/expr/func_substr_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
-	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
 )
 
@@ -177,16 +176,16 @@ func BenchmarkSubstr10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkSubstr10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkSubstr(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkSubstr(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkSubstr(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_summarize_test.go
+++ b/expr/func_summarize_test.go
@@ -928,16 +928,16 @@ func BenchmarkSummarize10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkSummarize(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k, "1h")
 }
 
-func benchmarkSummarize(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point, intervalString string) {
+func benchmarkSummarize(b *testing.B, numSeries int, fn0, fn1 test.DataFunc, intervalString string) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			Target: strconv.Itoa(i),
 		}
 		if i%1 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_timeshift_test.go
+++ b/expr/func_timeshift_test.go
@@ -209,16 +209,16 @@ func BenchmarkTimeShift10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkTimeShift(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkTimeShift(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkTimeShift(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_transformnull_test.go
+++ b/expr/func_transformnull_test.go
@@ -118,16 +118,16 @@ func BenchmarkTransformNull10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkTransformNull(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkTransformNull(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkTransformNull(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_unique_test.go
+++ b/expr/func_unique_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
-	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
 )
 
@@ -110,16 +109,16 @@ func BenchmarkUnique10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkUnique(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkUnique(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkUnique(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/seriesaggregator_test.go
+++ b/expr/seriesaggregator_test.go
@@ -194,16 +194,16 @@ func BenchmarkSeriesAggregateCount10k_100WithNulls(b *testing.B) {
 	benchmarkSeriesAggregate(b, crossSeriesCount, 100, test.RandFloats10k, test.RandFloatsWithNulls10k)
 }
 
-func benchmarkSeriesAggregate(b *testing.B, aggFunc crossSeriesAggFunc, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkSeriesAggregate(b *testing.B, aggFunc crossSeriesAggFunc, numSeries int, fn0, fn1 test.DataFunc) {
 	var input []models.Series
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			Target: strconv.Itoa(i),
 		}
 		if i%1 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/test/points.go
+++ b/test/points.go
@@ -13,33 +13,37 @@ import (
 var randFloats = make(map[int][]schema.Point)
 var randFloatsWithNulls = make(map[int][]schema.Point)
 
-func RandFloats100() []schema.Point { return RandFloats(100) }
-func RandFloats10k() []schema.Point { return RandFloats(10000) }
-func RandFloats1M() []schema.Point  { return RandFloats(1000000) }
+type DataFunc func() ([]schema.Point, uint32)
 
-func RandFloats(size int) []schema.Point {
+func RandFloats100() ([]schema.Point, uint32) { return RandFloats(100) }
+func RandFloats10k() ([]schema.Point, uint32) { return RandFloats(10000) }
+func RandFloats1M() ([]schema.Point, uint32)  { return RandFloats(1000000) }
+
+func RandFloats(size int) ([]schema.Point, uint32) {
 	data, ok := randFloats[size]
+	interval := 1
 	if !ok {
 		data = make([]schema.Point, size)
-		for i := 0; i < size; i++ {
+		for i := 0; i < size; i += interval {
 			data[i] = schema.Point{Val: rand.Float64(), Ts: uint32(i)}
 		}
 		randFloats[size] = data
 	}
 	out := make([]schema.Point, size)
 	copy(out, data)
-	return out
+	return out, uint32(interval)
 }
 
-func RandFloatsWithNulls100() []schema.Point { return RandFloatsWithNulls(100) }
-func RandFloatsWithNulls10k() []schema.Point { return RandFloatsWithNulls(10000) }
-func RandFloatsWithNulls1M() []schema.Point  { return RandFloatsWithNulls(1000000) }
+func RandFloatsWithNulls100() ([]schema.Point, uint32) { return RandFloatsWithNulls(100) }
+func RandFloatsWithNulls10k() ([]schema.Point, uint32) { return RandFloatsWithNulls(10000) }
+func RandFloatsWithNulls1M() ([]schema.Point, uint32)  { return RandFloatsWithNulls(1000000) }
 
-func RandFloatsWithNulls(size int) []schema.Point {
+func RandFloatsWithNulls(size int) ([]schema.Point, uint32) {
 	data, ok := randFloatsWithNulls[size]
+	interval := 1
 	if !ok {
 		data = make([]schema.Point, size)
-		for i := 0; i < size; i++ {
+		for i := 0; i < size; i += interval {
 			if i%2 == 0 {
 				data[i] = schema.Point{Val: math.NaN(), Ts: uint32(i)}
 			} else {
@@ -50,5 +54,5 @@ func RandFloatsWithNulls(size int) []schema.Point {
 	}
 	out := make([]schema.Point, size)
 	copy(out, data)
-	return out
+	return out, uint32(interval)
 }


### PR DESCRIPTION
Most if not all benchmarks were failing because the test series had an interval of 0 -- causing a panic when dividing by 0 when normalizing the series.

This PR modifies the test functions to return the interval as well as the datapoints.