### PR TITLE
update machine image and turn off go modules for stack tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
   qa-post-build:
     working_directory: /home/circleci/.go_workspace/src/github.com/grafana/metrictank
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2204:2022.04.2
     steps:
       - checkout
       - attach_workspace:
@@ -53,12 +53,13 @@ jobs:
       - run: go version
       - run: scripts/qa/docs.sh
       - run: docker load -i build_docker/metrictank.tar
-      - run: go test -v ./stacktest/tests/end2end_carbon
-      - run: go test -v ./stacktest/tests/end2end_carbon_bigtable
+      - run: GO111MODULE=off go test -v ./stacktest/tests/end2end_carbon
+      - run: GO111MODULE=off go test -v ./stacktest/tests/end2end_carbon_bigtable
 
   qa-chaos:
     working_directory: /home/circleci/.go_workspace/src/github.com/grafana/metrictank
-    machine: true
+    machine:
+      image: ubuntu-2204:2022.04.2
     steps:
       - checkout
       - attach_workspace:
@@ -109,16 +110,16 @@ workflows:
       - build
       - test
       - qa
-      - qa-post-build:
-          requires:
-            - build
       - qa-chaos:
           requires:
             - build
+      - qa-post-build:
+          requires:
+            - build
+            - qa-chaos
       - deploy:
           requires:
             - build
             - test
             - qa
             - qa-post-build
-            - qa-chaos

--- a/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
+++ b/stacktest/tests/end2end_carbon_bigtable/end2end_carbon_test.go
@@ -3,18 +3,16 @@ package end2end_carbon_bigtable
 import (
 	"flag"
 	"os"
-	"os/exec"
-	"syscall"
 	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/metrictank/logger"
+	"github.com/grafana/metrictank/stacktest/docker"
 	"github.com/grafana/metrictank/stacktest/fakemetrics"
 	"github.com/grafana/metrictank/stacktest/grafana"
 	"github.com/grafana/metrictank/stacktest/graphite"
 	"github.com/grafana/metrictank/stacktest/track"
-	"github.com/grafana/metrictank/test"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -31,6 +29,7 @@ func init() {
 	log.SetFormatter(formatter)
 	log.SetLevel(log.InfoLevel)
 }
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if testing.Short() {
@@ -39,36 +38,40 @@ func TestMain(m *testing.M) {
 	}
 
 	log.Println("stopping docker-dev stack should it be running...")
-	cmd := exec.Command("docker-compose", "down")
-	cmd.Dir = test.Path("docker/docker-dev-bigtable")
-	err := cmd.Start()
+	dockerDownCmd := docker.DockerChaosAction("docker/docker-dev-bigtable", "down", nil)
+	err := dockerDownCmd.Start()
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	err = cmd.Wait()
+	err = dockerDownCmd.Wait()
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
-	version := exec.Command("docker-compose", "version")
-	output, err := version.CombinedOutput()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	log.Println(string(output))
+	log.Println(string(docker.ComposeVersion()))
 
 	log.Println("launching docker-dev-bigtable stack...")
-	// TODO: should probably use -V flag here.
-	// introduced here https://github.com/docker/compose/releases/tag/1.19.0
-	// but circleCI machine image still stuck with 1.14.0
-	cmd = exec.Command("docker-compose", "up", "--force-recreate", "metrictank", "graphite", "statsdaemon", "bigtable", "grafana")
-	cmd.Dir = test.Path("docker/docker-dev-bigtable")
+	dockerUpCmd := docker.DockerChaosAction(
+		"docker/docker-dev-bigtable",
+		"up",
+		map[string]string{
+			"PATH": "/usr/bin",
+		},
+		"-V",
+		"--force-recreate",
+		"metrictank",
+		"graphite",
+		"statsdaemon",
+		"bigtable",
+		"grafana",
+		"jaeger",
+	)
 
-	tracker, err = track.NewTracker(cmd, false, false, "launch-stdout", "launch-stderr")
+	tracker, err = track.NewTracker(dockerUpCmd, true, true, "launch-stdout", "launch-stderr")
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	err = cmd.Start()
+	err = dockerUpCmd.Start()
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -82,12 +85,17 @@ func TestMain(m *testing.M) {
 	fm.Close()
 
 	log.Println("stopping docker-compose stack...")
-	cmd.Process.Signal(syscall.SIGINT)
+	dockerDownCmd = docker.DockerChaosAction("docker/docker-dev-bigtable", "down", nil)
+	err = dockerDownCmd.Start()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
 	// note: even when we don't care about the output, it's best to consume it before calling cmd.Wait()
 	// even though the cmd.Wait docs say it will wait for stdout/stderr copying to complete
 	// however the docs for cmd.StdoutPipe say "it is incorrect to call Wait before all reads from the pipe have completed"
 	tracker.Wait()
-	err = cmd.Wait()
+	err = dockerDownCmd.Wait()
 
 	// 130 means ctrl-C (interrupt) which is what we want
 	if err != nil && err.Error() != "exit status 130" {


### PR DESCRIPTION
This PR replaces https://github.com/grafana/metrictank/pull/2035/

I created a new PR to replace it because in https://github.com/grafana/metrictank/pull/2035/ there are contributors who have not signed the CLA and who are not available to sign it, so merging is blocked on that.