### PR TITLE
Implement log function natively

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -112,7 +112,7 @@ See also:
 | linearRegression                                               |              | No         |
 | linearRegressionAnalysis                                       |              | No         |
 | lineWidth                                                      |              | No         |
-| logarithm                                                      |              | No         |
+| logarithm                                                      | log          | Stable     |
 | logit                                                          |              | No         |
 | lowest(seriesList, n, func) seriesList                         |              | Stable     |
 | lowestAverage(seriesList, n, func) seriesList                  |              | Stable     |

--- a/expr/func_log.go
+++ b/expr/func_log.go
@@ -1,0 +1,56 @@
+package expr
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+)
+
+type FuncLog struct {
+	in   GraphiteFunc
+	base float64
+}
+
+func NewLog() GraphiteFunc {
+	return &FuncLog{base: 10}
+}
+
+func (s *FuncLog) Signature() ([]Arg, []Arg) {
+	return []Arg{
+			ArgSeriesList{val: &s.in},
+			ArgFloat{key: "base", opt: true, validator: []Validator{FloatPositiveNotOne}, val: &s.base},
+		}, []Arg{
+			ArgSeriesList{},
+		}
+}
+
+func (s *FuncLog) Context(context Context) Context {
+	return context
+}
+
+func (s *FuncLog) Exec(dataMap DataMap) ([]models.Series, error) {
+	series, err := s.in.Exec(dataMap)
+	if err != nil {
+		return nil, err
+	}
+
+	outputs := make([]models.Series, 0, len(series))
+	for _, serie := range series {
+		out := pointSlicePool.GetMin(len(serie.Datapoints))
+
+		for _, v := range serie.Datapoints {
+			// math.Log returns NaN for negative value and -Inf() for 0 value.
+			out = append(out, schema.Point{Val: math.Log(v.Val) / math.Log(s.base), Ts: v.Ts})
+		}
+
+		serie.Target = fmt.Sprintf("log(%s,%g)", serie.Target, s.base)
+		serie.QueryPatt = fmt.Sprintf("log(%s,%g)", serie.QueryPatt, s.base)
+		serie.Datapoints = out
+
+		outputs = append(outputs, serie)
+	}
+	dataMap.Add(Req{}, outputs...)
+	return outputs, nil
+}

