### PR TITLE
Harden index load against failures on startup

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -298,6 +298,8 @@ cass config flags:
     	comma separated list of cassandra addresses in host:port form (default "localhost:9042")
   -init-load-concurrency int
     	Number of partitions to load concurrently on startup. (default 1)
+  -init-load-retries int
+    	Number of times to retry loading a partition on startup before failing. (default 3)
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
   -num-conns int
@@ -505,6 +507,8 @@ cass config flags:
     	comma separated list of cassandra addresses in host:port form (default "localhost:9042")
   -init-load-concurrency int
     	Number of partitions to load concurrently on startup. (default 1)
+  -init-load-retries int
+    	Number of times to retry loading a partition on startup before failing. (default 3)
   -keyspace string
     	Cassandra keyspace to store metricDefinitions in. (default "metrictank")
   -num-conns int

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -341,7 +341,11 @@ func (c *CasIdx) rebuildIndex() {
 func (c *CasIdx) Load(defs []schema.MetricDefinition, now time.Time) []schema.MetricDefinition {
 	session := c.Session.CurrentSession()
 	iter := session.Query(fmt.Sprintf("SELECT id, orgid, partition, name, interval, unit, mtype, tags, lastupdate from %s", c.Config.Table)).Iter()
-	return c.load(defs, iter, now)
+	defs, err := c.load(defs, iter, now)
+	if err != nil {
+		log.Fatalf("cassandra-idx: Failed to load: %s", err)
+	}
+	return defs
 }
 
 // LoadPartitions appends MetricDefinitions from the given partitions to defs and returns the modified defs, honoring pruning settings relative to now
@@ -352,13 +356,22 @@ func (c *CasIdx) LoadPartitions(partitions []int32, defs []schema.MetricDefiniti
 	}
 	q := fmt.Sprintf("SELECT id, orgid, partition, name, interval, unit, mtype, tags, lastupdate from %s where partition in (%s)", c.Config.Table, strings.Join(placeholders, ","))
 
-	session := c.Session.CurrentSession()
-	iter := session.Query(q).Iter()
-	return c.load(defs, iter, now)
+	// Retry a few times on error
+	var err error
+	for i := 0; i < c.Config.InitLoadRetries; i++ {
+		session := c.Session.CurrentSession()
+		iter := session.Query(q).Iter()
+		defs, err = c.load(defs, iter, now)
+		if err == nil {
+			return defs
+		}
+	}
+	log.Fatalf("cassandra-idx: Failed to load partitions %v after %d retries: %s", partitions, c.Config.InitLoadRetries, err)
+	return nil
 }
 
 // load appends MetricDefinitions from the iterator to defs and returns the modified defs, honoring pruning settings relative to now
-func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, now time.Time) []schema.MetricDefinition {
+func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, now time.Time) ([]schema.MetricDefinition, error) {
 	defsByNames := make(map[string][]*schema.MetricDefinition)
 	var id, name, unit, mtype string
 	var orgId, interval int
@@ -407,7 +420,8 @@ func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, now time
 		defsByNames[nameWithTags] = append(defsByNames[nameWithTags], mdef)
 	}
 	if err := iter.Close(); err != nil {
-		log.Fatalf("cassandra-idx: could not close iterator: %s", err.Error())
+		log.Errorf("cassandra-idx: could not close iterator: %s", err.Error())
+		return nil, err
 	}
 
 	// getting all cutoffs once saves having to recompute everytime we have a match
@@ -429,7 +443,7 @@ NAMES:
 		}
 	}
 
-	return defs
+	return defs, nil
 }
 
 // ArchiveDefs writes each of the provided defs to the archive table and

--- a/idx/cassandra/cassandra.go
+++ b/idx/cassandra/cassandra.go
@@ -397,6 +397,12 @@ func (c *CasIdx) load(defs []schema.MetricDefinition, iter cqlIterator, now time
 			// (that's how Graphite works anyway)
 			LastUpdate: util.MinInt64(maxLastUpdate, lastupdate+updateInterval),
 		}
