### PR TITLE
Fix: querying rollup data does not show aggregated points corresponding to points in ROB

### DIFF
--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -153,9 +153,8 @@ func (a *AggMetric) SyncAggregatedChunkSaveState(ts uint32, consolidator consoli
 }
 
 func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSpan, from, to uint32) (Result, error) {
-
-	for _, a := range a.aggregators {
-		if a.span == aggSpan {
+	for _, aggregator := range a.aggregators {
+		if aggregator.span == aggSpan {
 			var agg *AggMetric
 			switch consolidator {
 			case consolidation.None:
@@ -169,15 +168,15 @@ func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSp
 				badConsolidator.Inc()
 				return Result{}, err
 			case consolidation.Cnt:
-				agg = a.cntMetric
+				agg = aggregator.cntMetric
 			case consolidation.Lst:
-				agg = a.lstMetric
+				agg = aggregator.lstMetric
 			case consolidation.Min:
-				agg = a.minMetric
+				agg = aggregator.minMetric
 			case consolidation.Max:
-				agg = a.maxMetric
+				agg = aggregator.maxMetric
 			case consolidation.Sum:
-				agg = a.sumMetric
+				agg = aggregator.sumMetric
 			default:
 				err := fmt.Errorf("internal error: AggMetric.GetAggregated(): unknown consolidator %q", consolidator)
 				log.Errorf("AM: %s", err.Error())
@@ -185,9 +184,22 @@ func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSp
 				return Result{}, err
 			}
 			if agg == nil {
-				return Result{}, fmt.Errorf("Consolidator %q not configured", consolidator)
+				return Result{}, fmt.Errorf("consolidator %q not configured", consolidator)
 			}
-			return agg.Get(from, to)
+			result, err := agg.Get(from, to)
+			if err != nil {
+				return Result{}, err
+			}
+			futurePoints := []schema.Point{}
+			if a.rob != nil {
+				futurePoints = a.rob.Get()
+			}
+			result.Points = aggregator.Foresee(consolidator, from, to, futurePoints)
+			if result.Oldest > result.Points[0].Ts {
+				result.Oldest = result.Points[0].Ts
+			}
+
+			return result, nil
 		}
 	}
 	err := fmt.Errorf("internal error: AggMetric.GetAggregated(): unknown aggSpan %d", aggSpan)
@@ -433,7 +445,7 @@ func (a *AggMetric) persist(pos int) {
 		pendingChunk--
 	}
 	persistDuration.Value(time.Now().Sub(pre))
-	return
+
 }
 
 // don't ever call with a ts of 0, cause we use 0 to mean not initialized!

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -193,7 +193,7 @@ func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSp
 			futurePoints := []schema.Point{}
 			if a.rob != nil {
 				futurePoints = a.rob.Get()
-				if result.Oldest > futurePoints[0].Ts {
+				if len(futurePoints) > 0 && result.Oldest > futurePoints[0].Ts {
 					result.Oldest = futurePoints[0].Ts
 				}
 			}
@@ -445,7 +445,6 @@ func (a *AggMetric) persist(pos int) {
 		pendingChunk--
 	}
 	persistDuration.Value(time.Now().Sub(pre))
-
 }
 
 // don't ever call with a ts of 0, cause we use 0 to mean not initialized!

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -193,11 +193,11 @@ func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSp
 			futurePoints := []schema.Point{}
 			if a.rob != nil {
 				futurePoints = a.rob.Get()
+				if result.Oldest > futurePoints[0].Ts {
+					result.Oldest = futurePoints[0].Ts
+				}
 			}
 			result.Points = aggregator.Foresee(consolidator, from, to, futurePoints)
-			if result.Oldest > result.Points[0].Ts {
-				result.Oldest = result.Points[0].Ts
-			}
 
 			return result, nil
 		}

--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -191,9 +191,14 @@ func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSp
 				return Result{}, err
 			}
 			futurePoints := []schema.Point{}
