### PR TITLE
Implement linearRegression natively

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -109,7 +109,7 @@ See also:
 | keepLastValue(seriesList, limit) seriesList                    |              | Stable     |
 | legendValue                                                    |              | No         |
 | limit                                                          |              | No         |
-| linearRegression                                               |              | No         |
+| linearRegression                                               |              | Stable     |
 | linearRegressionAnalysis                                       |              | No         |
 | lineWidth                                                      |              | No         |
 | logarithm                                                      |              | No         |

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -1,0 +1,144 @@
+package expr
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/tz"
+	"github.com/grafana/metrictank/mdata"
+	"github.com/grafana/metrictank/schema"
+)
+
+type FuncLinearRegression struct {
+	in GraphiteFunc
+
+	startSourceAt string // render time format
+	endSourceAt   string
+	startSource   uint32 // epoch seconds
+	endSource     uint32
+
+	startTarget uint32 // epoch seconds
+	endTarget   uint32
+}
+
+func NewLinearRegression() GraphiteFunc {
+	return &FuncLinearRegression{}
+}
+
+func (s *FuncLinearRegression) Signature() ([]Arg, []Arg) {
+	return []Arg{
+			ArgSeriesList{
+				val: &s.in,
+			},
+			ArgString{
+				key:       "startSourceAt",
+				opt:       true,
+				validator: []Validator{IsRenderTimeFormat},
+				val:       &s.startSourceAt,
+			},
+			ArgString{
+				key:       "endSourceAt",
+				opt:       true,
+				validator: []Validator{IsRenderTimeFormat},
+				val:       &s.endSourceAt,
+			},
+		},
+		[]Arg{ArgSeriesList{}}
+}
+
+func (s *FuncLinearRegression) Context(context Context) Context {
+	s.startTarget = context.from
+	s.endTarget = context.to
+
+	now := time.Now()
+	defaultFrom := uint32(now.Add(-24 * time.Hour).Unix())
+	defaultTo := uint32(now.Unix())
+	var err error
+	s.startSource, s.endSource, err = tz.GetFromTo(tz.FromTo{
+		From: s.startSourceAt,
+		To:   s.endSourceAt,
+	}, now, defaultFrom, defaultTo)
+	if err != nil {
+		return context // todo panic?
+	}
+	context.from = s.startSource
+	context.to = s.endSource
+
+	return context
+}
+
+func (s *FuncLinearRegression) Exec(dataMap DataMap) ([]models.Series, error) {
+	series, err := s.in.Exec(dataMap)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []models.Series{}
+	for _, serie := range series {
+		factor, offset, isValid := linearRegressionAnalysis(serie)
+		if !isValid {
+			continue
+		}
+
+		normalizedStartTarget := mdata.AggBoundary(s.startTarget, serie.Interval)
+		size := int((s.endTarget-normalizedStartTarget)/serie.Interval + 1)
+		datapoints := pointSlicePool.GetMin(size)
+		for i := 0; i < size; i++ {
+			datapoint := schema.Point{
+				Val: offset + (float64(normalizedStartTarget)+float64(i)*float64(serie.Interval))*factor,
+				Ts:  normalizedStartTarget + uint32(i)*serie.Interval,
+			}
+			datapoints = append(datapoints, datapoint)
+		}
+
+		newSeries := serie.Copy([]schema.Point{})
+		newSeries.Target = fmt.Sprintf("linearRegression(%s, %d, %d)", serie.Target, s.startSource, s.endSource)
+		newSeries.Datapoints = datapoints
+		newSeries.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", s.startSource, s.endSource)
+		newSeries.QueryPatt = newSeries.Target
+		newSeries.QueryFrom = s.startTarget
+		newSeries.QueryTo = s.endTarget
+
+		results = append(results, newSeries)
+	}
+
+	dataMap.Add(Req{}, results...)
+	return results, nil
+}
+
+func linearRegressionAnalysis(series models.Series) (float64, float64, bool) {
+	// Some functions normalize the series' datapoint timestamps,
+	// but not the series' QueryFrom/QueryTo fields.
+	startSource := series.QueryFrom
+	if len(series.Datapoints) > 0 {
+		startSource = series.Datapoints[0].Ts
+	}
+
+	var n float64
+	var sumI float64
+	var sumII float64
+	var sumV float64
+	var sumIV float64
+	for i, point := range series.Datapoints {
+		if math.IsNaN(point.Val) {
+			continue
+		}
+
+		n++
+		sumI += float64(i)
+		sumII += float64(i) * float64(i)
+		sumV += point.Val
+		sumIV += float64(i) * point.Val
+	}
+
+	denominator := n*sumII - sumI*sumI
+	if denominator == 0 {
+		return 0, 0, false
+	}
+	factor := (n*sumIV - sumI*sumV) / denominator / float64(series.Interval)
+	offset := (sumII*sumV-sumIV*sumI)/denominator - factor*float64(startSource)
+
+	return factor, offset, true
+}

