### PR TITLE
Reduce AggMetrics size

### DIFF
--- a/mdata/aggmetric.go
+++ b/mdata/aggmetric.go
@@ -31,14 +31,11 @@ var ErrInvalidRange = errors.New("AggMetric: invalid range: from must be less th
 // in addition, keep in mind that the last chunk is always a work in progress and not useable for aggregation
 // AggMetric is concurrency-safe
 type AggMetric struct {
-	store       Store
-	cachePusher cache.CachePusher
 	sync.RWMutex
+	store           Store
+	cachePusher     cache.CachePusher
 	key             schema.AMKey
 	rob             *ReorderBuffer
-	currentChunkPos int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
-	numChunks       uint32 // max size of the circular buffer
-	chunkSpan       uint32 // span of individual chunks in seconds
 	chunks          []*chunk.Chunk
 
 	// After NewAggMetric returns and thus before we start using the AggMetric, the contents of this slice (the pointers themselves)
@@ -47,13 +44,15 @@ type AggMetric struct {
 	// fields to hold the boundary and the data, and those are unprotected.  For read and write access to them,
 	// you should use this AggMetric's RWMutex.
 	aggregators     []*Aggregator
-	dropFirstChunk  bool
+	currentChunkPos int    // Chunks[CurrentChunkPos] is active. Others are finished. Only valid when len(chunks) > 0, e.g. when data has been written (excl ROB data)
+	chunkSpan       uint32 // span of individual chunks in seconds
 	ingestFromT0    uint32
 	futureTolerance uint32
 	ttl             uint32
 	lastSaveStart   uint32 // last chunk T0 that was added to the write Queue.
 	lastWrite       uint32 // wall clock time of when last point was successfully added (possibly to the ROB)
 	firstTs         uint32 // timestamp of first point seen
+	dropFirstChunk  bool
 }
 
 // NewAggMetric creates a metric with given key, it retains the given number of chunks each chunkSpan seconds long
@@ -71,15 +70,14 @@ func NewAggMetric(store Store, cachePusher cache.CachePusher, key schema.AMKey, 
 		cachePusher:     cachePusher,
 		store:           store,
 		key:             key,
-		chunkSpan:       ret.ChunkSpan,
-		numChunks:       ret.NumChunks,
 		chunks:          make([]*chunk.Chunk, 0, ret.NumChunks),
-		dropFirstChunk:  dropFirstChunk,
+		chunkSpan:       ret.ChunkSpan,
 		futureTolerance: uint32(ret.MaxRetention()) * uint32(futureToleranceRatio) / 100,
 		ttl:             uint32(ret.MaxRetention()),
 		// we set LastWrite here to make sure a new Chunk doesn't get immediately
 		// garbage collected right after creating it, before we can push to it.
-		lastWrite: uint32(time.Now().Unix()),
+		lastWrite:      uint32(time.Now().Unix()),
+		dropFirstChunk: dropFirstChunk,
 	}
 	if ingestFrom > 0 {
 		// we only want to ingest data that will go into chunks with a t0 >= 'ingestFrom'.
@@ -594,12 +592,12 @@ func (a *AggMetric) add(ts uint32, val float64) {
 		}
 
 		a.currentChunkPos++
-		if a.currentChunkPos >= int(a.numChunks) {
+		if a.currentChunkPos >= cap(a.chunks) {
 			a.currentChunkPos = 0
 		}
 
 		chunkCreate.Inc()
-		if len(a.chunks) < int(a.numChunks) {
+		if len(a.chunks) < cap(a.chunks) {
 			a.chunks = append(a.chunks, chunk.New(t0))
 			if err := a.chunks[a.currentChunkPos].Push(ts, val); err != nil {
 				panic(fmt.Sprintf("FATAL ERROR: this should never happen. Pushing initial value <%d,%f> to new chunk at pos %d failed: %q", ts, val, a.currentChunkPos, err))

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -25,6 +25,13 @@ type MockFlusher struct {
 	mockCache *cache.MockCache
 }
 
+func (m MockFlusher) IsCacheable(metric schema.AMKey) bool {
+	if m.mockCache == nil {
+		return false
+	}
+	return m.mockCache.IsCacheable(metric)
+}
+
 func (m MockFlusher) Cache(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	if m.mockCache != nil {
 		m.mockCache.AddIfHot(metric, prev, itergen)

--- a/mdata/aggmetric_test.go
+++ b/mdata/aggmetric_test.go
@@ -13,11 +13,27 @@ import (
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/conf"
 	"github.com/grafana/metrictank/mdata/cache"
+	"github.com/grafana/metrictank/mdata/chunk"
 	"github.com/grafana/metrictank/mdata/chunk/tsz"
 	"github.com/grafana/metrictank/test"
 )
 
 var mockstore = NewMockStore()
+
+type MockFlusher struct {
+	mockstore *MockStore
+	mockCache *cache.MockCache
+}
+
+func (m MockFlusher) Cache(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
+	if m.mockCache != nil {
+		m.mockCache.AddIfHot(metric, prev, itergen)
+	}
+}
+
+func (m MockFlusher) Store(cwr *ChunkWriteRequest) {
+	m.mockstore.Add(cwr)
+}
 
 type point struct {
 	ts  uint32
@@ -132,7 +148,7 @@ func testMetricPersistOptionalPrimary(t *testing.T, primary bool) {
 
 	chunkAddCount, chunkSpan := uint32(10), uint32(300)
 	rets := conf.MustParseRetentions("1s:1s:5min:5:true")
-	agg := NewAggMetric(mockstore, &mockCache, test.GetAMKey(42), rets, 0, chunkSpan, nil, false, false, 0)
+	agg := NewAggMetric(MockFlusher{mockstore, &mockCache}, test.GetAMKey(42), rets, 0, chunkSpan, nil, false, false, 0)
 
 	for ts := chunkSpan; ts <= chunkSpan*chunkAddCount; ts += chunkSpan {
 		agg.Add(ts, 1)
@@ -168,7 +184,7 @@ func TestAggMetric(t *testing.T) {
 	cluster.Init("default", "test", time.Now(), "http", 6060)
 
 	ret := conf.MustParseRetentions("1s:1s:2min:5:true")
-	c := NewChecker(t, NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0))
+	c := NewChecker(t, NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0))
 
 	// chunk t0's: 120, 240, 360, 480, 600, 720, 840, 960
 
@@ -246,7 +262,7 @@ func TestAggMetricWithReorderBuffer(t *testing.T) {
 		AggregationMethod: []conf.Method{conf.Avg},
 	}
 	ret := conf.MustParseRetentions("1s:1s:2min:5:true")
-	c := NewChecker(t, NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 10, 1, &agg, false, false, 0))
+	c := NewChecker(t, NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 10, 1, &agg, false, false, 0))
 
 	// basic adds and verifies with test data
 	c.Add(121, 121)
@@ -284,7 +300,7 @@ func TestAggMetricDropFirstChunk(t *testing.T) {
 	cluster.Manager.SetPrimary(true)
 	mockstore.Reset()
 	rets := conf.MustParseRetentions("1s:1s:10s:5:true")
-	m := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), rets, 0, 1, nil, false, true, 0)
+	m := NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), rets, 0, 1, nil, false, true, 0)
 	m.Add(10, 10)
 	m.Add(11, 11)
 	m.Add(12, 12)
@@ -312,7 +328,7 @@ func TestAggMetricIngestFrom(t *testing.T) {
 	mockstore.Reset()
 	ingestFrom := int64(25)
 	ret := conf.MustParseRetentions("1s:1s:10s:5:true")
-	m := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, nil, false, false, ingestFrom)
+	m := NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, nil, false, false, ingestFrom)
 	m.Add(10, 10)
 	m.Add(11, 11)
 	m.Add(12, 12)
@@ -357,11 +373,11 @@ func TestAggMetricFutureTolerance(t *testing.T) {
 
 	// with a raw retention of 600s, this will result in a future tolerance of 60s
 	futureToleranceRatio = 10
-	aggMetricTolerate60 := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
+	aggMetricTolerate60 := NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
 
 	// will not tolerate future datapoints at all
 	futureToleranceRatio = 0
-	aggMetricTolerate0 := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
+	aggMetricTolerate0 := NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
 
 	// add datapoint which is 30 seconds in the future to both aggmetrics, they should both accept it
 	// because enforcement of future tolerance is disabled, but the one with tolerance 0 should increase
@@ -396,9 +412,9 @@ func TestAggMetricFutureTolerance(t *testing.T) {
 	sampleTooFarAhead.SetUint32(0)
 	enforceFutureTolerance = true
 	futureToleranceRatio = 10
-	aggMetricTolerate60 = NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
+	aggMetricTolerate60 = NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
 	futureToleranceRatio = 0
-	aggMetricTolerate0 = NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
+	aggMetricTolerate0 = NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, nil, false, false, 0)
 
 	aggMetricTolerate60.Add(uint32(time.Now().Unix()+30), 10)
 	if len(aggMetricTolerate60.chunks) != 1 {
@@ -476,7 +492,7 @@ func TestGetAggregated(t *testing.T) {
 		AggregationMethod: []conf.Method{conf.Sum},
 	}
 
-	m := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, &agg, false, false, 0)
+	m := NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, &agg, false, false, 0)
 	m.Add(10, 10)
 	m.Add(11, 11)
 	m.Add(12, 12)
@@ -520,7 +536,7 @@ func TestGetAggregatedIngestFrom(t *testing.T) {
 		AggregationMethod: []conf.Method{conf.Sum},
 	}
 
-	m := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(42), ret, 0, 1, &agg, false, false, ingestFrom)
+	m := NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(42), ret, 0, 1, &agg, false, false, ingestFrom)
 	m.Add(10, 10)
 	m.Add(11, 11)
 	m.Add(12, 12)
@@ -560,7 +576,7 @@ func BenchmarkAggMetricAdd(b *testing.B) {
 
 	// each chunk contains 180 points
 	rets := conf.MustParseRetentions("10s:1000000000s,30min:1")
-	metric := NewAggMetric(mockstore, &cache.MockCache{}, test.GetAMKey(0), rets, 0, 10, nil, false, false, 0)
+	metric := NewAggMetric(MockFlusher{mockstore, nil}, test.GetAMKey(0), rets, 0, 10, nil, false, false, 0)
 
 	max := uint32(b.N*10 + 1)
 	for t := uint32(1); t < max; t += 10 {

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -181,6 +181,13 @@ func (ms *AggMetrics) GetOrCreate(key schema.MKey, schemaId, aggId uint16, inter
 	return m
 }
 
+func (ms *AggMetrics) IsCacheable(metric schema.AMKey) bool {
+	if ms.cachePusher == nil {
+		return false
+	}
+	return ms.cachePusher.IsCacheable(metric)
+}
+
 func (ms *AggMetrics) Cache(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	if ms.cachePusher != nil {
 		ms.cachePusher.AddIfHot(metric, prev, itergen)

--- a/mdata/aggmetrics.go
+++ b/mdata/aggmetrics.go
@@ -182,9 +182,13 @@ func (ms *AggMetrics) GetOrCreate(key schema.MKey, schemaId, aggId uint16, inter
 }
 
 func (ms *AggMetrics) Cache(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
-	ms.cachePusher.AddIfHot(metric, prev, itergen)
+	if ms.cachePusher != nil {
+		ms.cachePusher.AddIfHot(metric, prev, itergen)
+	}
 }
 
 func (ms *AggMetrics) Store(cwr *ChunkWriteRequest) {
-	ms.store.Add(cwr)
+	if ms.store != nil {
+		ms.store.Add(cwr)
+	}
 }

--- a/mdata/aggmetrics_test.go
+++ b/mdata/aggmetrics_test.go
@@ -12,6 +12,10 @@ import (
 
 type mockCachePusher struct{}
 
+func (m *mockCachePusher) IsCacheable(_ schema.AMKey) bool {
+	return true
+}
+
 func (m *mockCachePusher) AddIfHot(_ schema.AMKey, _ uint32, _ chunk.IterGen) {}
 
 func NewMockCachePusher() cache.CachePusher {

--- a/mdata/aggmetrics_test.go
+++ b/mdata/aggmetrics_test.go
@@ -62,12 +62,8 @@ func TestAggMetricsGetOrCreate(t *testing.T) {
 	testKey1, _ := schema.AMKeyFromString("1.12345678901234567890123456789012")
 	metric := aggMetrics.GetOrCreate(testKey1.MKey, 1, 0, 10).(*AggMetric)
 
-	if metric.store != mockStore {
-		t.Fatalf("Expected metric to have mock store, but it did not")
-	}
-
-	if metric.cachePusher != mockCachePusher {
-		t.Fatalf("Expected metric to have mock cache pusher, but it did not")
+	if metric.flusher.(*AggMetrics) != aggMetrics {
+		t.Fatalf("Expected metric to have flusher referencing aggMetrics, but it did not")
 	}
 
 	if metric.key.MKey != testKey1.MKey {

--- a/mdata/aggmetrics_test.go
+++ b/mdata/aggmetrics_test.go
@@ -78,8 +78,8 @@ func TestAggMetricsGetOrCreate(t *testing.T) {
 		t.Fatalf("Expected metric chunk span to be %d, but it was %d", 24*3600, metric.chunkSpan)
 	}
 
-	if metric.numChunks != 2 {
-		t.Fatalf("Expected metric num chunks to be 2, but it was %d", metric.numChunks)
+	if cap(metric.chunks) != 2 {
+		t.Fatalf("Expected metric num chunks to be 2, but it was %d", cap(metric.chunks))
 	}
 
 	if metric.ttl != 3600*24*365 {

--- a/mdata/aggregator.go
+++ b/mdata/aggregator.go
@@ -3,7 +3,6 @@ package mdata
 import (
 	"github.com/grafana/metrictank/conf"
 	"github.com/grafana/metrictank/consolidation"
-	"github.com/grafana/metrictank/mdata/cache"
 	"github.com/grafana/metrictank/schema"
 )
 
@@ -30,7 +29,7 @@ type Aggregator struct {
 	lstMetric       *AggMetric
 }
 
-func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey, retOrig string, ret conf.Retention, agg conf.Aggregation, dropFirstChunk bool, ingestFrom int64) *Aggregator {
+func NewAggregator(flusher Flusher, key schema.AMKey, retOrig string, ret conf.Retention, agg conf.Aggregation, dropFirstChunk bool, ingestFrom int64) *Aggregator {
 	if len(agg.AggregationMethod) == 0 {
 		panic("NewAggregator called without aggregations. this should never happen")
 	}
@@ -48,31 +47,31 @@ func NewAggregator(store Store, cachePusher cache.CachePusher, key schema.AMKey,
 		case conf.Avg:
 			if aggregator.sumMetric == nil {
 				key.Archive = schema.NewArchive(schema.Sum, span)
-				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
+				aggregator.sumMetric = NewAggMetric(flusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
 			}
 			if aggregator.cntMetric == nil {
 				key.Archive = schema.NewArchive(schema.Cnt, span)
-				aggregator.cntMetric = NewAggMetric(store, cachePusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
+				aggregator.cntMetric = NewAggMetric(flusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
 			}
 		case conf.Sum:
 			if aggregator.sumMetric == nil {
 				key.Archive = schema.NewArchive(schema.Sum, span)
-				aggregator.sumMetric = NewAggMetric(store, cachePusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
+				aggregator.sumMetric = NewAggMetric(flusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
 			}
 		case conf.Lst:
 			if aggregator.lstMetric == nil {
 				key.Archive = schema.NewArchive(schema.Lst, span)
-				aggregator.lstMetric = NewAggMetric(store, cachePusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
+				aggregator.lstMetric = NewAggMetric(flusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
 			}
 		case conf.Max:
 			if aggregator.maxMetric == nil {
 				key.Archive = schema.NewArchive(schema.Max, span)
-				aggregator.maxMetric = NewAggMetric(store, cachePusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
+				aggregator.maxMetric = NewAggMetric(flusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
 			}
 		case conf.Min:
 			if aggregator.minMetric == nil {
 				key.Archive = schema.NewArchive(schema.Min, span)
-				aggregator.minMetric = NewAggMetric(store, cachePusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
+				aggregator.minMetric = NewAggMetric(flusher, key, retentions, 0, span, nil, false, dropFirstChunk, ingestFrom)
 			}
 		}
 	}

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -81,13 +81,13 @@ func TestAggregator(t *testing.T) {
 		AggregationMethod: []conf.Method{conf.Avg, conf.Min, conf.Max, conf.Sum, conf.Lst},
 	}
 
-	agg := NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(0), ret.String(), ret, aggs, false, 0)
+	agg := NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(0), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	expected := []schema.Point{}
 	getFromMetricAndCompare("simple-min-unfinished", agg.minMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 0)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(1), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
@@ -97,7 +97,7 @@ func TestAggregator(t *testing.T) {
 	getFromMetricAndCompare("simple-min-one-block", agg.minMetric, expected)
 
 	// points with a timestamp belonging to the previous aggregation are ignored
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 0)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(1), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
@@ -108,7 +108,7 @@ func TestAggregator(t *testing.T) {
 	getFromMetricAndCompare("simple-min-ignore-back-in-time", agg.minMetric, expected)
 
 	// chunkspan is 120, ingestFrom = 140 means points before chunk starting at 240 are discarded
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 140)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(1), ret.String(), ret, aggs, false, 140)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	// this point is not flushed to agg.minMetric because no point after it with a timestamp
@@ -118,7 +118,7 @@ func TestAggregator(t *testing.T) {
 	getFromMetricAndCompare("simple-min-ingest-from-all-before-next-chunk", agg.minMetric, expected)
 
 	// chunkspan is 120, ingestFrom = 115 means points before chunk starting at 120 are discarded
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 115)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(1), ret.String(), ret, aggs, false, 115)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	// this point is not flushed to agg.minMetric for the same reason as in the previous test
@@ -129,7 +129,7 @@ func TestAggregator(t *testing.T) {
 	getFromMetricAndCompare("simple-min-ingest-from-one-in-next-chunk", agg.minMetric, expected)
 
 	// chunkspan is 120, ingestFrom = 120 means points before chunk starting at 120 are discarded
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 120)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(1), ret.String(), ret, aggs, false, 120)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	// this point is not flushed to agg.minMetric for the same reason as in the previous test
@@ -147,7 +147,7 @@ func TestAggregator(t *testing.T) {
 	// aggregated points:      120      180      240      300      360
 	// chunks by t0     :      120               240      300      360
 	// discarded chunk  :   xxxxxxxxxxxxxxxxxxxxx
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(1), ret.String(), ret, aggs, false, 170)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(1), ret.String(), ret, aggs, false, 170)
 	agg.Add(1, 1.1)
 	agg.Add(119, 119)
 	agg.Add(120, 120)
@@ -176,7 +176,7 @@ func TestAggregator(t *testing.T) {
 	}
 	getFromMetricAndCompare("multi-sum-ingest-from-one-in-next-chunk", agg.sumMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(2), ret.String(), ret, aggs, false, 0)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(2), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(120, 4)
@@ -185,7 +185,7 @@ func TestAggregator(t *testing.T) {
 	}
 	getFromMetricAndCompare("simple-min-one-block-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(3), ret.String(), ret, aggs, false, 0)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(3), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(150, 1.123)
@@ -196,7 +196,7 @@ func TestAggregator(t *testing.T) {
 	}
 	getFromMetricAndCompare("simple-min-two-blocks-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(4), ret.String(), ret, aggs, false, 0)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(4), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(190, 2451.123)

--- a/mdata/aggregator_test.go
+++ b/mdata/aggregator_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/metrictank/cluster"
 	"github.com/grafana/metrictank/conf"
 	"github.com/grafana/metrictank/consolidation"
-	"github.com/grafana/metrictank/mdata/cache"
 	"github.com/grafana/metrictank/schema"
 	"github.com/grafana/metrictank/test"
 )
@@ -224,7 +223,7 @@ func TestAggregator(t *testing.T) {
 		{Val: 2451.123 + 1451.123 + 978894.445, Ts: 240},
 	})
 
-	agg = NewAggregator(mockstore, &cache.MockCache{}, test.GetAMKey(4), ret.String(), ret, aggs, false, 0)
+	agg = NewAggregator(MockFlusher{mockstore, nil}, test.GetAMKey(4), ret.String(), ret, aggs, false, 0)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(190, 2451.123)

--- a/mdata/cache/cache_mock.go
+++ b/mdata/cache/cache_mock.go
@@ -37,6 +37,10 @@ func (mc *MockCache) AddRange(metric schema.AMKey, prev uint32, itergens []chunk
 	mc.AddCount += len(itergens)
 }
 
+func (mc *MockCache) IsCacheable(_ schema.AMKey) bool {
+	return true
+}
+
 func (mc *MockCache) AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	mc.Lock()
 	defer mc.Unlock()

--- a/mdata/cache/ccache.go
+++ b/mdata/cache/ccache.go
@@ -114,6 +114,18 @@ func (c *CCache) DelMetric(rawMetric schema.MKey) (int, int) {
 	return series, archives
 }
 
+// IsHot returns true if the metric is in the cache
+func (c *CCache) IsCacheable(metric schema.AMKey) bool {
+	if c == nil {
+		return false
+	}
+	c.RLock()
+	defer c.RUnlock()
+
+	_, ok := c.metricCache[metric]
+	return ok
+}
+
 // adds the given chunk to the cache, but only if the metric is sufficiently hot
 func (c *CCache) AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen) {
 	if c == nil {

--- a/mdata/cache/if.go
+++ b/mdata/cache/if.go
@@ -18,6 +18,7 @@ type Cache interface {
 }
 
 type CachePusher interface {
+	IsCacheable(metric schema.AMKey) bool
 	AddIfHot(metric schema.AMKey, prev uint32, itergen chunk.IterGen)
 }
 


### PR DESCRIPTION
- Combine 2 interfaces into 1
- Remove unneeded `numChunks` param

With this byte alignment, we should go from 184 bytes (9 padding bytes) to 160 bytes (5 padding bytes). Considering there are millions of these (billions across a cluster) it can add up.

There is also an optimization to only call `Encode` on cacheable elements which reduces the number of allocations / heap spikes during periodic flushes.