### PR TITLE
Add support for removeZeroSeries function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
     working_directory: /home/circleci/.go_workspace/src/github.com/grafana/metrictank
     machine:
       image: ubuntu-2204:2022.04.2
+
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
     working_directory: /home/circleci/.go_workspace/src/github.com/grafana/metrictank
     machine:
       image: ubuntu-2204:2022.04.2
-
     steps:
       - checkout
       - attach_workspace:

--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -154,6 +154,7 @@ See also:
 | removeBelowValue(seriesList, n) seriesList                     |              | Stable     |
 | removeBetweenPercentile                                        |              | No         |
 | removeEmptySeries                                              |              | Stable     |
+| removeZeroSeries                                               |              | Stable     |
 | round                                                          |              | Stable     |
 | scale(seriesList, num) series                                  |              | Stable     |
 | scaleToSeconds(seriesList, seconds) seriesList                 |              | Stable     |

--- a/expr/data_test.go
+++ b/expr/data_test.go
@@ -80,6 +80,24 @@ var allZeros = []schema.Point{
 	{Val: 0, Ts: 60},
 }
 
+var halfZeros = []schema.Point{
+	{Val: 0, Ts: 10},
+	{Val: 0, Ts: 20},
+	{Val: 0, Ts: 30},
+	{Val: 1, Ts: 40},
+	{Val: 2, Ts: 50},
+	{Val: 3, Ts: 60},
+}
+
+var noZeros = []schema.Point{
+	{Val: 1, Ts: 10},
+	{Val: 2, Ts: 20},
+	{Val: 3, Ts: 30},
+	{Val: 4, Ts: 40},
+	{Val: 5, Ts: 50},
+	{Val: 6, Ts: 60},
+}
+
 var allNulls = []schema.Point{
 	{Val: math.NaN(), Ts: 10},
 	{Val: math.NaN(), Ts: 20},

--- a/expr/func_removezeroseries.go
+++ b/expr/func_removezeroseries.go
@@ -1,0 +1,58 @@
+package expr
+
+import (
+	"math"
+
+	"github.com/grafana/metrictank/api/models"
+)
+
+type FuncRemoveZeroSeries struct {
+	in           GraphiteFunc
+	xFilesFactor float64
+}
+
+func NewRemoveZeroSeries() GraphiteFunc {
+	return &FuncRemoveZeroSeries{xFilesFactor: 0}
+}
+
+func (s *FuncRemoveZeroSeries) Signature() ([]Arg, []Arg) {
+
+	return []Arg{
+			ArgSeriesList{val: &s.in},
+			ArgFloat{key: "xFilesFactor", val: &s.xFilesFactor, opt: true, validator: []Validator{WithinZeroOneInclusiveInterval}},
+		}, []Arg{
+			ArgSeriesList{},
+		}
+}
+
+func (s *FuncRemoveZeroSeries) Context(context Context) Context {
+	return context
+}
+
+func (s *FuncRemoveZeroSeries) Exec(dataMap DataMap) ([]models.Series, error) {
+	series, err := s.in.Exec(dataMap)
+	if err != nil {
+		return nil, err
+	}
+
+	if math.IsNaN(s.xFilesFactor) {
+		s.xFilesFactor = 0.0
+	}
+
+	var output []models.Series
+
+	for _, serie := range series {
+		nonNull := 0.0
+
+		for _, p := range serie.Datapoints {
+			if p.Val != 0 {
+				nonNull++
+			}
+		}
+		if nonNull != 0 && nonNull/float64(len(serie.Datapoints)) >= s.xFilesFactor {
+			output = append(output, serie)
+		}
+	}
+
+	return output, nil
+}

--- a/expr/func_removezeroseries.go
+++ b/expr/func_removezeroseries.go
@@ -16,7 +16,6 @@ func NewRemoveZeroSeries() GraphiteFunc {
 }
 
 func (s *FuncRemoveZeroSeries) Signature() ([]Arg, []Arg) {
-
 	return []Arg{
 			ArgSeriesList{val: &s.in},
 			ArgFloat{key: "xFilesFactor", val: &s.xFilesFactor, opt: true, validator: []Validator{WithinZeroOneInclusiveInterval}},

--- a/expr/func_removezeroseries_test.go
+++ b/expr/func_removezeroseries_test.go
@@ -42,11 +42,12 @@ func TestRemoveZeroSeriesAllow30PercentNulls(t *testing.T) {
 		[]models.Series{
 			getSeries("a", "30% zeros", a),
 			getSeries("b", "half zeros", halfZeros),
-			getSeries("c", "no nulls", noZeros),
+			getSeries("c", "no zeros", noZeros),
 			getSeries("d", "all zeros", allZeros),
 		},
 		[]models.Series{
 			getSeries("a", "30% zeros", a),
+			getSeries("b", "half zeros", halfZeros),
 			getSeries("c", "no zeros", noZeros),
 		},
 		t,
@@ -95,6 +96,7 @@ func testRemoveZeroSeries(xff float64, in []models.Series, out []models.Series, 
 	dataMap := initDataMap(in)
 
 	got, err := f.Exec(dataMap)
+
 	if err := equalOutput(out, got, nil, err); err != nil {
 		t.Fatal(err)
 	}

--- a/expr/func_removezeroseries_test.go
+++ b/expr/func_removezeroseries_test.go
@@ -15,12 +15,12 @@ func TestRemoveZeroSeriesIfAtLeastOneNonNull(t *testing.T) {
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
 			getSeries("d", "allZeros", allZeros),
-			getSeries("e", "empty series", []schema.Point{})
+			getSeries("e", "empty series", []schema.Point{}),
 		},
 		[]models.Series{
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
-			getSeries("d", "noZeros", noZeros)
+			getSeries("d", "noZeros", noZeros),
 		},
 		t,
 	)
@@ -83,13 +83,8 @@ func TestRemoveZeroSeriesMissingInputXFilesFactor(t *testing.T) {
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
 			getSeries("d", "allZeros", allZeros),
-<<<<<<< HEAD
 			getSeries("d", "noZeros", noZeros),
 			getSeries("e", "empty series", []schema.Point{}),
-||||||| parent of 74d1b274 (Update styling and add more tests with no zeroes in data)
-=======
-			getSeries("d", "noZeros", noZeros)
->>>>>>> 74d1b274 (Update styling and add more tests with no zeroes in data)
 		},
 		[]models.Series{
 			getSeries("a", "some zeros", a),

--- a/expr/func_removezeroseries_test.go
+++ b/expr/func_removezeroseries_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/metrictank/api/models"
+	"github.com/grafana/metrictank/schema"
 )
 
 func TestRemoveZeroSeriesIfAtLeastOneNonNull(t *testing.T) {
@@ -14,10 +15,12 @@ func TestRemoveZeroSeriesIfAtLeastOneNonNull(t *testing.T) {
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
 			getSeries("d", "allZeros", allZeros),
+			getSeries("e", "empty series", []schema.Point{})
 		},
 		[]models.Series{
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
+			getSeries("d", "noZeros", noZeros)
 		},
 		t,
 	)
@@ -28,6 +31,7 @@ func TestRemoveZeroSeriesAllowNoNulls(t *testing.T) {
 		1.0, // xFilesFactor
 		[]models.Series{
 			getSeries("c", "no zeros", noZeros),
+			getSeries("e", "empty series", []schema.Point{}),
 		},
 		[]models.Series{
 			getSeries("c", "no zeros", noZeros),
@@ -44,6 +48,7 @@ func TestRemoveZeroSeriesAllow30PercentNulls(t *testing.T) {
 			getSeries("b", "half zeros", halfZeros),
 			getSeries("c", "no zeros", noZeros),
 			getSeries("d", "all zeros", allZeros),
+			getSeries("e", "empty series", []schema.Point{}),
 		},
 		[]models.Series{
 			getSeries("a", "30% zeros", a),
@@ -62,6 +67,7 @@ func TestRemoveZeroSeriesAllow70PercentNulls(t *testing.T) {
 			getSeries("b", "half zeros", halfZeros),
 			getSeries("c", "no zeros", noZeros),
 			getSeries("d", "all zeros", allZeros),
+			getSeries("e", "empty series", []schema.Point{}),
 		},
 		[]models.Series{
 			getSeries("c", "no zeros", noZeros),
@@ -77,10 +83,18 @@ func TestRemoveZeroSeriesMissingInputXFilesFactor(t *testing.T) {
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
 			getSeries("d", "allZeros", allZeros),
+<<<<<<< HEAD
+			getSeries("d", "noZeros", noZeros),
+			getSeries("e", "empty series", []schema.Point{}),
+||||||| parent of 74d1b274 (Update styling and add more tests with no zeroes in data)
+=======
+			getSeries("d", "noZeros", noZeros)
+>>>>>>> 74d1b274 (Update styling and add more tests with no zeroes in data)
 		},
 		[]models.Series{
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
+			getSeries("d", "noZeros", noZeros),
 		},
 		t,
 	)
@@ -92,21 +106,17 @@ func testRemoveZeroSeries(xff float64, in []models.Series, out []models.Series, 
 	f.(*FuncRemoveZeroSeries).xFilesFactor = xff
 
 	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
-
 	dataMap := initDataMap(in)
-
 	got, err := f.Exec(dataMap)
 
 	if err := equalOutput(out, got, nil, err); err != nil {
 		t.Fatal(err)
 	}
-
 	t.Run("DidNotModifyInput", func(t *testing.T) {
 		if err := equalOutput(inputCopy, in, nil, nil); err != nil {
 			t.Fatalf("Input was modified, err = %s", err)
 		}
 	})
-
 	t.Run("DoesNotDoubleReturnPoints", func(t *testing.T) {
 		if err := dataMap.CheckForOverlappingPoints(); err != nil {
 			t.Fatalf("Point slices in datamap overlap, err = %s", err)

--- a/expr/func_removezeroseries_test.go
+++ b/expr/func_removezeroseries_test.go
@@ -15,6 +15,7 @@ func TestRemoveZeroSeriesIfAtLeastOneNonNull(t *testing.T) {
 			getSeries("a", "some zeros", a),
 			getSeries("b", "half zeros", halfZeros),
 			getSeries("d", "allZeros", allZeros),
+			getSeries("d", "noZeros", noZeros),
 			getSeries("e", "empty series", []schema.Point{}),
 		},
 		[]models.Series{

--- a/expr/func_removezeroseries_test.go
+++ b/expr/func_removezeroseries_test.go
@@ -1,0 +1,113 @@
+package expr
+
+import (
+	"math"
+	"testing"
+
+	"github.com/grafana/metrictank/api/models"
+)
+
+func TestRemoveZeroSeriesIfAtLeastOneNonNull(t *testing.T) {
+	testRemoveZeroSeries(
+		0.0, // xFilesFactor
+		[]models.Series{
+			getSeries("a", "some zeros", a),
+			getSeries("b", "half zeros", halfZeros),
+			getSeries("d", "allZeros", allZeros),
+		},
+		[]models.Series{
+			getSeries("a", "some zeros", a),
+			getSeries("b", "half zeros", halfZeros),
+		},
+		t,
+	)
+}
+
+func TestRemoveZeroSeriesAllowNoNulls(t *testing.T) {
+	testRemoveZeroSeries(
+		1.0, // xFilesFactor
+		[]models.Series{
+			getSeries("c", "no zeros", noZeros),
+		},
+		[]models.Series{
+			getSeries("c", "no zeros", noZeros),
+		},
+		t,
+	)
+}
+
+func TestRemoveZeroSeriesAllow30PercentNulls(t *testing.T) {
+	testRemoveZeroSeries(
+		0.3, // xFilesFactor
+		[]models.Series{
+			getSeries("a", "30% zeros", a),
+			getSeries("b", "half zeros", halfZeros),
+			getSeries("c", "no nulls", noZeros),
+			getSeries("d", "all zeros", allZeros),
+		},
+		[]models.Series{
+			getSeries("a", "30% zeros", a),
+			getSeries("c", "no zeros", noZeros),
+		},
+		t,
+	)
+}
+
+func TestRemoveZeroSeriesAllow70PercentNulls(t *testing.T) {
+	testRemoveZeroSeries(
+		0.7, // xFilesFactor
+		[]models.Series{
+			getSeries("a", "30% zeros", a),
+			getSeries("b", "half zeros", halfZeros),
+			getSeries("c", "no zeros", noZeros),
+			getSeries("d", "all zeros", allZeros),
+		},
+		[]models.Series{
+			getSeries("c", "no zeros", noZeros),
+		},
+		t,
+	)
+}
+
+func TestRemoveZeroSeriesMissingInputXFilesFactor(t *testing.T) {
+	testRemoveZeroSeries(
+		math.NaN(), // xFilesFactor
+		[]models.Series{
+			getSeries("a", "some zeros", a),
+			getSeries("b", "half zeros", halfZeros),
+			getSeries("d", "allZeros", allZeros),
+		},
+		[]models.Series{
+			getSeries("a", "some zeros", a),
+			getSeries("b", "half zeros", halfZeros),
+		},
+		t,
+	)
+}
+
+func testRemoveZeroSeries(xff float64, in []models.Series, out []models.Series, t *testing.T) {
+	f := NewRemoveZeroSeries()
+	f.(*FuncRemoveZeroSeries).in = NewMock(in)
+	f.(*FuncRemoveZeroSeries).xFilesFactor = xff
+
+	inputCopy := models.SeriesCopy(in) // to later verify that it is unchanged
+
+	dataMap := initDataMap(in)
+
+	got, err := f.Exec(dataMap)
+	if err := equalOutput(out, got, nil, err); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("DidNotModifyInput", func(t *testing.T) {
+		if err := equalOutput(inputCopy, in, nil, nil); err != nil {
+			t.Fatalf("Input was modified, err = %s", err)
+		}
+	})
+
+	t.Run("DoesNotDoubleReturnPoints", func(t *testing.T) {
+		if err := dataMap.CheckForOverlappingPoints(); err != nil {
+			t.Fatalf("Point slices in datamap overlap, err = %s", err)
+		}
+	})
+}

--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -122,6 +122,7 @@ func init() {
 		"removeBelowPercentile":        {NewRemoveAboveBelowPercentileConstructor(false), true},
 		"removeBelowValue":             {NewRemoveAboveBelowValueConstructor(false), true},
 		"removeEmptySeries":            {NewRemoveEmptySeries, true},
+		"removeZeroSeries":             {NewRemoveZeroSeries, true},
 		"round":                        {NewRound, true},
 		"scale":                        {NewScale, true},
 		"scaleToSeconds":               {NewScaleToSeconds, true},


### PR DESCRIPTION
This PR adds support for removeZeroSeries in Graphite web, which operates similarly to removeEmptySeries, but instead checks data points in the series for values equal to 0, instead of values equal to math.NaN().