--- a/expr/func_linearregression.go
+++ b/expr/func_linearregression.go
@@ -53,7 +53,7 @@ func (s *FuncLinearRegression) Context(context Context) Context {
 	s.endTarget = context.to
 
 	now := time.Now()
-	defaultFrom := uint32(now.Add(-24 * time.Hour).Unix())
+	defaultFrom := uint32(now.Add(-5 * time.Minute).Unix())
 	defaultTo := uint32(now.Unix())
 	var err error
 	s.startSource, s.endSource, err = tz.GetFromTo(tz.FromTo{

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -330,7 +330,7 @@ func BenchmarkLinearRegression10k_100AllSeriesHalfNulls(b *testing.B) {
 func BenchmarkLinearRegression10k_1000AllSeriesHalfNulls(b *testing.B) {
 	benchmarkLinearRegression(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
 }
-func benchmarkLinearRegression(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+func benchmarkLinearRegression(b *testing.B, numSeries int, fn0, fn1 test.DataFunc) {
 	var err error
 	tz.TimeZone, err = time.LoadLocation("")
 	if err != nil {
@@ -341,12 +341,11 @@ func benchmarkLinearRegression(b *testing.B, numSeries int, fn0, fn1 func() []sc
 	for i := 0; i < numSeries; i++ {
 		series := models.Series{
 			QueryPatt: strconv.Itoa(i),
-			Interval:  1,
 		}
 		if i%2 == 0 {
-			series.Datapoints = fn0()
+			series.Datapoints, series.Interval = fn0()
 		} else {
-			series.Datapoints = fn1()
+			series.Datapoints, series.Interval = fn1()
 		}
 		input = append(input, series)
 	}

--- a/expr/func_linearregression_test.go
+++ b/expr/func_linearregression_test.go
@@ -1,0 +1,363 @@
+package expr
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/api/tz"
+	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/test"
+)
+
+func TestLinearRegression(t *testing.T) {
+	in := []models.Series{{
+		Target: "test.value",
+		Tags: map[string]string{
+			"test": "value",
+		},
+		QueryPatt: "test.value",
+		Interval:  60,
+		QueryFrom: 180,
+		QueryTo:   480,
+		Datapoints: []schema.Point{
+			{
+				Val: 3,
+				Ts:  180,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  240,
+			},
+			{
+				Val: 5,
+				Ts:  300,
+			},
+			{
+				Val: 6,
+				Ts:  360,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  420,
+			},
+			{
+				Val: 8,
+				Ts:  480,
+			},
+		},
+	}}
+
+	expected := []models.Series{{
+		Target: "linearRegression(test.value, 180, 480)",
+		Tags: map[string]string{
+			"test":              "value",
+			"linearRegressions": "180, 480",
+		},
+		QueryPatt: "linearRegression(test.value, 180, 480)",
+		Interval:  60,
+		QueryFrom: 1200,
+		QueryTo:   1500,
+		Datapoints: []schema.Point{
+			{
+				Val: 20,
+				Ts:  1200,
+			},
+			{
+				Val: 21,
+				Ts:  1260,
+			},
+			{
+				Val: 22,
+				Ts:  1320,
+			},
+			{
+				Val: 23,
+				Ts:  1380,
+			},
+			{
+				Val: 24,
+				Ts:  1440,
+			},
+			{
+				Val: 25,
+				Ts:  1500,
+			},
+		},
+	}}
+
+	testLinearRegression(t, "00:03 19700101", "00:08 19700101", 1200, 1500, in, expected)
+}
+
+func TestLinearRegressionRelative(t *testing.T) {
+	now := uint32(time.Now().Unix())
+	normalizedNow := now / 60 * 60 // normalize to prevent test fragility
+
+	in := []models.Series{{
+		Target: "test.value",
+		Tags: map[string]string{
+			"test": "value",
+		},
+		QueryPatt: "test.value",
+		Interval:  60,
+		QueryFrom: normalizedNow - 1320,
+		QueryTo:   normalizedNow - 1020,
+		Datapoints: []schema.Point{
+			{
+				Val: 3,
+				Ts:  normalizedNow - 1320,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  normalizedNow - 1260,
+			},
+			{
+				Val: 5,
+				Ts:  normalizedNow - 1200,
+			},
+			{
+				Val: 6,
+				Ts:  normalizedNow - 1140,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  normalizedNow - 1080,
+			},
+			{
+				Val: 8,
+				Ts:  normalizedNow - 1020,
+			},
+		},
+	}}
+
+	expected := []models.Series{{
+		Target: fmt.Sprintf("linearRegression(test.value, %d, %d)", now-1320, now-1020),
+		Tags: map[string]string{
+			"test":              "value",
+			"linearRegressions": fmt.Sprintf("%d, %d", now-1320, now-1020),
+		},
+		QueryPatt: fmt.Sprintf("linearRegression(test.value, %d, %d)", now-1320, now-1020),
+		Interval:  60,
+		QueryFrom: normalizedNow - 300,
+		QueryTo:   normalizedNow,
+		Datapoints: []schema.Point{
+			{
+				Val: 20,
+				Ts:  normalizedNow - 300,
+			},
+			{
+				Val: 21,
+				Ts:  normalizedNow - 240,
+			},
+			{
+				Val: 22,
+				Ts:  normalizedNow - 180,
+			},
+			{
+				Val: 23,
+				Ts:  normalizedNow - 120,
+			},
+			{
+				Val: 24,
+				Ts:  normalizedNow - 60,
+			},
+			{
+				Val: 25,
+				Ts:  normalizedNow,
+			},
+		},
+	}}
+
+	testLinearRegression(t, "now-1320s", "now-1020s", normalizedNow-300, normalizedNow, in, expected)
+}
+
+func TestLinearRegressionNormalization(t *testing.T) {
+	in := []models.Series{{
+		Target: "test.value",
+		Tags: map[string]string{
+			"test": "value",
+		},
+		QueryPatt: "test.value",
+		Interval:  60,
+		QueryFrom: 180,
+		QueryTo:   480,
+		Datapoints: []schema.Point{
+			{
+				Val: 3,
+				Ts:  180,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  240,
+			},
+			{
+				Val: 5,
+				Ts:  300,
+			},
+			{
+				Val: 6,
+				Ts:  360,
+			},
+			{
+				Val: math.NaN(),
+				Ts:  420,
+			},
+			{
+				Val: 8,
+				Ts:  480,
+			},
+		},
+	}}
+
+	expected := []models.Series{{
+		Target: "linearRegression(test.value, 180, 480)",
+		Tags: map[string]string{
+			"test":              "value",
+			"linearRegressions": "180, 480",
+		},
+		QueryPatt: "linearRegression(test.value, 180, 480)",
+		Interval:  60,
+		QueryFrom: 1199,
+		QueryTo:   1501,
+		Datapoints: []schema.Point{
+			{
+				Val: 20,
+				Ts:  1200,
+			},
+			{
+				Val: 21,
+				Ts:  1260,
+			},
+			{
+				Val: 22,
+				Ts:  1320,
+			},
+			{
+				Val: 23,
+				Ts:  1380,
+			},
+			{
+				Val: 24,
+				Ts:  1440,
+			},
+			{
+				Val: 25,
+				Ts:  1500,
+			},
+		},
+	}}
+
+	testLinearRegression(t, "00:03 19700101", "00:08 19700101", 1199, 1501, in, expected)
+}
+
+func testLinearRegression(t *testing.T, startSourceAt string, endSourceAt string, startTargetAt uint32, endTargetAt uint32, input []models.Series, expected []models.Series) {
+	var err error
+	tz.TimeZone, err = time.LoadLocation("")
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	inputCopy := models.SeriesCopy(input) // to later verify that it is unchanged
+
+	funcLinearRegression := FuncLinearRegression{
+		in:            NewMock(input),
+		startSourceAt: startSourceAt,
+		endSourceAt:   endSourceAt,
+	}
+
+	context := Context{
+		from: startTargetAt,
+		to:   endTargetAt,
+	}
+	newContext := funcLinearRegression.Context(context)
+	t.Run("ModifiedContext", func(t *testing.T) {
+		if newContext.from == context.from || newContext.to == context.to {
+			t.Fatal("the context is expected to be modified by the linear regression function")
+		}
+	})
+
+	actual, err := funcLinearRegression.Exec(initDataMap(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := equalOutput(expected, actual, nil, err); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("DidNotModifyInput", func(t *testing.T) {
+		if err := equalOutput(inputCopy, input, nil, nil); err != nil {
+			t.Fatal("Input was modified: ", err)
+		}
+	})
+}
+
+func BenchmarkLinearRegression10k_1NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_10NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 10, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_100NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 100, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_1000NoNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1000, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLinearRegression10k_1SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_10SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 10, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_100SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 100, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_1000SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1000, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_1AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_10AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 10, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_100AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 100, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLinearRegression10k_1000AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLinearRegression(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func benchmarkLinearRegression(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var err error
+	tz.TimeZone, err = time.LoadLocation("")
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+
+	var input []models.Series
+	for i := 0; i < numSeries; i++ {
+		series := models.Series{
+			QueryPatt: strconv.Itoa(i),
+			Interval:  1,
+		}
+		if i%2 == 0 {
+			series.Datapoints = fn0()
+		} else {
+			series.Datapoints = fn1()
+		}
+		input = append(input, series)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewLinearRegression()
+		f.(*FuncLinearRegression).in = NewMock(input)
+		got, err := f.Exec(make(map[Req][]models.Series))
+		if err != nil {
+			b.Fatalf("%s", err)
+		}
+		results = got
+	}
+}

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -92,6 +92,7 @@ func init() {
 		"invert":                       {NewInvert, true},
 		"isNonNull":                    {NewIsNonNull, true},
 		"keepLastValue":                {NewKeepLastValue, true},
+		"linearRegression":             {NewLinearRegression, true},
 		"lowest":                       {NewHighestLowestConstructor("", false), true},
 		"lowestAverage":                {NewHighestLowestConstructor("average", false), true},
 		"lowestCurrent":                {NewHighestLowestConstructor("current", false), true},

--- a/expr/validator.go
+++ b/expr/validator.go
@@ -1,6 +1,9 @@
 package expr
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/errors"
 	"github.com/raintank/dur"
@@ -76,5 +79,21 @@ func WithinZeroOneInclusiveInterval(e *expr) error {
 	if e.float < 0 || e.float > 1 {
 		return ErrWithinZeroOneInclusiveInterval
 	}
+	return nil
+}
+
+// at(1) format
+func IsRenderTimeFormat(e *expr) error {
+	loc, err := time.LoadLocation("")
+	if err != nil {
+		return fmt.Errorf("failed to load default timezone location: %w", err)
+	}
+
+	now := time.Now()
+	_, err = dur.ParseDateTime(e.str, loc, now, uint32(now.Unix()))
+	if err != nil {
+		return fmt.Errorf("failed to parse date time %q: %w", e.str, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
This PR implements the [linearRegression function](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.linearRegression) natively.

It depends on #2015, so I'll rebase once thats merged.