### PR TITLE
Graceful shutdown

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -143,10 +143,12 @@ func (s *Server) Run() {
 
 func (s *Server) Stop() {
 	log.Info("API shutdown started.")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := s.httpServer.Shutdown(ctx); err != nil {
-		log.Printf("HTTP Server Shutdown Error: %v", err)
+	if s.httpServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.httpServer.Shutdown(ctx); err != nil {
+			log.Printf("HTTP Server Shutdown Error: %v", err)
+		}
 	}
 }
 

--- a/cmd/metrictank/metrictank.go
+++ b/cmd/metrictank/metrictank.go
@@ -532,7 +532,7 @@ func shutdown() {
 	// and so will stop sending us requests.
 	cluster.Stop()
 
-	// stop API
+	// stop API gracefully
 	apiServer.Stop()
 
 	// shutdown our input plugins.  These may take a while as we allow them


### PR DESCRIPTION
Currently the API server shuts down without giving any in-flight requests a chance to finish. This change is to call `Shutdown` on the server and block for a short window to allow these requests to finish successfully. This way, in normal shutdown procedure we should see minimal failures for requests.

I also think it simplifies the flow, removing a background goroutine/channel