+
+		if err = mdef.Validate(); err != nil {
+			log.Errorf("Encountered invalid idx entry: def = %v, err = %v", mdef, err)
+			continue
+		}
+
 		nameWithTags := mdef.NameWithTags()
 		defsByNames[nameWithTags] = append(defsByNames[nameWithTags], mdef)
 	}

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -584,30 +584,40 @@ func TestPruneStaleOnLoad(t *testing.T) {
 	}
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(1).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "longtermrecentenough",
 		interval:   1,
 		lastUpdate: now.Add(-350 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(2).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "longtermtooold",
 		interval:   1,
 		lastUpdate: now.Add(-380 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(3).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "foobarrecentenough",
 		interval:   3,
 		lastUpdate: now.Add(-5 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(4).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "foobartooold",
 		interval:   3,
 		lastUpdate: now.Add(-9 * 24 * time.Hour).Unix(),
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(5).String(),
+		orgId:      1,
+		mtype:      "gauge",
 		name:       "default-super-old-but-never-pruned",
 		interval:   1,
 		lastUpdate: now.Add(-2 * 365 * 24 * time.Hour).Unix(),
@@ -661,6 +671,7 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(1).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   1,
@@ -671,6 +682,7 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(2).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   2,
@@ -681,20 +693,22 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(3).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   3,
 		lastUpdate: now.Add(-8 * 24 * time.Hour).Unix(), // this one will expire
-		tags:       []string{"tag1=val1;foo=bar"},
+		tags:       []string{"tag1=val1", "foo=bar"},
 	})
 	iter.rows = append(iter.rows, cassRow{
 		id:         test.GetMKey(4).String(),
 		orgId:      1,
+		mtype:      "gauge",
 		partition:  1,
 		name:       "met1",
 		interval:   4,
 		lastUpdate: now.Add(-8 * 24 * time.Hour).Unix(), // this one won't because it doesn't match the tag
-		tags:       []string{"tag1=val1;foo=baz"},
+		tags:       []string{"tag1=val1", "foo=baz"},
 	})
 
 	idx := &CasIdx{}

--- a/idx/cassandra/cassandra_test.go
+++ b/idx/cassandra/cassandra_test.go
@@ -614,7 +614,10 @@ func TestPruneStaleOnLoad(t *testing.T) {
 	})
 
 	idx := &CasIdx{}
-	defs := idx.load(nil, &iter, now)
+	defs, err := idx.load(nil, &iter, now)
+	if err != nil {
+		t.Fatalf("unexpected error when loading: %s", err)
+	}
 
 	exp := []schema.MKey{
 		test.GetMKey(1),
@@ -695,7 +698,11 @@ func TestPruneStaleOnLoadWithTags(t *testing.T) {
 	})
 
 	idx := &CasIdx{}
-	defs := idx.load(nil, &iter, now)
+	defs, err := idx.load(nil, &iter, now)
+	if err != nil {
+		t.Fatalf("unexpected error when loading: %s", err)
+	}
+
 	exp := []schema.MKey{
 		test.GetMKey(1),
 		test.GetMKey(2),

--- a/idx/cassandra/config.go
+++ b/idx/cassandra/config.go
@@ -44,6 +44,7 @@ type IdxConfig struct {
 	ProtoVer                 int
 	DisableInitialHostLookup bool
 	InitLoadConcurrency      int
+	InitLoadRetries          int
 }
 
 // NewIdxConfig returns IdxConfig with default values set.
@@ -74,6 +75,7 @@ func NewIdxConfig() *IdxConfig {
 		Username:                 "cassandra",
 		Password:                 "cassandra",
 		InitLoadConcurrency:      1,
+		InitLoadRetries:          3,
 	}
 }
 
@@ -107,6 +109,7 @@ func ConfigSetup() *flag.FlagSet {
 	casIdx.DurationVar(&CliConfig.updateInterval, "update-interval", CliConfig.updateInterval, "frequency at which we should update the metricDef lastUpdate field, use 0s for instant updates")
 	casIdx.DurationVar(&CliConfig.pruneInterval, "prune-interval", CliConfig.pruneInterval, "Interval at which the index should be checked for stale series.")
 	casIdx.IntVar(&CliConfig.InitLoadConcurrency, "init-load-concurrency", CliConfig.InitLoadConcurrency, "Number of partitions to load concurrently on startup.")
+	casIdx.IntVar(&CliConfig.InitLoadRetries, "init-load-retries", CliConfig.InitLoadRetries, "Number of times to retry loading a partition on startup before failing.")
 	casIdx.IntVar(&CliConfig.ProtoVer, "protocol-version", CliConfig.ProtoVer, "cql protocol version to use")
 	casIdx.BoolVar(&CliConfig.CreateKeyspace, "create-keyspace", CliConfig.CreateKeyspace, "enable the creation of the index keyspace and tables, only one node needs this")
 	casIdx.StringVar(&CliConfig.SchemaFile, "schema-file", CliConfig.SchemaFile, "File containing the needed schemas in case database needs initializing")

--- a/test/key.go
+++ b/test/key.go
@@ -16,6 +16,7 @@ func GetAMKey(suffix int) schema.AMKey {
 func GetMKey(suffix int) schema.MKey {
 	s := uint32(suffix)
 	return schema.MKey{
+		Org: 1,
 		Key: [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, byte(s >> 24), byte(s >> 16), byte(s >> 8), byte(s)},
 	}
 }


### PR DESCRIPTION
After a cassandra crash, invalid index entries caused MT to crash repeatedly. Additionally, there were spurious timeouts and metrictank cannot start if *any* partition failed to load. With even a low chance of partition failure (e.g. 10%) and 16 partitions to load, it's likely Metrictank will fail to start several times.  Add some retries so that it's much more likely all partitions succeed.