--- a/expr/func_log_test.go
+++ b/expr/func_log_test.go
@@ -17,7 +17,7 @@ func TestLogNoInput(t *testing.T) {
 
 func TestLogSingle(t *testing.T) {
 	outBased10 := []schema.Point{
-		{Val: math.Inf(-1), Ts: 10},
+		{Val: math.NaN(), Ts: 10},
 		{Val: 1.5185139398778875, Ts: 20},
 		{Val: 2.298853076409707, Ts: 30},
 		{Val: 1.462397997898956, Ts: 40},
@@ -26,7 +26,7 @@ func TestLogSingle(t *testing.T) {
 	}
 
 	outBasedE := []schema.Point{
-		{Val: math.Inf(-1), Ts: 10},
+		{Val: math.NaN(), Ts: 10},
 		{Val: 3.4965075614664802, Ts: 20},
 		{Val: 5.293304824724492, Ts: 30},
 		{Val: 3.367295829986474, Ts: 40},
@@ -61,7 +61,7 @@ func TestLogSingle(t *testing.T) {
 
 func TestLogMultiple(t *testing.T) {
 	outBased10 := []schema.Point{
-		{Val: math.Inf(-1), Ts: 10},
+		{Val: math.NaN(), Ts: 10},
 		{Val: 1.5185139398778875, Ts: 20},
 		{Val: 2.298853076409707, Ts: 30},
 		{Val: 1.462397997898956, Ts: 40},
@@ -95,7 +95,7 @@ func TestLogSpecialValues(t *testing.T) {
 		{Val: 1024, Ts: 70},
 	}
 	out := []schema.Point{
-		{Val: math.Inf(1), Ts: 10},
+		{Val: math.NaN(), Ts: 10},
 		{Val: 0, Ts: 20},
 		{Val: math.NaN(), Ts: 30},
 		{Val: -1024, Ts: 40},

--- a/expr/func_log_test.go
+++ b/expr/func_log_test.go
@@ -1,0 +1,208 @@
+package expr
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/test"
+)
+
+func TestLogNoInput(t *testing.T) {
+	testLog("no_input", 10, []models.Series{}, []models.Series{}, t)
+}
+
+func TestLogSingle(t *testing.T) {
+	outBased10 := []schema.Point{
+		{Val: math.Inf(-1), Ts: 10},
+		{Val: 1.5185139398778875, Ts: 20},
+		{Val: 2.298853076409707, Ts: 30},
+		{Val: 1.462397997898956, Ts: 40},
+		{Val: 1.9030899869919435, Ts: 50},
+		{Val: 2.3979400086720375, Ts: 60},
+	}
+
+	outBasedE := []schema.Point{
+		{Val: math.Inf(-1), Ts: 10},
+		{Val: 3.4965075614664802, Ts: 20},
+		{Val: 5.293304824724492, Ts: 30},
+		{Val: 3.367295829986474, Ts: 40},
+		{Val: 4.382026634673881, Ts: 50},
+		{Val: 5.521460917862246, Ts: 60},
+	}
+
+	testLog(
+		"single",
+		10,
+		[]models.Series{
+			getSeriesNamed("d", d),
+		},
+		[]models.Series{
+			getSeriesNamed("log(d,10)", outBased10),
+		},
+		t,
+	)
+
+	testLog(
+		"single",
+		math.E,
+		[]models.Series{
+			getSeriesNamed("d2", d),
+		},
+		[]models.Series{
+			getSeriesNamed(fmt.Sprintf("log(d2,%g)", math.E), outBasedE),
+		},
+		t,
+	)
+}
+
+func TestLogMultiple(t *testing.T) {
+	outBased10 := []schema.Point{
+		{Val: math.Inf(-1), Ts: 10},
+		{Val: 1.5185139398778875, Ts: 20},
+		{Val: 2.298853076409707, Ts: 30},
+		{Val: 1.462397997898956, Ts: 40},
+		{Val: 1.9030899869919435, Ts: 50},
+		{Val: 2.3979400086720375, Ts: 60},
+	}
+
+	testLog(
+		"multiple",
+		10,
+		[]models.Series{
+			getSeriesNamed("d", d),
+			getSeriesNamed("d2", d),
+		},
+		[]models.Series{
+			getSeriesNamed("log(d,10)", outBased10),
+			getSeriesNamed("log(d2,10)", outBased10),
+		},
+		t,
+	)
+}
+
+func TestLogSpecialValues(t *testing.T) {
+	specialValues := []schema.Point{
+		{Val: 0, Ts: 10},
+		{Val: 1, Ts: 20},
+		{Val: -1.8, Ts: 30},
+		{Val: math.MaxFloat64, Ts: 40},
+		{Val: math.Inf(1), Ts: 50},
+		{Val: math.Inf(-1), Ts: 60},
+		{Val: 1024, Ts: 70},
+	}
+	out := []schema.Point{
+		{Val: math.Inf(1), Ts: 10},
+		{Val: 0, Ts: 20},
+		{Val: math.NaN(), Ts: 30},
+		{Val: -1024, Ts: 40},
+		{Val: math.Inf(-1), Ts: 50},
+		{Val: math.NaN(), Ts: 60},
+		{Val: -10, Ts: 70},
+	}
+
+	testLog(
+		"specialValues",
+		0.5,
+		[]models.Series{
+			getSeriesNamed("specialValues", specialValues),
+		},
+		[]models.Series{
+			getSeriesNamed("log(specialValues,0.5)", out),
+		},
+		t,
+	)
+}
+
+func testLog(name string, base float64, in []models.Series, out []models.Series, t *testing.T) {
+	f := NewLog()
+	f.(*FuncLog).in = NewMock(in)
+	f.(*FuncLog).base = base
+
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
+
+	dataMap := initDataMap(in)
+
+	got, err := f.Exec(dataMap)
+	if err := equalOutput(out, got, nil, err); err != nil {
+		t.Fatalf("Case %s: %s", name, err)
+	}
+
+	t.Run("DidNotModifyInput", func(t *testing.T) {
+		if err := equalOutput(inputCopy, in, nil, nil); err != nil {
+			t.Fatalf("Case %s: Input was modified, err = %s", name, err)
+		}
+	})
+
+	t.Run("DoesNotDoubleReturnPoints", func(t *testing.T) {
+		if err := dataMap.CheckForOverlappingPoints(); err != nil {
+			t.Fatalf("Case %s: Point slices in datamap overlap, err = %s", name, err)
+		}
+	})
+}
+
+func BenchmarkLog10k_1NoNulls(b *testing.B) {
+	benchmarkLog(b, 1, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLog10k_10NoNulls(b *testing.B) {
+	benchmarkLog(b, 10, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLog10k_100NoNulls(b *testing.B) {
+	benchmarkLog(b, 100, test.RandFloats10k, test.RandFloats10k)
+}
+func BenchmarkLog10k_1000NoNulls(b *testing.B) {
+	benchmarkLog(b, 1000, test.RandFloats10k, test.RandFloats10k)
+}
+
+func BenchmarkLog10k_1SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 1, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLog10k_10SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 10, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLog10k_100SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 100, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLog10k_1000SomeSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 1000, test.RandFloats10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLog10k_1AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 1, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLog10k_10AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 10, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLog10k_100AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 100, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+func BenchmarkLog10k_1000AllSeriesHalfNulls(b *testing.B) {
+	benchmarkLog(b, 1000, test.RandFloatsWithNulls10k, test.RandFloatsWithNulls10k)
+}
+
+func benchmarkLog(b *testing.B, numSeries int, fn0, fn1 func() []schema.Point) {
+	var input []models.Series
+	for i := 0; i < numSeries; i++ {
+		series := models.Series{
+			QueryPatt: strconv.Itoa(i),
+		}
+		if i%2 == 0 {
+			series.Datapoints = fn0()
+		} else {
+			series.Datapoints = fn1()
+		}
+		input = append(input, series)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewScale()
+		f.(*FuncScale).in = NewMock(input)
+		got, err := f.Exec(make(map[Req][]models.Series))
+		if err != nil {
+			b.Fatalf("%s", err)
+		}
+		results = got
+	}
+}

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -92,6 +92,8 @@ func init() {
 		"invert":                       {NewInvert, true},
 		"isNonNull":                    {NewIsNonNull, true},
 		"keepLastValue":                {NewKeepLastValue, true},
+		"log":                          {NewLog, true},
+		"logarithmic":                  {NewLog, true},
 		"lowest":                       {NewHighestLowestConstructor("", false), true},
 		"lowestAverage":                {NewHighestLowestConstructor("average", false), true},
 		"lowestCurrent":                {NewHighestLowestConstructor("current", false), true},

--- a/expr/validator.go
+++ b/expr/validator.go
@@ -13,7 +13,7 @@ var ErrIntZeroOrPositive = errors.NewBadRequest("integer must be zero or positiv
 var ErrInvalidAggFunc = errors.NewBadRequest("Invalid aggregation func")
 var ErrNonNegativePercent = errors.NewBadRequest("The requested percent is required to be greater than 0")
 var ErrWithinZeroOneInclusiveInterval = errors.NewBadRequest("value must lie within interval [0,1]")
-var ErrPositiveNotOne = errors.NewBadRequest("value must be positive and does not equal to one")
+var ErrPositiveNotOne = errors.NewBadRequest("value must be positive and not equal to one")
 
 // Validator is a function to validate an input
 type Validator func(e *expr) error

--- a/expr/validator.go
+++ b/expr/validator.go
@@ -1,6 +1,8 @@
 package expr
 
 import (
+	"math"
+
 	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/errors"
 	"github.com/raintank/dur"
@@ -11,6 +13,7 @@ var ErrIntZeroOrPositive = errors.NewBadRequest("integer must be zero or positiv
 var ErrInvalidAggFunc = errors.NewBadRequest("Invalid aggregation func")
 var ErrNonNegativePercent = errors.NewBadRequest("The requested percent is required to be greater than 0")
 var ErrWithinZeroOneInclusiveInterval = errors.NewBadRequest("value must lie within interval [0,1]")
+var ErrFloatPositiveNotOne = errors.NewBadRequest("value must be positive and does not equals to one")
 
 // Validator is a function to validate an input
 type Validator func(e *expr) error
@@ -75,6 +78,13 @@ func NonNegativePercent(e *expr) error {
 func WithinZeroOneInclusiveInterval(e *expr) error {
 	if e.float < 0 || e.float > 1 {
 		return ErrWithinZeroOneInclusiveInterval
+	}
+	return nil
+}
+
+func FloatPositiveNotOne(e *expr) error {
+	if e.float <= 0 || math.Abs(e.float-1) < 1e-10 {
+		return ErrFloatPositiveNotOne
 	}
 	return nil
 }

--- a/expr/validator.go
+++ b/expr/validator.go
@@ -13,7 +13,7 @@ var ErrIntZeroOrPositive = errors.NewBadRequest("integer must be zero or positiv
 var ErrInvalidAggFunc = errors.NewBadRequest("Invalid aggregation func")
 var ErrNonNegativePercent = errors.NewBadRequest("The requested percent is required to be greater than 0")
 var ErrWithinZeroOneInclusiveInterval = errors.NewBadRequest("value must lie within interval [0,1]")
-var ErrFloatPositiveNotOne = errors.NewBadRequest("value must be positive and does not equals to one")
+var ErrPositiveNotOne = errors.NewBadRequest("value must be positive and does not equal to one")
 
 // Validator is a function to validate an input
 type Validator func(e *expr) error
@@ -82,9 +82,12 @@ func WithinZeroOneInclusiveInterval(e *expr) error {
 	return nil
 }
 
-func FloatPositiveNotOne(e *expr) error {
-	if e.float <= 0 || math.Abs(e.float-1) < 1e-10 {
-		return ErrFloatPositiveNotOne
+func PositiveButNotOne(e *expr) error {
+	if e.etype == etInt && e.int > 0 && e.int != 1 {
+		return nil
 	}
-	return nil
+	if e.etype == etFloat && e.float > 0 && math.Abs(e.float-1) > 1e-10 {
+		return nil
+	}
+	return ErrPositiveNotOne
 }


### PR DESCRIPTION
**Describe your changes**
Add the `log` function similar to Graphite's [log](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.logarithm)

**Testing performed**
* Unit Test (pass)
* Integration Test (pass)

I tested using [mtcmptest](https://github.com/shanson7/mtcmptest) with the following json
```json
{
    "log()": "log(seriesByTag('name=jitter.g'))",
    "log(0.8)": "log(seriesByTag('name=jitter.g'),0.8)",
    "log(2.73)": "log(seriesByTag('name=jitter.g'),2.73)",
    "log(10)": "log(seriesByTag('name=jitter.g'),10)",
    "log(233333333)": "log(seriesByTag('name=jitter.g'),233333333)"
}

```
Basically they are the same except that the tag for log is `{string: string}` in mt & `{string: float}` in graphite, and very occasionally there's 1 bit precision difference.
[link to](http://paste.dev.bloomberg.com/c4RV8T5yWZk3bGeHzL8L.cs) the comparison result 


**Additional context**
Benchmark
```
goos: darwin
goarch: amd64
pkg: github.com/grafana/metrictank/expr
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLog10k_1NoNulls
BenchmarkLog10k_1NoNulls-12                        39400             28115 ns/op
BenchmarkLog10k_10NoNulls
BenchmarkLog10k_10NoNulls-12                        4143            300366 ns/op
BenchmarkLog10k_100NoNulls
BenchmarkLog10k_100NoNulls-12                        342           3290549 ns/op
BenchmarkLog10k_1000NoNulls
BenchmarkLog10k_1000NoNulls-12                        37          30940075 ns/op
BenchmarkLog10k_1SomeSeriesHalfNulls
BenchmarkLog10k_1SomeSeriesHalfNulls-12            43148             27560 ns/op
BenchmarkLog10k_10SomeSeriesHalfNulls
BenchmarkLog10k_10SomeSeriesHalfNulls-12            4471            293390 ns/op
BenchmarkLog10k_100SomeSeriesHalfNulls
BenchmarkLog10k_100SomeSeriesHalfNulls-12            384           3079671 ns/op
BenchmarkLog10k_1000SomeSeriesHalfNulls
BenchmarkLog10k_1000SomeSeriesHalfNulls-12            40          29678756 ns/op
BenchmarkLog10k_1AllSeriesHalfNulls
BenchmarkLog10k_1AllSeriesHalfNulls-12             42213             28313 ns/op
BenchmarkLog10k_10AllSeriesHalfNulls
BenchmarkLog10k_10AllSeriesHalfNulls-12             4590            256792 ns/op
BenchmarkLog10k_100AllSeriesHalfNulls
BenchmarkLog10k_100AllSeriesHalfNulls-12             392           3157942 ns/op
BenchmarkLog10k_1000AllSeriesHalfNulls
BenchmarkLog10k_1000AllSeriesHalfNulls-12             37          30260522 ns/op
PASS
ok      github.com/grafana/metrictank/expr      18.915s
```