+
+			a.RLock()
+			defer a.RUnlock()
+
 			if a.rob != nil {
 				futurePoints = a.rob.Get()
-				if len(futurePoints) > 0 && result.Oldest > futurePoints[0].Ts {
+				// we may need to update result.Oldest if there are no points in result.
+				if len(futurePoints) > 0 && len(result.Iters) == 0 && len(result.Points) == 0 {
 					result.Oldest = futurePoints[0].Ts
 				}
 			}

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -486,14 +486,13 @@ func TestGetAggregated(t *testing.T) {
 	m.Add(30, 30)
 	m.Add(31, 31)
 	m.Add(32, 32)
-	m.Add(40, 40)
 
 	result, err := m.GetAggregated(consolidation.Sum, aggSpan, 0, 1000)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got := itersToPoints(result.Iters)
+	got := append(itersToPoints(result.Iters), result.Points...)
 
 	expected := []schema.Point{
 		{Val: 10, Ts: 10},
@@ -502,7 +501,6 @@ func TestGetAggregated(t *testing.T) {
 		{Val: 21 + 22, Ts: 25},
 		{Val: 30, Ts: 30},
 		{Val: 31 + 32, Ts: 35},
-		{Val: 40, Ts: 40},
 	}
 	assertPointsEqual(t, got, expected)
 }

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -1,181 +1,698 @@
 package mdata
 
 import (
+	"errors"
+	"fmt"
+	"math"
 	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/grafana/metrictank/cluster"
+	"github.com/grafana/metrictank/conf"
+	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/mdata/cache"
+	"github.com/grafana/metrictank/mdata/chunk"
+	mdataerrors "github.com/grafana/metrictank/mdata/errors"
 	"github.com/grafana/metrictank/schema"
+	"github.com/grafana/metrictank/util"
 	log "github.com/sirupsen/logrus"
 )
 
-// AggMetrics is an in-memory store of AggMetric objects
-// note: they are keyed by MKey here because each
-// AggMetric manages access to, and references of,
-// their rollup archives themselves
-type AggMetrics struct {
-	store          Store
-	cachePusher    cache.CachePusher
-	dropFirstChunk bool
-	ingestFrom     map[uint32]int64
-	chunkMaxStale  uint32
-	metricMaxStale uint32
-	gcInterval     time.Duration
+var ErrInvalidRange = errors.New("AggMetric: invalid range: from must be less than to")
 
+// AggMetric takes in new values, updates the in-memory data and streams the points to aggregators
+// it uses a circular buffer of chunks
+// each chunk starts at their respective t0
+// a t0 is a timestamp divisible by chunkSpan without a remainder (e.g. 2 hour boundaries)
+// firstT0's data is held at index 0, indexes go up and wrap around from numChunks-1 to 0
+// in addition, keep in mind that the last chunk is always a work in progress and not useable for aggregation
+// AggMetric is concurrency-safe
+type AggMetric struct {
+	store       Store
+	cachePusher cache.CachePusher
 	sync.RWMutex
-	Metrics map[uint32]map[schema.Key]*AggMetric
+	key             schema.AMKey
+	rob             *ReorderBuffer
+	currentChunkPos int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
+	numChunks       uint32 // max size of the circular buffer
+	chunkSpan       uint32 // span of individual chunks in seconds
+	chunks          []*chunk.Chunk
+	aggregators     []*Aggregator
+	dropFirstChunk  bool
+	ingestFromT0    uint32
+	futureTolerance uint32
+	ttl             uint32
+	lastSaveStart   uint32 // last chunk T0 that was added to the write Queue.
+	lastWrite       uint32 // wall clock time of when last point was successfully added (possibly to the ROB)
+	firstTs         uint32 // timestamp of first point seen
 }
 
-func NewAggMetrics(store Store, cachePusher cache.CachePusher, dropFirstChunk bool, ingestFrom map[uint32]int64, chunkMaxStale, metricMaxStale uint32, gcInterval time.Duration) *AggMetrics {
-	ms := AggMetrics{
-		store:          store,
-		cachePusher:    cachePusher,
-		dropFirstChunk: dropFirstChunk,
-		ingestFrom:     ingestFrom,
-		Metrics:        make(map[uint32]map[schema.Key]*AggMetric),
-		chunkMaxStale:  chunkMaxStale,
-		metricMaxStale: metricMaxStale,
-		gcInterval:     gcInterval,
+// NewAggMetric creates a metric with given key, it retains the given number of chunks each chunkSpan seconds long
+// it optionally also creates aggregations with the given settings
+// the 0th retention is the native archive of this metric. if there's several others, we create aggregators, using agg.
+// it's the callers responsibility to make sure agg is not nil in that case!
+// If reorderWindow is greater than 0, a reorder buffer is enabled. In that case data points with duplicate timestamps
+// the behavior is defined by reorderAllowUpdate
+func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, retentions conf.Retentions, reorderWindow, interval uint32, agg *conf.Aggregation, reorderAllowUpdate, dropFirstChunk bool, ingestFrom int64) *AggMetric {
+
+	// note: during parsing of retentions, we assure there's at least 1.
+	ret := retentions.Rets[0]
+
+	m := AggMetric{
+		cachePusher:     cachePusher,
+		store:           store,
+		key:             key,
+		chunkSpan:       ret.ChunkSpan,
+		numChunks:       ret.NumChunks,
+		chunks:          make([]*chunk.Chunk, 0, ret.NumChunks),
+		dropFirstChunk:  dropFirstChunk,
+		futureTolerance: uint32(ret.MaxRetention()) * uint32(futureToleranceRatio) / 100,
+		ttl:             uint32(ret.MaxRetention()),
+		// we set LastWrite here to make sure a new Chunk doesn't get immediately
+		// garbage collected right after creating it, before we can push to it.
+		lastWrite: uint32(time.Now().Unix()),
+	}
+	if ingestFrom > 0 {
+		// we only want to ingest data that will go into chunks with a t0 >= 'ingestFrom'.
+		m.ingestFromT0 = AggBoundary(uint32(ingestFrom), ret.ChunkSpan)
+	}
+	if reorderWindow != 0 {
+		m.rob = NewReorderBuffer(reorderWindow, interval, reorderAllowUpdate)
 	}
 
-	// gcInterval = 0 can be useful in tests
-	if gcInterval > 0 {
-		go ms.GC()
+	origSplits := strings.Split(retentions.Orig, ":")
+	for i, ret := range retentions.Rets[1:] {
+		retOrig := origSplits[i+1]
+		m.aggregators = append(m.aggregators, NewAggregator(store, cachePusher, key, retOrig, ret, *agg, dropFirstChunk, ingestFrom))
 	}
-	return &ms
+
+	return &m
 }
 
-// periodically scan chunks and close any that have not received data in a while
-func (ms *AggMetrics) GC() {
+// Sync the saved state of a chunk by its T0.
+func (a *AggMetric) SyncChunkSaveState(ts uint32, sendPersist bool) ChunkSaveCallback {
+	return func() {
+		util.AtomicBumpUint32(&a.lastSaveStart, ts)
+
+		log.Debugf("AM: metric %s at chunk T0=%d has been saved.", a.key, ts)
+		if sendPersist {
+			SendPersistMessage(a.key.String(), ts)
+		}
+	}
+}
+
+// Sync the saved state of a chunk by its T0.
+func (a *AggMetric) SyncAggregatedChunkSaveState(ts uint32, consolidator consolidation.Consolidator, aggSpan uint32) {
+	// no lock needed cause aggregators don't change at runtime
+	for _, a := range a.aggregators {
+		if a.span == aggSpan {
+			switch consolidator {
+			case consolidation.None:
+				panic("cannot get an archive for no consolidation")
+			case consolidation.Avg:
+				panic("avg consolidator has no matching Archive(). you need sum and cnt")
+			case consolidation.Cnt:
+				if a.cntMetric != nil {
+					a.cntMetric.SyncChunkSaveState(ts, false)()
+				}
+				return
+			case consolidation.Min:
+				if a.minMetric != nil {
+					a.minMetric.SyncChunkSaveState(ts, false)()
+				}
+				return
+			case consolidation.Max:
+				if a.maxMetric != nil {
+					a.maxMetric.SyncChunkSaveState(ts, false)()
+				}
+				return
+			case consolidation.Sum:
+				if a.sumMetric != nil {
+					a.sumMetric.SyncChunkSaveState(ts, false)()
+				}
+				return
+			case consolidation.Lst:
+				if a.lstMetric != nil {
+					a.lstMetric.SyncChunkSaveState(ts, false)()
+				}
+				return
+			default:
+				panic(fmt.Sprintf("internal error: no such consolidator %q with span %d", consolidator, aggSpan))
+			}
+		}
+	}
+}
+
+func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSpan, from, to uint32) (Result, error) {
+	// no lock needed cause aggregators don't change at runtime
+	for _, a := range a.aggregators {
+		if a.span == aggSpan {
+			var agg *AggMetric
+			switch consolidator {
+			case consolidation.None:
+				err := errors.New("internal error: AggMetric.GetAggregated(): cannot get an archive for no consolidation")
+				log.Errorf("AM: %s", err.Error())
+				badConsolidator.Inc()
+				return Result{}, err
+			case consolidation.Avg:
+				err := errors.New("internal error: AggMetric.GetAggregated(): avg consolidator has no matching Archive(). you need sum and cnt")
+				log.Errorf("AM: %s", err.Error())
+				badConsolidator.Inc()
+				return Result{}, err
+			case consolidation.Cnt:
+				agg = a.cntMetric
+			case consolidation.Lst:
+				agg = a.lstMetric
+			case consolidation.Min:
+				agg = a.minMetric
+			case consolidation.Max:
+				agg = a.maxMetric
+			case consolidation.Sum:
+				agg = a.sumMetric
+			default:
+				err := fmt.Errorf("internal error: AggMetric.GetAggregated(): unknown consolidator %q", consolidator)
+				log.Errorf("AM: %s", err.Error())
+				badConsolidator.Inc()
+				return Result{}, err
+			}
+			if agg == nil {
+				return Result{}, fmt.Errorf("Consolidator %q not configured", consolidator)
+			}
+			return agg.Get(from, to)
+		}
+	}
+	err := fmt.Errorf("internal error: AggMetric.GetAggregated(): unknown aggSpan %d", aggSpan)
+	log.Errorf("AM: %s", err.Error())
+	badAggSpan.Inc()
+	return Result{}, err
+}
+
+// Get all data between the requested time ranges. From is inclusive, to is exclusive. from <= x < to
+// more data then what's requested may be included
+// specifically, returns:
+// * points from the ROB (if enabled)
+// * iters from matching chunks
+// * oldest point we have, so that if your query needs data before it, the caller knows when to query the store
+func (a *AggMetric) Get(from, to uint32) (Result, error) {
+	pre := time.Now()
+	log.Debugf("AM: %s Get(): %d - %d (%s - %s) span:%ds", a.key, from, to, TS(from), TS(to), to-from-1)
+	if from >= to {
+		return Result{}, ErrInvalidRange
+	}
+	a.RLock()
+	defer a.RUnlock()
+
+	result := Result{
+		Oldest: math.MaxInt32,
+	}
+
+	if a.rob != nil {
+		result.Points = a.rob.Get()
+		if len(result.Points) > 0 {
+			result.Oldest = result.Points[0].Ts
+			if result.Oldest <= from {
+				return result, nil
+			}
+		}
+	}
+
+	if len(a.chunks) == 0 {
+		// we dont have any data yet.
+		log.Debugf("AM: %s Get(): no data for requested range.", a.key)
+		return result, nil
+	}
+
+	newestChunk := a.chunks[a.currentChunkPos]
+
+	if from >= newestChunk.Series.T0+a.chunkSpan {
+		// request falls entirely ahead of the data we have
+		// this can happen in a few cases:
+		// * queries for the most recent data, but our ingestion has fallen behind.
+		//   we don't want such a degradation to cause a storm of cassandra queries
+		//   we should just return an oldest value that is <= from so we don't hit cassandra
+		//   but it doesn't have to be the real oldest value, so do whatever is cheap.
+		// * data got once written by another node, but has been re-sending (perhaps fixed)
+		//   to this node, but not yet up to the point it was previously sent. so we're
+		//   only aware of older data and not the newer data in cassandra. this is unlikely
+		//   and it's better to not serve this scenario well in favor of the above case.
+		//   seems like a fair tradeoff anyway that you have to refill all the way first.
+		log.Debugf("AM: %s Get(): no data for requested range.", a.key)
+		result.Oldest = from
+		return result, nil
+	}
+
+	// get the oldest chunk we have.
+	// eg if we have 5 chunks, N is the current chunk and n-4 is the oldest chunk.
+	// -----------------------------
+	// | n-4 | n-3 | n-2 | n-1 | n |  CurrentChunkPos = 4
+	// -----------------------------
+	// -----------------------------
+	// | n | n-4 | n-3 | n-2 | n-1 |  CurrentChunkPos = 0
+	// -----------------------------
+	// -----------------------------
+	// | n-2 | n-1 | n | n-4 | n-3 |  CurrentChunkPos = 2
+	// -----------------------------
+	oldestPos := a.currentChunkPos + 1
+	if oldestPos >= len(a.chunks) {
+		oldestPos = 0
+	}
+
+	oldestChunk := a.chunks[oldestPos]
+
+	if to <= oldestChunk.Series.T0 {
+		// the requested time range ends before any data we have.
+		log.Debugf("AM: %s Get(): no data for requested range", a.key)
+		if oldestChunk.First {
+			result.Oldest = a.firstTs
+		} else {
+			result.Oldest = oldestChunk.Series.T0
+		}
+		return result, nil
+	}
+
+	// Find the oldest Chunk that the "from" ts falls in.  If from extends before the oldest
+	// chunk, then we just use the oldest chunk.
+	for from >= oldestChunk.Series.T0+a.chunkSpan {
+		oldestPos++
+		if oldestPos >= len(a.chunks) {
+			oldestPos = 0
+		}
+		oldestChunk = a.chunks[oldestPos]
+	}
+
+	// find the newest Chunk that "to" falls in.  If "to" extends to after the newest data
+	// then just return the newest chunk.
+	// some examples to clarify this more. assume newestChunk.T0 is at 120, then
+	// for a to of 121 -> data up to (incl) 120 -> stay at this chunk, it has a point we need
+	// for a to of 120 -> data up to (incl) 119 -> use older chunk
+	// for a to of 119 -> data up to (incl) 118 -> use older chunk
+	newestPos := a.currentChunkPos
+	for to <= newestChunk.Series.T0 {
+		newestPos--
+		if newestPos < 0 {
+			newestPos += len(a.chunks)
+		}
+		newestChunk = a.chunks[newestPos]
+	}
+
+	// now just start at oldestPos and move through the Chunks circular Buffer to newestPos
 	for {
-		var purged int
+		c := a.chunks[oldestPos]
+		result.Iters = append(result.Iters, c.Series.Iter())
 
-		unix := time.Duration(time.Now().UnixNano())
-		diff := ms.gcInterval - (unix % ms.gcInterval)
-		time.Sleep(diff + time.Minute)
-		log.Info("Aggmetrics: checking for stale chunks that need persisting.")
-		nowTime := time.Now()
-		now := uint32(nowTime.Unix())
-		chunkMinTs := now - uint32(ms.chunkMaxStale)
-		metricMinTs := now - uint32(ms.metricMaxStale)
-
-		// as this is the only goroutine that can delete from ms.Metrics
-		// we only need to lock long enough to get the list of orgs, then for each org
-		// get the list of active metrics.
-		// It doesn't matter if new orgs or metrics are added while we iterate these lists.
-		ms.RLock()
-		orgs := make([]uint32, 0, len(ms.Metrics))
-		for o := range ms.Metrics {
-			orgs = append(orgs, o)
-		}
-		ms.RUnlock()
-		for _, org := range orgs {
-			orgActiveMetrics := promActiveMetrics.WithLabelValues(strconv.Itoa(int(org)))
-			ms.RLock()
-			keys := make([]schema.Key, 0, len(ms.Metrics[org]))
-			for k := range ms.Metrics[org] {
-				keys = append(keys, k)
-			}
-			ms.RUnlock()
-			for _, key := range keys {
-				gcMetric.Inc()
-				ms.RLock()
-				a := ms.Metrics[org][key]
-				ms.RUnlock()
-				points, stale := a.GC(now, chunkMinTs, metricMinTs)
-				if stale {
-					log.Debugf("metric %s is stale. Purging data from memory.", key)
-					ms.Lock()
-					purged++
-					delete(ms.Metrics[org], key)
-					orgActiveMetrics.Set(float64(len(ms.Metrics[org])))
-					// note: this is racey. if a metric has just become unstale, it may have created a new chunk,
-					// pruning an older one. in which case we double-subtract those points
-					// hard to fix and super rare. see https://github.com/grafana/metrictank/pull/1242
-					totalPoints.DecUint64(uint64(points))
-					ms.Unlock()
-				}
-			}
-			ms.RLock()
-			orgActive := len(ms.Metrics[org])
-			ms.RUnlock()
-			orgActiveMetrics.Set(float64(orgActive))
-
-			// If this org has no keys, then delete the org from the map
-			if orgActive == 0 {
-				// To prevent races, we need to check that there are still no metrics for the org while holding a write lock
-				ms.Lock()
-				orgActive = len(ms.Metrics[org])
-				if orgActive == 0 {
-					delete(ms.Metrics, org)
-				}
-				ms.Unlock()
-			}
+		if oldestPos == newestPos {
+			break
 		}
 
-		// Get the totalActive across all orgs.
-		totalActive := 0
-		ms.RLock()
-		for o := range ms.Metrics {
-			totalActive += len(ms.Metrics[o])
+		oldestPos++
+		if oldestPos >= len(a.chunks) {
+			oldestPos = 0
 		}
-		ms.RUnlock()
-		metricsActive.Set(totalActive)
+	}
 
-		log.Infof("Aggmetrics: finished GC %s. number of purged (deleted) metrics from tank: %d", time.Since(nowTime), purged)
+	if oldestChunk.First {
+		result.Oldest = a.firstTs
+	} else {
+		result.Oldest = oldestChunk.Series.T0
+	}
+
+	memToIterDuration.Value(time.Now().Sub(pre))
+	return result, nil
+}
+
+// caller must hold lock
+func (a *AggMetric) addAggregators(ts uint32, val float64) {
+	for _, agg := range a.aggregators {
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("AM: %s pushing %d,%f to aggregator %d", a.key, ts, val, agg.span)
+		}
+		agg.Add(ts, val)
 	}
 }
 
-func (ms *AggMetrics) Get(key schema.MKey) (Metric, bool) {
-	var m *AggMetric
-	ms.RLock()
-	_, ok := ms.Metrics[key.Org]
-	if ok {
-		m, ok = ms.Metrics[key.Org][key.Key]
+// pushToCache adds the chunk into the cache if it is hot
+// caller must hold lock
+func (a *AggMetric) pushToCache(c *chunk.Chunk) {
+	if a.cachePusher == nil {
+		return
 	}
-	ms.RUnlock()
-	return m, ok
+	// push into cache
+	intervalHint := a.key.Archive.Span()
+
+	itergen, err := chunk.NewIterGen(c.Series.T0, intervalHint, c.Encode(a.chunkSpan))
+	if err != nil {
+		log.Errorf("AM: %s failed to generate IterGen. this should never happen: %s", a.key, err)
+	}
+	go a.cachePusher.AddIfHot(a.key, 0, itergen)
 }
 
-func (ms *AggMetrics) GetOrCreate(key schema.MKey, schemaId, aggId uint16, interval uint32) Metric {
-	var m *AggMetric
-	// in the most common case, it's already there and an Rlock is all we need
-	ms.RLock()
-	_, ok := ms.Metrics[key.Org]
-	if ok {
-		m, ok = ms.Metrics[key.Org][key.Key]
-	}
-	ms.RUnlock()
-	if ok {
-		return m
+// write a chunk to persistent storage.
+// never persist a chunk that may receive further updates!
+// (because the stores will read out chunk data on the unlocked chunk)
+// caller must hold lock.
+func (a *AggMetric) persist(pos int) {
+	chunk := a.chunks[pos]
+	pre := time.Now()
+
+	lastSaveStart := atomic.LoadUint32(&a.lastSaveStart)
+	if lastSaveStart >= chunk.Series.T0 {
+		// this can happen if
+		// a) there are 2 primary MT nodes both saving chunks to Cassandra
+		// b) a primary failed and this node was promoted to be primary but metric consuming is lagging.
+		// c) chunk was persisted by GC (stale) and then new data triggered another persist call
+		// d) dropFirstChunk is enabled and this is the first chunk
+		log.Debugf("AM: persist(): duplicate persist call for chunk.")
+		return
 	}
 
-	k := schema.AMKey{
-		MKey: key,
+	// create an array of chunks that need to be sent to the writeQueue.
+	pending := make([]*ChunkWriteRequest, 1)
+	// add the current chunk to the list of chunks to send to the writeQueue
+	cwr := NewChunkWriteRequest(
+		a.SyncChunkSaveState(chunk.Series.T0, true),
+		a.key,
+		a.ttl,
+		chunk.Series.T0,
+		chunk.Encode(a.chunkSpan),
+		time.Now(),
+	)
+	pending[0] = &cwr
+
+	// if we recently became the primary, there may be older chunks
+	// that the old primary did not save.  We should check for those
+	// and save them.
+	previousPos := pos - 1
+	if previousPos < 0 {
+		previousPos += len(a.chunks)
+	}
+	previousChunk := a.chunks[previousPos]
+	for (previousChunk.Series.T0 < chunk.Series.T0) && (lastSaveStart < previousChunk.Series.T0) {
+		log.Debugf("AM: persist(): old chunk needs saving. Adding %s:%d to writeQueue", a.key, previousChunk.Series.T0)
+		cwr := NewChunkWriteRequest(
+			a.SyncChunkSaveState(previousChunk.Series.T0, true),
+			a.key,
+			a.ttl,
+			previousChunk.Series.T0,
+			previousChunk.Encode(a.chunkSpan),
+			time.Now(),
+		)
+		pending = append(pending, &cwr)
+		previousPos--
+		if previousPos < 0 {
+			previousPos += len(a.chunks)
+		}
+		previousChunk = a.chunks[previousPos]
 	}
 
-	agg := Aggregations.Get(aggId)
-	confSchema := Schemas.Get(schemaId)
+	// Every chunk with a T0 <= this chunks' T0 is now either saved, or in the writeQueue.
+	util.AtomicBumpUint32(&a.lastSaveStart, chunk.Series.T0)
 
-	// if it wasn't there, get the write lock and prepare to add it
-	// but first we need to check again if someone has added it in
-	// the meantime (quite rare, but anyway)
-	ms.Lock()
-	if _, ok := ms.Metrics[key.Org]; !ok {
-		ms.Metrics[key.Org] = make(map[schema.Key]*AggMetric)
+	log.Debugf("AM: persist(): sending %d chunks to write queue", len(pending))
+
+	pendingChunk := len(pending) - 1
+
+	// if the store blocks,
+	// the calling function will block waiting for persist() to complete.
+	// This is intended to put backpressure on our message handlers so
+	// that they stop consuming messages, leaving them to buffer at
+	// the message bus. The "pending" array of chunks are processed
+	// last-to-first ensuring that older data is added to the store
+	// before newer data.
+	for pendingChunk >= 0 {
+		log.Debugf("AM: persist(): sealing chunk %d/%d (%s:%d) and adding to write queue.", pendingChunk, len(pending), a.key, chunk.Series.T0)
+		a.store.Add(pending[pendingChunk])
+		pendingChunk--
 	}
-	m, ok = ms.Metrics[key.Org][key.Key]
-	if ok {
-		ms.Unlock()
-		return m
+	persistDuration.Value(time.Now().Sub(pre))
+	return
+}
+
+// don't ever call with a ts of 0, cause we use 0 to mean not initialized!
+func (a *AggMetric) Add(ts uint32, val float64) {
+	if ts < a.ingestFromT0 {
+		// TODO: add metric to keep track of the # of points discarded
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-from. First chunk considered starts at %d", ts, val, a.ingestFromT0)
+		}
+		// even if a point is too old for our raw data, it may not be too old for aggregated data
+		// for example let's say a chunk starts at t0=3600 but we have 300-secondly aggregates
+		// that mean the aggregators need data from 3301 and onwards, because we aggregate 3301-3600 into a point with ts=3600
+		a.addAggregators(ts, val)
+		return
 	}
-	ingestFrom := ms.ingestFrom[key.Org]
-	m = NewAggMetric(ms.store, ms.cachePusher, k, confSchema.Retentions, confSchema.ReorderWindow, interval, &agg, confSchema.ReorderAllowUpdate, ms.dropFirstChunk, ingestFrom)
-	ms.Metrics[key.Org][key.Key] = m
-	active := len(ms.Metrics[key.Org])
-	ms.Unlock()
-	metricsActive.Inc()
-	promActiveMetrics.WithLabelValues(strconv.Itoa(int(key.Org))).Set(float64(active))
-	return m
+
+	// need to check if ts > futureTolerance to prevent that we reject a datapoint
+	// because the ts value has wrapped around the uint32 boundary
+	if ts > a.futureTolerance && int64(ts-a.futureTolerance) > time.Now().Unix() {
+		sampleTooFarAhead.Inc()
+
+		if enforceFutureTolerance {
+			if log.IsLevelEnabled(log.DebugLevel) {
+				log.Debugf("AM: discarding metric <%d,%f>: timestamp is too far in the future, accepting timestamps up to %d seconds into the future", ts, val, a.futureTolerance)
+			}
+
+			discardedSampleTooFarAhead.Inc()
+			PromDiscardedSamples.WithLabelValues(tooFarAhead, strconv.Itoa(int(a.key.MKey.Org))).Inc()
+			return
+		}
+	}
+
+	a.Lock()
+	defer a.Unlock()
+
+	if a.rob == nil {
+		// write directly
+		a.add(ts, val)
+	} else {
+		// write through reorder buffer
+		res, err := a.rob.Add(ts, val)
+
+		if err == nil {
+			if len(res) == 0 {
+				a.lastWrite = uint32(time.Now().Unix())
+			} else {
+				for _, p := range res {
+					a.add(p.Ts, p.Val)
+				}
+			}
+		} else {
+			log.Debugf("AM: failed to add metric to reorder buffer for %s. %s", a.key, err)
+			a.discardedMetricsInc(err)
+		}
+	}
+}
+
+// don't ever call with a ts of 0, cause we use 0 to mean not initialized!
+// caller must hold write lock
+func (a *AggMetric) add(ts uint32, val float64) {
+	t0 := ts - (ts % a.chunkSpan)
+
+	if len(a.chunks) == 0 {
+		chunkCreate.Inc()
+		// no data has been added to this AggMetric yet.
+		// note that we may not be aware of prior data that belongs into this chunk
+		// so we should track this cutoff point
+		a.chunks = append(a.chunks, chunk.NewFirst(t0))
+		a.firstTs = ts
+
+		if err := a.chunks[0].Push(ts, val); err != nil {
+			panic(fmt.Sprintf("FATAL ERROR: this should never happen. Pushing initial value <%d,%f> to new chunk at pos 0 failed: %q", ts, val, err))
+		}
+		totalPoints.Inc()
+
+		log.Debugf("AM: %s Add(): created first chunk with first point: %v", a.key, a.chunks[0])
+		a.lastWrite = uint32(time.Now().Unix())
+		if a.dropFirstChunk {
+			util.AtomicBumpUint32(&a.lastSaveStart, t0)
+		}
+		a.addAggregators(ts, val)
+		return
+	}
+
+	currentChunk := a.chunks[a.currentChunkPos]
+
+	if t0 == currentChunk.Series.T0 {
+		// last prior data was in same chunk as new point
+		if currentChunk.Series.Finished {
+			// if we've already 'finished' the chunk, it means it has the end-of-stream marker and any new points behind it wouldn't be read by an iterator
+			// you should monitor this metric closely, it indicates that maybe your GC settings don't match how you actually send data (too late)
+			discardedReceivedTooLate.Inc()
+			PromDiscardedSamples.WithLabelValues(receivedTooLate, strconv.Itoa(int(a.key.MKey.Org))).Inc()
+			return
+		}
+
+		if err := currentChunk.Push(ts, val); err != nil {
+			log.Debugf("AM: failed to add metric to chunk for %s. %s", a.key, err)
+			a.discardedMetricsInc(err)
+			return
+		}
+		totalPoints.Inc()
+		a.lastWrite = uint32(time.Now().Unix())
+
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("AM: %s Add(): pushed new value to last chunk: %v", a.key, a.chunks[0])
+		}
+	} else if t0 < currentChunk.Series.T0 {
+		log.Debugf("AM: Point at %d has t0 %d, goes back into previous chunk. CurrentChunk t0: %d, LastTs: %d", ts, t0, currentChunk.Series.T0, currentChunk.Series.T)
+		discardedSampleOutOfOrder.Inc()
+		PromDiscardedSamples.WithLabelValues(sampleOutOfOrder, strconv.Itoa(int(a.key.MKey.Org))).Inc()
+		return
+	} else {
+		// Data belongs in a new chunk.
+
+		// If it isn't finished already, add the end-of-stream marker and flag the chunk as "closed"
+		currentChunk.Finish()
+
+		a.pushToCache(currentChunk)
+		// If we are a primary node, then add the chunk to the write queue to be saved to Cassandra
+		if cluster.Manager.IsPrimary() {
+			log.Debugf("AM: persist(): node is primary, saving chunk. %s T0: %d", a.key, currentChunk.Series.T0)
+			// persist the chunk. If the writeQueue is full, then this will block.
+			a.persist(a.currentChunkPos)
+		}
+
+		a.currentChunkPos++
+		if a.currentChunkPos >= int(a.numChunks) {
+			a.currentChunkPos = 0
+		}
+
+		chunkCreate.Inc()
+		if len(a.chunks) < int(a.numChunks) {
+			a.chunks = append(a.chunks, chunk.New(t0))
+			if err := a.chunks[a.currentChunkPos].Push(ts, val); err != nil {
+				panic(fmt.Sprintf("FATAL ERROR: this should never happen. Pushing initial value <%d,%f> to new chunk at pos %d failed: %q", ts, val, a.currentChunkPos, err))
+			}
+			totalPoints.Inc()
+			log.Debugf("AM: %s Add(): added new chunk to buffer. now %d chunks. and added the new point: %s", a.key, a.currentChunkPos+1, a.chunks[a.currentChunkPos])
+		} else {
+			chunkClear.Inc()
+			totalPoints.DecUint64(uint64(a.chunks[a.currentChunkPos].NumPoints))
+
+			a.chunks[a.currentChunkPos] = chunk.New(t0)
+			if err := a.chunks[a.currentChunkPos].Push(ts, val); err != nil {
+				panic(fmt.Sprintf("FATAL ERROR: this should never happen. Pushing initial value <%d,%f> to new chunk at pos %d failed: %q", ts, val, a.currentChunkPos, err))
+			}
+			totalPoints.Inc()
+			log.Debugf("AM: %s Add(): cleared chunk at %d of %d and replaced with new. and added the new point: %s", a.key, a.currentChunkPos, len(a.chunks), a.chunks[a.currentChunkPos])
+		}
+		a.lastWrite = uint32(time.Now().Unix())
+
+	}
+	a.addAggregators(ts, val)
+}
+
+// collectable returns whether the AggMetric is garbage collectable
+// an Aggmetric is collectable based on two conditions:
+// * the AggMetric hasn't been written to in a configurable amount of time
+//   (wether the write went to the ROB or a chunk is irrelevant)
+// * the last chunk - if any - is no longer "active".
+//   active means:
+//   any reasonable realtime stream (e.g. up to 15 min behind wall-clock)
+//   could add points to the chunk
+//
+// caller must hold lock
+func (a *AggMetric) collectable(now, chunkMinTs uint32) bool {
+
+	// no chunks at all means "possibly collectable"
+	// the caller (AggMetric.GC()) still has its own checks to
+	// handle the "no chunks" correctly later.
+	// also: we want AggMetric.GC() to go ahead with flushing the ROB in this case
+	if len(a.chunks) == 0 {
+		return a.lastWrite < chunkMinTs
+	}
+
+	currentChunk := a.chunks[a.currentChunkPos]
+	return a.lastWrite < chunkMinTs && currentChunk.Series.T0+a.chunkSpan+15*60 < now
+}
+
+// GC returns whether or not this AggMetric is stale and can be removed, and its pointcount if so
+// chunkMinTs -> min timestamp of a chunk before to be considered stale and to be persisted to Cassandra
+// metricMinTs -> min timestamp for a metric before to be considered stale and to be purged from the tank
+func (a *AggMetric) GC(now, chunkMinTs, metricMinTs uint32) (uint32, bool) {
+	a.Lock()
+	defer a.Unlock()
+
+	// unless it looks like the AggMetric is collectable, abort and mark as not stale
+	if !a.collectable(now, chunkMinTs) {
+		return 0, false
+	}
+
+	// make sure any points in the reorderBuffer are moved into our chunks so we can save the data
+	if a.rob != nil {
+		tmpLastWrite := a.lastWrite
+		pts := a.rob.Flush()
+		for _, p := range pts {
+			a.add(p.Ts, p.Val)
+		}
+
+		// adding points will cause our lastWrite to be updated, but we want to keep the old value
+		a.lastWrite = tmpLastWrite
+	}
+
+	// this aggMetric has never had metrics written to it.
+	if len(a.chunks) == 0 {
+		return a.gcAggregators(now, chunkMinTs, metricMinTs)
+	}
+
+	currentChunk := a.chunks[a.currentChunkPos]
+
+	// we must check collectable again. Imagine this scenario:
+	// * we didn't have any chunks when calling collectable() the first time so it returned true
+	// * data from the ROB is flushed and moved into a new chunk
+	// * this new chunk is active so we're not collectable, even though earlier we thought we were.
+	if !a.collectable(now, chunkMinTs) {
+		return 0, false
+	}
+
+	if !currentChunk.Series.Finished {
+		// chunk hasn't been written to in a while, and is not yet closed.
+		// Let's close it and persist it if we are a primary
+		log.Debugf("AM: Found stale Chunk, adding end-of-stream bytes. key: %v T0: %d", a.key, currentChunk.Series.T0)
+		currentChunk.Finish()
+		a.pushToCache(currentChunk)
+		if cluster.Manager.IsPrimary() {
+			log.Debugf("AM: persist(): node is primary, saving chunk. %v T0: %d", a.key, currentChunk.Series.T0)
+			// persist the chunk. If the writeQueue is full, then this will block.
+			a.persist(a.currentChunkPos)
+		}
+	}
+
+	var points uint32
+	for _, chunk := range a.chunks {
+		points += chunk.NumPoints
+	}
+	p, stale := a.gcAggregators(now, chunkMinTs, metricMinTs)
+	points += p
+	return points, stale && a.lastWrite < metricMinTs
+}
+
+// gcAggregators returns whether all aggregators are stale and can be removed, and their pointcount if so
+func (a *AggMetric) gcAggregators(now, chunkMinTs, metricMinTs uint32) (uint32, bool) {
+	var points uint32
+	stale := true
+	for _, agg := range a.aggregators {
+		p, s := agg.GC(now, chunkMinTs, metricMinTs, a.lastWrite)
+		points += p
+		stale = stale && s
+	}
+	return points, stale
+}
+
+func (a *AggMetric) discardedMetricsInc(err error) {
+	var reason string
+	switch err {
+	case mdataerrors.ErrMetricTooOld:
+		reason = sampleOutOfOrder
+		discardedSampleOutOfOrder.Inc()
+	case mdataerrors.ErrMetricNewValueForTimestamp:
+		reason = newValueForTimestamp
+		discardedNewValueForTimestamp.Inc()
+	default:
+		discardedUnknown.Inc()
+		reason = "unknown"
+	}
+	PromDiscardedSamples.WithLabelValues(reason, strconv.Itoa(int(a.key.MKey.Org))).Inc()
 }

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -1,698 +1,181 @@
 package mdata
 
 import (
-	"errors"
-	"fmt"
-	"math"
 	"strconv"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
-	"github.com/grafana/metrictank/cluster"
-	"github.com/grafana/metrictank/conf"
-	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/mdata/cache"
-	"github.com/grafana/metrictank/mdata/chunk"
-	mdataerrors "github.com/grafana/metrictank/mdata/errors"
 	"github.com/grafana/metrictank/schema"
-	"github.com/grafana/metrictank/util"
 	log "github.com/sirupsen/logrus"
 )
 
-var ErrInvalidRange = errors.New("AggMetric: invalid range: from must be less than to")
+// AggMetrics is an in-memory store of AggMetric objects
+// note: they are keyed by MKey here because each
+// AggMetric manages access to, and references of,
+// their rollup archives themselves
+type AggMetrics struct {
+	store          Store
+	cachePusher    cache.CachePusher
+	dropFirstChunk bool
+	ingestFrom     map[uint32]int64
+	chunkMaxStale  uint32
+	metricMaxStale uint32
+	gcInterval     time.Duration
 
-// AggMetric takes in new values, updates the in-memory data and streams the points to aggregators
-// it uses a circular buffer of chunks
-// each chunk starts at their respective t0
-// a t0 is a timestamp divisible by chunkSpan without a remainder (e.g. 2 hour boundaries)
-// firstT0's data is held at index 0, indexes go up and wrap around from numChunks-1 to 0
-// in addition, keep in mind that the last chunk is always a work in progress and not useable for aggregation
-// AggMetric is concurrency-safe
-type AggMetric struct {
-	store       Store
-	cachePusher cache.CachePusher
 	sync.RWMutex
-	key             schema.AMKey
-	rob             *ReorderBuffer
-	currentChunkPos int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
-	numChunks       uint32 // max size of the circular buffer
-	chunkSpan       uint32 // span of individual chunks in seconds
-	chunks          []*chunk.Chunk
-	aggregators     []*Aggregator
-	dropFirstChunk  bool
-	ingestFromT0    uint32
-	futureTolerance uint32
-	ttl             uint32
-	lastSaveStart   uint32 // last chunk T0 that was added to the write Queue.
-	lastWrite       uint32 // wall clock time of when last point was successfully added (possibly to the ROB)
-	firstTs         uint32 // timestamp of first point seen
+	Metrics map[uint32]map[schema.Key]*AggMetric
 }
 
-// NewAggMetric creates a metric with given key, it retains the given number of chunks each chunkSpan seconds long
-// it optionally also creates aggregations with the given settings
-// the 0th retention is the native archive of this metric. if there's several others, we create aggregators, using agg.
-// it's the callers responsibility to make sure agg is not nil in that case!
-// If reorderWindow is greater than 0, a reorder buffer is enabled. In that case data points with duplicate timestamps
-// the behavior is defined by reorderAllowUpdate
-func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, retentions conf.Retentions, reorderWindow, interval uint32, agg *conf.Aggregation, reorderAllowUpdate, dropFirstChunk bool, ingestFrom int64) *AggMetric {
-
-	// note: during parsing of retentions, we assure there's at least 1.
-	ret := retentions.Rets[0]
-
-	m := AggMetric{
-		cachePusher:     cachePusher,
-		store:           store,
-		key:             key,
-		chunkSpan:       ret.ChunkSpan,
-		numChunks:       ret.NumChunks,
-		chunks:          make([]*chunk.Chunk, 0, ret.NumChunks),
-		dropFirstChunk:  dropFirstChunk,
-		futureTolerance: uint32(ret.MaxRetention()) * uint32(futureToleranceRatio) / 100,
-		ttl:             uint32(ret.MaxRetention()),
-		// we set LastWrite here to make sure a new Chunk doesn't get immediately
-		// garbage collected right after creating it, before we can push to it.
-		lastWrite: uint32(time.Now().Unix()),
-	}
-	if ingestFrom > 0 {
-		// we only want to ingest data that will go into chunks with a t0 >= 'ingestFrom'.
-		m.ingestFromT0 = AggBoundary(uint32(ingestFrom), ret.ChunkSpan)
-	}
-	if reorderWindow != 0 {
-		m.rob = NewReorderBuffer(reorderWindow, interval, reorderAllowUpdate)
+func NewAggMetrics(store Store, cachePusher cache.CachePusher, dropFirstChunk bool, ingestFrom map[uint32]int64, chunkMaxStale, metricMaxStale uint32, gcInterval time.Duration) *AggMetrics {
+	ms := AggMetrics{
+		store:          store,
+		cachePusher:    cachePusher,
+		dropFirstChunk: dropFirstChunk,
+		ingestFrom:     ingestFrom,
+		Metrics:        make(map[uint32]map[schema.Key]*AggMetric),
+		chunkMaxStale:  chunkMaxStale,
+		metricMaxStale: metricMaxStale,
+		gcInterval:     gcInterval,
 	}
 
-	origSplits := strings.Split(retentions.Orig, ":")
-	for i, ret := range retentions.Rets[1:] {
-		retOrig := origSplits[i+1]
-		m.aggregators = append(m.aggregators, NewAggregator(store, cachePusher, key, retOrig, ret, *agg, dropFirstChunk, ingestFrom))
+	// gcInterval = 0 can be useful in tests
+	if gcInterval > 0 {
+		go ms.GC()
 	}
-
-	return &m
+	return &ms
 }
 
-// Sync the saved state of a chunk by its T0.
-func (a *AggMetric) SyncChunkSaveState(ts uint32, sendPersist bool) ChunkSaveCallback {
-	return func() {
-		util.AtomicBumpUint32(&a.lastSaveStart, ts)
-
-		log.Debugf("AM: metric %s at chunk T0=%d has been saved.", a.key, ts)
-		if sendPersist {
-			SendPersistMessage(a.key.String(), ts)
-		}
-	}
-}
-
-// Sync the saved state of a chunk by its T0.
-func (a *AggMetric) SyncAggregatedChunkSaveState(ts uint32, consolidator consolidation.Consolidator, aggSpan uint32) {
-	// no lock needed cause aggregators don't change at runtime
-	for _, a := range a.aggregators {
-		if a.span == aggSpan {
-			switch consolidator {
-			case consolidation.None:
-				panic("cannot get an archive for no consolidation")
-			case consolidation.Avg:
-				panic("avg consolidator has no matching Archive(). you need sum and cnt")
-			case consolidation.Cnt:
-				if a.cntMetric != nil {
-					a.cntMetric.SyncChunkSaveState(ts, false)()
-				}
-				return
-			case consolidation.Min:
-				if a.minMetric != nil {
-					a.minMetric.SyncChunkSaveState(ts, false)()
-				}
-				return
-			case consolidation.Max:
-				if a.maxMetric != nil {
-					a.maxMetric.SyncChunkSaveState(ts, false)()
-				}
-				return
-			case consolidation.Sum:
-				if a.sumMetric != nil {
-					a.sumMetric.SyncChunkSaveState(ts, false)()
-				}
-				return
-			case consolidation.Lst:
-				if a.lstMetric != nil {
-					a.lstMetric.SyncChunkSaveState(ts, false)()
-				}
-				return
-			default:
-				panic(fmt.Sprintf("internal error: no such consolidator %q with span %d", consolidator, aggSpan))
-			}
-		}
-	}
-}
-
-func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSpan, from, to uint32) (Result, error) {
-	// no lock needed cause aggregators don't change at runtime
-	for _, a := range a.aggregators {
-		if a.span == aggSpan {
-			var agg *AggMetric
-			switch consolidator {
-			case consolidation.None:
-				err := errors.New("internal error: AggMetric.GetAggregated(): cannot get an archive for no consolidation")
-				log.Errorf("AM: %s", err.Error())
-				badConsolidator.Inc()
-				return Result{}, err
-			case consolidation.Avg:
-				err := errors.New("internal error: AggMetric.GetAggregated(): avg consolidator has no matching Archive(). you need sum and cnt")
-				log.Errorf("AM: %s", err.Error())
-				badConsolidator.Inc()
-				return Result{}, err
-			case consolidation.Cnt:
-				agg = a.cntMetric
-			case consolidation.Lst:
-				agg = a.lstMetric
-			case consolidation.Min:
-				agg = a.minMetric
-			case consolidation.Max:
-				agg = a.maxMetric
-			case consolidation.Sum:
-				agg = a.sumMetric
-			default:
-				err := fmt.Errorf("internal error: AggMetric.GetAggregated(): unknown consolidator %q", consolidator)
-				log.Errorf("AM: %s", err.Error())
-				badConsolidator.Inc()
-				return Result{}, err
-			}
-			if agg == nil {
-				return Result{}, fmt.Errorf("Consolidator %q not configured", consolidator)
-			}
-			return agg.Get(from, to)
-		}
-	}
-	err := fmt.Errorf("internal error: AggMetric.GetAggregated(): unknown aggSpan %d", aggSpan)
-	log.Errorf("AM: %s", err.Error())
-	badAggSpan.Inc()
-	return Result{}, err
-}
-
-// Get all data between the requested time ranges. From is inclusive, to is exclusive. from <= x < to
-// more data then what's requested may be included
-// specifically, returns:
-// * points from the ROB (if enabled)
-// * iters from matching chunks
-// * oldest point we have, so that if your query needs data before it, the caller knows when to query the store
-func (a *AggMetric) Get(from, to uint32) (Result, error) {
-	pre := time.Now()
-	log.Debugf("AM: %s Get(): %d - %d (%s - %s) span:%ds", a.key, from, to, TS(from), TS(to), to-from-1)
-	if from >= to {
-		return Result{}, ErrInvalidRange
-	}
-	a.RLock()
-	defer a.RUnlock()
-
-	result := Result{
-		Oldest: math.MaxInt32,
-	}
-
-	if a.rob != nil {
-		result.Points = a.rob.Get()
-		if len(result.Points) > 0 {
-			result.Oldest = result.Points[0].Ts
-			if result.Oldest <= from {
-				return result, nil
-			}
-		}
-	}
-
-	if len(a.chunks) == 0 {
-		// we dont have any data yet.
-		log.Debugf("AM: %s Get(): no data for requested range.", a.key)
-		return result, nil
-	}
-
-	newestChunk := a.chunks[a.currentChunkPos]
-
-	if from >= newestChunk.Series.T0+a.chunkSpan {
-		// request falls entirely ahead of the data we have
-		// this can happen in a few cases:
-		// * queries for the most recent data, but our ingestion has fallen behind.
-		//   we don't want such a degradation to cause a storm of cassandra queries
-		//   we should just return an oldest value that is <= from so we don't hit cassandra
-		//   but it doesn't have to be the real oldest value, so do whatever is cheap.
-		// * data got once written by another node, but has been re-sending (perhaps fixed)
-		//   to this node, but not yet up to the point it was previously sent. so we're
-		//   only aware of older data and not the newer data in cassandra. this is unlikely
-		//   and it's better to not serve this scenario well in favor of the above case.
-		//   seems like a fair tradeoff anyway that you have to refill all the way first.
-		log.Debugf("AM: %s Get(): no data for requested range.", a.key)
-		result.Oldest = from
-		return result, nil
-	}
-
-	// get the oldest chunk we have.
-	// eg if we have 5 chunks, N is the current chunk and n-4 is the oldest chunk.
-	// -----------------------------
-	// | n-4 | n-3 | n-2 | n-1 | n |  CurrentChunkPos = 4
-	// -----------------------------
-	// -----------------------------
-	// | n | n-4 | n-3 | n-2 | n-1 |  CurrentChunkPos = 0
-	// -----------------------------
-	// -----------------------------
-	// | n-2 | n-1 | n | n-4 | n-3 |  CurrentChunkPos = 2
-	// -----------------------------
-	oldestPos := a.currentChunkPos + 1
-	if oldestPos >= len(a.chunks) {
-		oldestPos = 0
-	}
-
-	oldestChunk := a.chunks[oldestPos]
-
-	if to <= oldestChunk.Series.T0 {
-		// the requested time range ends before any data we have.
-		log.Debugf("AM: %s Get(): no data for requested range", a.key)
-		if oldestChunk.First {
-			result.Oldest = a.firstTs
-		} else {
-			result.Oldest = oldestChunk.Series.T0
-		}
-		return result, nil
-	}
-
-	// Find the oldest Chunk that the "from" ts falls in.  If from extends before the oldest
-	// chunk, then we just use the oldest chunk.
-	for from >= oldestChunk.Series.T0+a.chunkSpan {
-		oldestPos++
-		if oldestPos >= len(a.chunks) {
-			oldestPos = 0
-		}
-		oldestChunk = a.chunks[oldestPos]
-	}
-
-	// find the newest Chunk that "to" falls in.  If "to" extends to after the newest data
-	// then just return the newest chunk.
-	// some examples to clarify this more. assume newestChunk.T0 is at 120, then
-	// for a to of 121 -> data up to (incl) 120 -> stay at this chunk, it has a point we need
-	// for a to of 120 -> data up to (incl) 119 -> use older chunk
-	// for a to of 119 -> data up to (incl) 118 -> use older chunk
-	newestPos := a.currentChunkPos
-	for to <= newestChunk.Series.T0 {
-		newestPos--
-		if newestPos < 0 {
-			newestPos += len(a.chunks)
-		}
-		newestChunk = a.chunks[newestPos]
-	}
-
-	// now just start at oldestPos and move through the Chunks circular Buffer to newestPos
+// periodically scan chunks and close any that have not received data in a while
+func (ms *AggMetrics) GC() {
 	for {
-		c := a.chunks[oldestPos]
-		result.Iters = append(result.Iters, c.Series.Iter())
+		var purged int
 
-		if oldestPos == newestPos {
-			break
+		unix := time.Duration(time.Now().UnixNano())
+		diff := ms.gcInterval - (unix % ms.gcInterval)
+		time.Sleep(diff + time.Minute)
+		log.Info("Aggmetrics: checking for stale chunks that need persisting.")
+		nowTime := time.Now()
+		now := uint32(nowTime.Unix())
+		chunkMinTs := now - uint32(ms.chunkMaxStale)
+		metricMinTs := now - uint32(ms.metricMaxStale)
+
+		// as this is the only goroutine that can delete from ms.Metrics
+		// we only need to lock long enough to get the list of orgs, then for each org
+		// get the list of active metrics.
+		// It doesn't matter if new orgs or metrics are added while we iterate these lists.
+		ms.RLock()
+		orgs := make([]uint32, 0, len(ms.Metrics))
+		for o := range ms.Metrics {
+			orgs = append(orgs, o)
 		}
-
-		oldestPos++
-		if oldestPos >= len(a.chunks) {
-			oldestPos = 0
-		}
-	}
-
-	if oldestChunk.First {
-		result.Oldest = a.firstTs
-	} else {
-		result.Oldest = oldestChunk.Series.T0
-	}
-
-	memToIterDuration.Value(time.Now().Sub(pre))
-	return result, nil
-}
-
-// caller must hold lock
-func (a *AggMetric) addAggregators(ts uint32, val float64) {
-	for _, agg := range a.aggregators {
-		if log.IsLevelEnabled(log.DebugLevel) {
-			log.Debugf("AM: %s pushing %d,%f to aggregator %d", a.key, ts, val, agg.span)
-		}
-		agg.Add(ts, val)
-	}
-}
-
-// pushToCache adds the chunk into the cache if it is hot
-// caller must hold lock
-func (a *AggMetric) pushToCache(c *chunk.Chunk) {
-	if a.cachePusher == nil {
-		return
-	}
-	// push into cache
-	intervalHint := a.key.Archive.Span()
-
-	itergen, err := chunk.NewIterGen(c.Series.T0, intervalHint, c.Encode(a.chunkSpan))
-	if err != nil {
-		log.Errorf("AM: %s failed to generate IterGen. this should never happen: %s", a.key, err)
-	}
-	go a.cachePusher.AddIfHot(a.key, 0, itergen)
-}
-
-// write a chunk to persistent storage.
-// never persist a chunk that may receive further updates!
-// (because the stores will read out chunk data on the unlocked chunk)
-// caller must hold lock.
-func (a *AggMetric) persist(pos int) {
-	chunk := a.chunks[pos]
-	pre := time.Now()
-
-	lastSaveStart := atomic.LoadUint32(&a.lastSaveStart)
-	if lastSaveStart >= chunk.Series.T0 {
-		// this can happen if
-		// a) there are 2 primary MT nodes both saving chunks to Cassandra
-		// b) a primary failed and this node was promoted to be primary but metric consuming is lagging.
-		// c) chunk was persisted by GC (stale) and then new data triggered another persist call
-		// d) dropFirstChunk is enabled and this is the first chunk
-		log.Debugf("AM: persist(): duplicate persist call for chunk.")
-		return
-	}
-
-	// create an array of chunks that need to be sent to the writeQueue.
-	pending := make([]*ChunkWriteRequest, 1)
-	// add the current chunk to the list of chunks to send to the writeQueue
-	cwr := NewChunkWriteRequest(
-		a.SyncChunkSaveState(chunk.Series.T0, true),
-		a.key,
-		a.ttl,
-		chunk.Series.T0,
-		chunk.Encode(a.chunkSpan),
-		time.Now(),
-	)
-	pending[0] = &cwr
-
-	// if we recently became the primary, there may be older chunks
-	// that the old primary did not save.  We should check for those
-	// and save them.
-	previousPos := pos - 1
-	if previousPos < 0 {
-		previousPos += len(a.chunks)
-	}
-	previousChunk := a.chunks[previousPos]
-	for (previousChunk.Series.T0 < chunk.Series.T0) && (lastSaveStart < previousChunk.Series.T0) {
-		log.Debugf("AM: persist(): old chunk needs saving. Adding %s:%d to writeQueue", a.key, previousChunk.Series.T0)
-		cwr := NewChunkWriteRequest(
-			a.SyncChunkSaveState(previousChunk.Series.T0, true),
-			a.key,
-			a.ttl,
-			previousChunk.Series.T0,
-			previousChunk.Encode(a.chunkSpan),
-			time.Now(),
-		)
-		pending = append(pending, &cwr)
-		previousPos--
-		if previousPos < 0 {
-			previousPos += len(a.chunks)
-		}
-		previousChunk = a.chunks[previousPos]
-	}
-
-	// Every chunk with a T0 <= this chunks' T0 is now either saved, or in the writeQueue.
-	util.AtomicBumpUint32(&a.lastSaveStart, chunk.Series.T0)
-
-	log.Debugf("AM: persist(): sending %d chunks to write queue", len(pending))
-
-	pendingChunk := len(pending) - 1
-
-	// if the store blocks,
-	// the calling function will block waiting for persist() to complete.
-	// This is intended to put backpressure on our message handlers so
-	// that they stop consuming messages, leaving them to buffer at
-	// the message bus. The "pending" array of chunks are processed
-	// last-to-first ensuring that older data is added to the store
-	// before newer data.
-	for pendingChunk >= 0 {
-		log.Debugf("AM: persist(): sealing chunk %d/%d (%s:%d) and adding to write queue.", pendingChunk, len(pending), a.key, chunk.Series.T0)
-		a.store.Add(pending[pendingChunk])
-		pendingChunk--
-	}
-	persistDuration.Value(time.Now().Sub(pre))
-	return
-}
-
-// don't ever call with a ts of 0, cause we use 0 to mean not initialized!
-func (a *AggMetric) Add(ts uint32, val float64) {
-	if ts < a.ingestFromT0 {
-		// TODO: add metric to keep track of the # of points discarded
-		if log.IsLevelEnabled(log.DebugLevel) {
-			log.Debugf("AM: discarding metric <%d,%f>: does not belong to a chunk starting after ingest-from. First chunk considered starts at %d", ts, val, a.ingestFromT0)
-		}
-		// even if a point is too old for our raw data, it may not be too old for aggregated data
-		// for example let's say a chunk starts at t0=3600 but we have 300-secondly aggregates
-		// that mean the aggregators need data from 3301 and onwards, because we aggregate 3301-3600 into a point with ts=3600
-		a.addAggregators(ts, val)
-		return
-	}
-
-	// need to check if ts > futureTolerance to prevent that we reject a datapoint
-	// because the ts value has wrapped around the uint32 boundary
-	if ts > a.futureTolerance && int64(ts-a.futureTolerance) > time.Now().Unix() {
-		sampleTooFarAhead.Inc()
-
-		if enforceFutureTolerance {
-			if log.IsLevelEnabled(log.DebugLevel) {
-				log.Debugf("AM: discarding metric <%d,%f>: timestamp is too far in the future, accepting timestamps up to %d seconds into the future", ts, val, a.futureTolerance)
+		ms.RUnlock()
+		for _, org := range orgs {
+			orgActiveMetrics := promActiveMetrics.WithLabelValues(strconv.Itoa(int(org)))
+			ms.RLock()
+			keys := make([]schema.Key, 0, len(ms.Metrics[org]))
+			for k := range ms.Metrics[org] {
+				keys = append(keys, k)
 			}
-
-			discardedSampleTooFarAhead.Inc()
-			PromDiscardedSamples.WithLabelValues(tooFarAhead, strconv.Itoa(int(a.key.MKey.Org))).Inc()
-			return
-		}
-	}
-
-	a.Lock()
-	defer a.Unlock()
-
-	if a.rob == nil {
-		// write directly
-		a.add(ts, val)
-	} else {
-		// write through reorder buffer
-		res, err := a.rob.Add(ts, val)
-
-		if err == nil {
-			if len(res) == 0 {
-				a.lastWrite = uint32(time.Now().Unix())
-			} else {
-				for _, p := range res {
-					a.add(p.Ts, p.Val)
+			ms.RUnlock()
+			for _, key := range keys {
+				gcMetric.Inc()
+				ms.RLock()
+				a := ms.Metrics[org][key]
+				ms.RUnlock()
+				points, stale := a.GC(now, chunkMinTs, metricMinTs)
+				if stale {
+					log.Debugf("metric %s is stale. Purging data from memory.", key)
+					ms.Lock()
+					purged++
+					delete(ms.Metrics[org], key)
+					orgActiveMetrics.Set(float64(len(ms.Metrics[org])))
+					// note: this is racey. if a metric has just become unstale, it may have created a new chunk,
+					// pruning an older one. in which case we double-subtract those points
+					// hard to fix and super rare. see https://github.com/grafana/metrictank/pull/1242
+					totalPoints.DecUint64(uint64(points))
+					ms.Unlock()
 				}
 			}
-		} else {
-			log.Debugf("AM: failed to add metric to reorder buffer for %s. %s", a.key, err)
-			a.discardedMetricsInc(err)
-		}
-	}
-}
+			ms.RLock()
+			orgActive := len(ms.Metrics[org])
+			ms.RUnlock()
+			orgActiveMetrics.Set(float64(orgActive))
 
-// don't ever call with a ts of 0, cause we use 0 to mean not initialized!
-// caller must hold write lock
-func (a *AggMetric) add(ts uint32, val float64) {
-	t0 := ts - (ts % a.chunkSpan)
-
-	if len(a.chunks) == 0 {
-		chunkCreate.Inc()
-		// no data has been added to this AggMetric yet.
-		// note that we may not be aware of prior data that belongs into this chunk
-		// so we should track this cutoff point
-		a.chunks = append(a.chunks, chunk.NewFirst(t0))
-		a.firstTs = ts
-
-		if err := a.chunks[0].Push(ts, val); err != nil {
-			panic(fmt.Sprintf("FATAL ERROR: this should never happen. Pushing initial value <%d,%f> to new chunk at pos 0 failed: %q", ts, val, err))
-		}
-		totalPoints.Inc()
-
-		log.Debugf("AM: %s Add(): created first chunk with first point: %v", a.key, a.chunks[0])
-		a.lastWrite = uint32(time.Now().Unix())
-		if a.dropFirstChunk {
-			util.AtomicBumpUint32(&a.lastSaveStart, t0)
-		}
-		a.addAggregators(ts, val)
-		return
-	}
-
-	currentChunk := a.chunks[a.currentChunkPos]
-
-	if t0 == currentChunk.Series.T0 {
-		// last prior data was in same chunk as new point
-		if currentChunk.Series.Finished {
-			// if we've already 'finished' the chunk, it means it has the end-of-stream marker and any new points behind it wouldn't be read by an iterator
-			// you should monitor this metric closely, it indicates that maybe your GC settings don't match how you actually send data (too late)
-			discardedReceivedTooLate.Inc()
-			PromDiscardedSamples.WithLabelValues(receivedTooLate, strconv.Itoa(int(a.key.MKey.Org))).Inc()
-			return
-		}
-
-		if err := currentChunk.Push(ts, val); err != nil {
-			log.Debugf("AM: failed to add metric to chunk for %s. %s", a.key, err)
-			a.discardedMetricsInc(err)
-			return
-		}
-		totalPoints.Inc()
-		a.lastWrite = uint32(time.Now().Unix())
-
-		if log.IsLevelEnabled(log.DebugLevel) {
-			log.Debugf("AM: %s Add(): pushed new value to last chunk: %v", a.key, a.chunks[0])
-		}
-	} else if t0 < currentChunk.Series.T0 {
-		log.Debugf("AM: Point at %d has t0 %d, goes back into previous chunk. CurrentChunk t0: %d, LastTs: %d", ts, t0, currentChunk.Series.T0, currentChunk.Series.T)
-		discardedSampleOutOfOrder.Inc()
-		PromDiscardedSamples.WithLabelValues(sampleOutOfOrder, strconv.Itoa(int(a.key.MKey.Org))).Inc()
-		return
-	} else {
-		// Data belongs in a new chunk.
-
-		// If it isn't finished already, add the end-of-stream marker and flag the chunk as "closed"
-		currentChunk.Finish()
-
-		a.pushToCache(currentChunk)
-		// If we are a primary node, then add the chunk to the write queue to be saved to Cassandra
-		if cluster.Manager.IsPrimary() {
-			log.Debugf("AM: persist(): node is primary, saving chunk. %s T0: %d", a.key, currentChunk.Series.T0)
-			// persist the chunk. If the writeQueue is full, then this will block.
-			a.persist(a.currentChunkPos)
-		}
-
-		a.currentChunkPos++
-		if a.currentChunkPos >= int(a.numChunks) {
-			a.currentChunkPos = 0
-		}
-
-		chunkCreate.Inc()
-		if len(a.chunks) < int(a.numChunks) {
-			a.chunks = append(a.chunks, chunk.New(t0))
-			if err := a.chunks[a.currentChunkPos].Push(ts, val); err != nil {
-				panic(fmt.Sprintf("FATAL ERROR: this should never happen. Pushing initial value <%d,%f> to new chunk at pos %d failed: %q", ts, val, a.currentChunkPos, err))
+			// If this org has no keys, then delete the org from the map
+			if orgActive == 0 {
+				// To prevent races, we need to check that there are still no metrics for the org while holding a write lock
+				ms.Lock()
+				orgActive = len(ms.Metrics[org])
+				if orgActive == 0 {
+					delete(ms.Metrics, org)
+				}
+				ms.Unlock()
 			}
-			totalPoints.Inc()
-			log.Debugf("AM: %s Add(): added new chunk to buffer. now %d chunks. and added the new point: %s", a.key, a.currentChunkPos+1, a.chunks[a.currentChunkPos])
-		} else {
-			chunkClear.Inc()
-			totalPoints.DecUint64(uint64(a.chunks[a.currentChunkPos].NumPoints))
-
-			a.chunks[a.currentChunkPos] = chunk.New(t0)
-			if err := a.chunks[a.currentChunkPos].Push(ts, val); err != nil {
-				panic(fmt.Sprintf("FATAL ERROR: this should never happen. Pushing initial value <%d,%f> to new chunk at pos %d failed: %q", ts, val, a.currentChunkPos, err))
-			}
-			totalPoints.Inc()
-			log.Debugf("AM: %s Add(): cleared chunk at %d of %d and replaced with new. and added the new point: %s", a.key, a.currentChunkPos, len(a.chunks), a.chunks[a.currentChunkPos])
-		}
-		a.lastWrite = uint32(time.Now().Unix())
-
-	}
-	a.addAggregators(ts, val)
-}
-
-// collectable returns whether the AggMetric is garbage collectable
-// an Aggmetric is collectable based on two conditions:
-// * the AggMetric hasn't been written to in a configurable amount of time
-//   (wether the write went to the ROB or a chunk is irrelevant)
-// * the last chunk - if any - is no longer "active".
-//   active means:
-//   any reasonable realtime stream (e.g. up to 15 min behind wall-clock)
-//   could add points to the chunk
-//
-// caller must hold lock
-func (a *AggMetric) collectable(now, chunkMinTs uint32) bool {
-
-	// no chunks at all means "possibly collectable"
-	// the caller (AggMetric.GC()) still has its own checks to
-	// handle the "no chunks" correctly later.
-	// also: we want AggMetric.GC() to go ahead with flushing the ROB in this case
-	if len(a.chunks) == 0 {
-		return a.lastWrite < chunkMinTs
-	}
-
-	currentChunk := a.chunks[a.currentChunkPos]
-	return a.lastWrite < chunkMinTs && currentChunk.Series.T0+a.chunkSpan+15*60 < now
-}
-
-// GC returns whether or not this AggMetric is stale and can be removed, and its pointcount if so
-// chunkMinTs -> min timestamp of a chunk before to be considered stale and to be persisted to Cassandra
-// metricMinTs -> min timestamp for a metric before to be considered stale and to be purged from the tank
-func (a *AggMetric) GC(now, chunkMinTs, metricMinTs uint32) (uint32, bool) {
-	a.Lock()
-	defer a.Unlock()
-
-	// unless it looks like the AggMetric is collectable, abort and mark as not stale
-	if !a.collectable(now, chunkMinTs) {
-		return 0, false
-	}
-
-	// make sure any points in the reorderBuffer are moved into our chunks so we can save the data
-	if a.rob != nil {
-		tmpLastWrite := a.lastWrite
-		pts := a.rob.Flush()
-		for _, p := range pts {
-			a.add(p.Ts, p.Val)
 		}
 
-		// adding points will cause our lastWrite to be updated, but we want to keep the old value
-		a.lastWrite = tmpLastWrite
-	}
-
-	// this aggMetric has never had metrics written to it.
-	if len(a.chunks) == 0 {
-		return a.gcAggregators(now, chunkMinTs, metricMinTs)
-	}
-
-	currentChunk := a.chunks[a.currentChunkPos]
-
-	// we must check collectable again. Imagine this scenario:
-	// * we didn't have any chunks when calling collectable() the first time so it returned true
-	// * data from the ROB is flushed and moved into a new chunk
-	// * this new chunk is active so we're not collectable, even though earlier we thought we were.
-	if !a.collectable(now, chunkMinTs) {
-		return 0, false
-	}
-
-	if !currentChunk.Series.Finished {
-		// chunk hasn't been written to in a while, and is not yet closed.
-		// Let's close it and persist it if we are a primary
-		log.Debugf("AM: Found stale Chunk, adding end-of-stream bytes. key: %v T0: %d", a.key, currentChunk.Series.T0)
-		currentChunk.Finish()
-		a.pushToCache(currentChunk)
-		if cluster.Manager.IsPrimary() {
-			log.Debugf("AM: persist(): node is primary, saving chunk. %v T0: %d", a.key, currentChunk.Series.T0)
-			// persist the chunk. If the writeQueue is full, then this will block.
-			a.persist(a.currentChunkPos)
+		// Get the totalActive across all orgs.
+		totalActive := 0
+		ms.RLock()
+		for o := range ms.Metrics {
+			totalActive += len(ms.Metrics[o])
 		}
-	}
+		ms.RUnlock()
+		metricsActive.Set(totalActive)
 
-	var points uint32
-	for _, chunk := range a.chunks {
-		points += chunk.NumPoints
+		log.Infof("Aggmetrics: finished GC %s. number of purged (deleted) metrics from tank: %d", time.Since(nowTime), purged)
 	}
-	p, stale := a.gcAggregators(now, chunkMinTs, metricMinTs)
-	points += p
-	return points, stale && a.lastWrite < metricMinTs
 }
 
-// gcAggregators returns whether all aggregators are stale and can be removed, and their pointcount if so
-func (a *AggMetric) gcAggregators(now, chunkMinTs, metricMinTs uint32) (uint32, bool) {
-	var points uint32
-	stale := true
-	for _, agg := range a.aggregators {
-		p, s := agg.GC(now, chunkMinTs, metricMinTs, a.lastWrite)
-		points += p
-		stale = stale && s
+func (ms *AggMetrics) Get(key schema.MKey) (Metric, bool) {
+	var m *AggMetric
+	ms.RLock()
+	_, ok := ms.Metrics[key.Org]
+	if ok {
+		m, ok = ms.Metrics[key.Org][key.Key]
 	}
-	return points, stale
+	ms.RUnlock()
+	return m, ok
 }
 
-func (a *AggMetric) discardedMetricsInc(err error) {
-	var reason string
-	switch err {
-	case mdataerrors.ErrMetricTooOld:
-		reason = sampleOutOfOrder
-		discardedSampleOutOfOrder.Inc()
-	case mdataerrors.ErrMetricNewValueForTimestamp:
-		reason = newValueForTimestamp
-		discardedNewValueForTimestamp.Inc()
-	default:
-		discardedUnknown.Inc()
-		reason = "unknown"
+func (ms *AggMetrics) GetOrCreate(key schema.MKey, schemaId, aggId uint16, interval uint32) Metric {
+	var m *AggMetric
+	// in the most common case, it's already there and an Rlock is all we need
+	ms.RLock()
+	_, ok := ms.Metrics[key.Org]
+	if ok {
+		m, ok = ms.Metrics[key.Org][key.Key]
 	}
-	PromDiscardedSamples.WithLabelValues(reason, strconv.Itoa(int(a.key.MKey.Org))).Inc()
+	ms.RUnlock()
+	if ok {
+		return m
+	}
+
+	k := schema.AMKey{
+		MKey: key,
+	}
+
+	agg := Aggregations.Get(aggId)
+	confSchema := Schemas.Get(schemaId)
+
+	// if it wasn't there, get the write lock and prepare to add it
+	// but first we need to check again if someone has added it in
+	// the meantime (quite rare, but anyway)
+	ms.Lock()
+	if _, ok := ms.Metrics[key.Org]; !ok {
+		ms.Metrics[key.Org] = make(map[schema.Key]*AggMetric)
+	}
+	m, ok = ms.Metrics[key.Org][key.Key]
+	if ok {
+		ms.Unlock()
+		return m
+	}
+	ingestFrom := ms.ingestFrom[key.Org]
+	m = NewAggMetric(ms.store, ms.cachePusher, k, confSchema.Retentions, confSchema.ReorderWindow, interval, &agg, confSchema.ReorderAllowUpdate, ms.dropFirstChunk, ingestFrom)
+	ms.Metrics[key.Org][key.Key] = m
+	active := len(ms.Metrics[key.Org])
+	ms.Unlock()
+	metricsActive.Inc()
+	promActiveMetrics.WithLabelValues(strconv.Itoa(int(key.Org))).Set(float64(active))
+	return m
 }

--- a/mdata/aggregation.go
+++ b/mdata/aggregation.go
@@ -1,6 +1,12 @@
 package mdata
 
-import "math"
+import (
+	"fmt"
+	"math"
+
+	"github.com/grafana/metrictank/consolidation"
+	log "github.com/sirupsen/logrus"
+)
 
 // Aggregation is a container for all summary statistics / aggregated data for 1 metric, in 1 time frame
 // if the Cnt is 0, the numbers don't necessarily make sense.
@@ -17,6 +23,24 @@ func NewAggregation() *Aggregation {
 		Min: math.MaxFloat64,
 		Max: -math.MaxFloat64,
 	}
+}
+
+func (a *Aggregation) GetValueFor(consolidator consolidation.Consolidator) (float64, error) {
+	switch consolidator {
+	case consolidation.Cnt:
+		return a.Cnt, nil
+	case consolidation.Lst:
+		return a.Lst, nil
+	case consolidation.Min:
+		return a.Min, nil
+	case consolidation.Max:
+		return a.Max, nil
+	case consolidation.Sum:
+		return a.Sum, nil
+	}
+	err := fmt.Errorf("internal error: AggMetric.GetAggregated(): unknown consolidator %q", consolidator)
+	log.Errorf("AM: %s", err.Error())
+	return 0, err
 }
 
 func (a *Aggregation) Add(val float64) {

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -125,7 +125,7 @@ func (agg *Aggregator) Foresee(consolidator consolidation.Consolidator, from, to
 		}
 		aggregationPreview.Add(point.Val)
 	}
-	if aggregationPreview.Cnt != 0 && currentBoundary <= to {
+	if aggregationPreview.Cnt != 0 && currentBoundary < to {
 		value, _ := aggregationPreview.GetValueFor(consolidator)
 		aggregatedPoints = append(aggregatedPoints, schema.Point{Val: value, Ts: currentBoundary})
 	}

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -2,6 +2,7 @@ package mdata
 
 import (
 	"github.com/grafana/metrictank/conf"
+	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/mdata/cache"
 	"github.com/grafana/metrictank/schema"
 )
@@ -97,6 +98,38 @@ func (agg *Aggregator) flush() {
 	}
 	//msg := fmt.Sprintf("flushed cnt %v sum %f min %f max %f, reset the block", agg.agg.cnt, agg.agg.sum, agg.agg.min, agg.agg.max)
 	agg.agg.Reset()
+}
+
+// Foresee duplicates the underlying Aggregation,
+// consumes points in the future, and return the newly aggregated points.
+// Foresee won't actually add those points to AggMetric.
+func (agg *Aggregator) Foresee(consolidator consolidation.Consolidator, from, to uint32, futurePoints []schema.Point) []schema.Point {
+	aggregationPreview := *(agg.agg)
+	var aggregatedPoints []schema.Point
+	currentBoundary := agg.currentBoundary
+	for _, point := range futurePoints {
+		boundary := AggBoundary(point.Ts, agg.span)
+		if boundary < currentBoundary {
+			// ignore the point it was for a previous bucket. we can't process it
+			continue
+		} else if boundary > currentBoundary {
+			// point is for a more recent bucket
+			// store current aggregates as a new point in their series and start the new bucket
+			// if the cnt is still 0, the numbers are invalid, not to be flushed and we can simply reuse the aggregation
+			if aggregationPreview.Cnt != 0 {
+				value, _ := aggregationPreview.GetValueFor(consolidator)
+				aggregatedPoints = append(aggregatedPoints, schema.Point{Val: value, Ts: currentBoundary})
+				aggregationPreview.Reset()
+			}
+			currentBoundary = boundary
+		}
+		aggregationPreview.Add(point.Val)
+	}
+	if aggregationPreview.Cnt != 0 && currentBoundary <= to {
+		value, _ := aggregationPreview.GetValueFor(consolidator)
+		aggregatedPoints = append(aggregatedPoints, schema.Point{Val: value, Ts: currentBoundary})
+	}
+	return aggregatedPoints
 }
 
 // Add adds the point to the in-progress aggregation, and flushes it if we reached the boundary

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/conf"
+	"github.com/grafana/metrictank/consolidation"
 	"github.com/grafana/metrictank/mdata/cache"
 	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
@@ -43,7 +44,20 @@ func TestAggBoundary(t *testing.T) {
 // note that values don't get "committed" to the metric until the aggregation interval is complete
 func TestAggregator(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
-	compare := func(key string, metric Metric, expected []schema.Point) {
+
+	comparePoints := func(key string, got []schema.Point, expected []schema.Point) {
+		if len(got) != len(expected) {
+			t.Fatalf("output for testcase %s mismatch: expected: %v points, got: %v", key, len(expected), len(got))
+		}
+		for i, g := range got {
+			exp := expected[i]
+			if exp.Val != g.Val || exp.Ts != g.Ts {
+				t.Fatalf("output for testcase %s mismatch at point %d: expected: %v, got: %v", key, i, exp, g)
+			}
+		}
+	}
+
+	getFromMetricAndCompare := func(key string, metric Metric, expected []schema.Point) {
 		cluster.Manager.SetPrimary(true)
 		res, err := metric.Get(0, 1000)
 
@@ -58,19 +72,10 @@ func TestAggregator(t *testing.T) {
 				got = append(got, schema.Point{Val: val, Ts: ts})
 			}
 		}
-		if len(got) != len(expected) {
-			t.Fatalf("output for testcase %s mismatch: expected: %v points, got: %v", key, len(expected), len(got))
-
-		} else {
-			for i, g := range got {
-				exp := expected[i]
-				if exp.Val != g.Val || exp.Ts != g.Ts {
-					t.Fatalf("output for testcase %s mismatch at point %d: expected: %v, got: %v", key, i, exp, g)
-				}
-			}
-		}
+		comparePoints(key, got, expected)
 		cluster.Manager.SetPrimary(false)
 	}
+
 	ret := conf.NewRetentionMT(60, 86400, 120, 10, 0)
 	aggs := conf.Aggregation{
 		AggregationMethod: []conf.Method{conf.Avg, conf.Min, conf.Max, conf.Sum, conf.Lst},
@@ -80,7 +85,7 @@ func TestAggregator(t *testing.T) {
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	expected := []schema.Point{}
-	compare("simple-min-unfinished", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-unfinished", agg.minMetric, expected)
 
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
@@ -89,7 +94,7 @@ func TestAggregator(t *testing.T) {
 	expected = []schema.Point{
 		{Val: 5, Ts: 120},
 	}
-	compare("simple-min-one-block", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-one-block", agg.minMetric, expected)
 
 	// points with a timestamp belonging to the previous aggregation are ignored
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 0)
@@ -100,7 +105,7 @@ func TestAggregator(t *testing.T) {
 	expected = []schema.Point{
 		{Val: 5, Ts: 120},
 	}
-	compare("simple-min-ignore-back-in-time", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-ignore-back-in-time", agg.minMetric, expected)
 
 	// chunkspan is 120, ingestFrom = 140 means points before chunk starting at 240 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 140)
@@ -110,7 +115,7 @@ func TestAggregator(t *testing.T) {
 	// crossing the aggregation boundary is added (aggregation span here is 60)
 	agg.Add(130, 130)
 	expected = []schema.Point{}
-	compare("simple-min-ingest-from-all-before-next-chunk", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-ingest-from-all-before-next-chunk", agg.minMetric, expected)
 
 	// chunkspan is 120, ingestFrom = 115 means points before chunk starting at 120 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 115)
@@ -121,7 +126,7 @@ func TestAggregator(t *testing.T) {
 	expected = []schema.Point{
 		{Val: 5, Ts: 120},
 	}
-	compare("simple-min-ingest-from-one-in-next-chunk", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-ingest-from-one-in-next-chunk", agg.minMetric, expected)
 
 	// chunkspan is 120, ingestFrom = 120 means points before chunk starting at 120 are discarded
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 120)
@@ -132,7 +137,7 @@ func TestAggregator(t *testing.T) {
 	expected = []schema.Point{
 		{Val: 5, Ts: 120},
 	}
-	compare("simple-min-ingest-from-on-chunk-boundary", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-ingest-from-on-chunk-boundary", agg.minMetric, expected)
 
 	// chunkspan is 120, ingestFrom = 170 means points before chunk starting at 240 are discarded
 	// but, each aggregation contains 60s of data, so the point at 240 covers raw data from 181..240
@@ -169,7 +174,7 @@ func TestAggregator(t *testing.T) {
 		{Val: 181 + 220 + 230 + 231 + 233 + 239 + 240, Ts: 240},
 		{Val: 245 + 249 + 250 + 299 + 300, Ts: 300},
 	}
-	compare("multi-sum-ingest-from-one-in-next-chunk", agg.sumMetric, expected)
+	getFromMetricAndCompare("multi-sum-ingest-from-one-in-next-chunk", agg.sumMetric, expected)
 
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(2), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
@@ -178,7 +183,7 @@ func TestAggregator(t *testing.T) {
 	expected = []schema.Point{
 		{Val: 4, Ts: 120},
 	}
-	compare("simple-min-one-block-done-cause-last-point-just-right", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-one-block-done-cause-last-point-just-right", agg.minMetric, expected)
 
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(3), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
@@ -189,7 +194,7 @@ func TestAggregator(t *testing.T) {
 		{Val: 5, Ts: 120},
 		{Val: 1, Ts: 180},
 	}
-	compare("simple-min-two-blocks-done-cause-last-point-just-right", agg.minMetric, expected)
+	getFromMetricAndCompare("simple-min-two-blocks-done-cause-last-point-just-right", agg.minMetric, expected)
 
 	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(4), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
@@ -198,25 +203,99 @@ func TestAggregator(t *testing.T) {
 	agg.Add(200, 1451.123)
 	agg.Add(220, 978894.445)
 	agg.Add(250, 1)
-	compare("simple-min-skip-a-block", agg.minMetric, []schema.Point{
+	getFromMetricAndCompare("simple-min-skip-a-block", agg.minMetric, []schema.Point{
 		{Val: 5, Ts: 120},
 		{Val: 1451.123, Ts: 240},
 	})
-	compare("simple-max-skip-a-block", agg.maxMetric, []schema.Point{
+	getFromMetricAndCompare("simple-max-skip-a-block", agg.maxMetric, []schema.Point{
 		{Val: 123.4, Ts: 120},
 		{Val: 978894.445, Ts: 240},
 	})
-	compare("simple-cnt-skip-a-block", agg.cntMetric, []schema.Point{
+	getFromMetricAndCompare("simple-cnt-skip-a-block", agg.cntMetric, []schema.Point{
 		{Val: 2, Ts: 120},
 		{Val: 3, Ts: 240},
 	})
-	compare("simple-lst-skip-a-block", agg.lstMetric, []schema.Point{
+	getFromMetricAndCompare("simple-lst-skip-a-block", agg.lstMetric, []schema.Point{
 		{Val: 5, Ts: 120},
 		{Val: 978894.445, Ts: 240},
 	})
-	compare("simple-sum-skip-a-block", agg.sumMetric, []schema.Point{
+	getFromMetricAndCompare("simple-sum-skip-a-block", agg.sumMetric, []schema.Point{
 		{Val: 128.4, Ts: 120},
 		{Val: 2451.123 + 1451.123 + 978894.445, Ts: 240},
 	})
 
+	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(4), ret.String(), ret, aggs, false, 0)
+	agg.Add(100, 123.4)
+	agg.Add(110, 5)
+	agg.Add(190, 2451.123)
+	agg.Add(200, 1451.123)
+	agg.Add(220, 978894.445)
+	agg.Add(250, 1)
+	futurePoints := []schema.Point{
+		{Val: 7, Ts: 260},
+		{Val: 2, Ts: 270},
+		{Val: 4, Ts: 310},
+	}
+	comparePoints(
+		"simple-min-foresee",
+		agg.Foresee(consolidation.Min, 0, 1000, futurePoints),
+		[]schema.Point{
+			{Val: 1, Ts: 300},
+			{Val: 4, Ts: 360},
+		},
+	)
+	comparePoints(
+		"simple-max-foresee",
+		agg.Foresee(consolidation.Max, 0, 1000, futurePoints),
+		[]schema.Point{
+			{Val: 7, Ts: 300},
+			{Val: 4, Ts: 360},
+		},
+	)
+	// Ts:360 should not be returned given span (0, 359)
+	comparePoints(
+		"simple-cnt-foresee",
+		agg.Foresee(consolidation.Cnt, 0, 359, futurePoints),
+		[]schema.Point{
+			{Val: 3, Ts: 300},
+		},
+	)
+	comparePoints(
+		"simple-lst-foresee",
+		agg.Foresee(consolidation.Lst, 0, 1000, futurePoints),
+		[]schema.Point{
+			{Val: 2, Ts: 300},
+			{Val: 4, Ts: 360},
+		},
+	)
+	comparePoints(
+		"simple-sum-foresee",
+		agg.Foresee(consolidation.Sum, 0, 1000, futurePoints),
+		[]schema.Point{
+			{Val: 10, Ts: 300},
+			{Val: 4, Ts: 360},
+		},
+	)
+
+	// Foresee should not change the actual state of aggregator
+	getFromMetricAndCompare("simple-min-skip-a-block", agg.minMetric, []schema.Point{
+		{Val: 5, Ts: 120},
+		{Val: 1451.123, Ts: 240},
+	})
+	getFromMetricAndCompare("simple-max-skip-a-block", agg.maxMetric, []schema.Point{
+		{Val: 123.4, Ts: 120},
+		{Val: 978894.445, Ts: 240},
+	})
+	getFromMetricAndCompare("simple-cnt-skip-a-block", agg.cntMetric, []schema.Point{
+		{Val: 2, Ts: 120},
+		{Val: 3, Ts: 240},
+	})
+	getFromMetricAndCompare("simple-lst-skip-a-block", agg.lstMetric, []schema.Point{
+		{Val: 5, Ts: 120},
+		{Val: 978894.445, Ts: 240},
+	})
+	getFromMetricAndCompare("simple-sum-skip-a-block", agg.sumMetric, []schema.Point{
+		{Val: 128.4, Ts: 120},
+		{Val: 2451.123 + 1451.123 + 978894.445, Ts: 240},
+	})
 }


### PR DESCRIPTION
Fix for issue https://github.com/grafana/metrictank/issues/1485

**Describe your changes**
The rollup aggregators only get the points once they leave the ROB.
This PR fixs aggregator so when being queried it will return the current value (considering points in ROB) but will not actually consume the points in ROB.

**Testing performed**
* Add some unit tests for it and pass it.
* Integrate test by comparing raw data and rollup data queried at the same time

![mt-fix](https://user-images.githubusercontent.com/92168069/138118258-9e53e908-7b42-4ba7-85bd-fb8400a1e530.png)

