### PR TITLE
Fix mt-backfill data flush

### DIFF
--- a/cmd/mt-backfill/main.go
+++ b/cmd/mt-backfill/main.go
@@ -258,6 +258,8 @@ func handlerTimeout() {
 
 // normal shutdown
 func shutdown() {
+	// Force all data to flush
+	aggMetrics.ForceGC()
 	cluster.Stop()
 	timer := time.NewTimer(time.Second * 20)
 	kafkaStopped := make(chan bool)

--- a/conf/retention.go
+++ b/conf/retention.go
@@ -145,7 +145,7 @@ func ParseRetentions(defs string) (Retentions, error) {
 	}
 	cnt := strings.Count(defs, ",")
 	if cnt > 254 {
-		return retentions, errors.New("no more than 255 individual retensions per rule supported")
+		return retentions, errors.New("no more than 255 individual retentions per rule supported")
 	}
 	for i, def := range strings.Split(defs, ",") {
 		def = strings.TrimSpace(def)


### PR DESCRIPTION
We have noticed for a while that the mt-backfill tool never seems to flush all of the data it has. It turns out, this is due to a mix of using system time and chunk spans.

`AggMetric.lastWrite` uses the system time when the data point was ingested, not the timestamp of the datapoint. This is probably the right thing to do to avoid prematurely flushing when backfilling.

However, `Aggregator` won't GC a chunk until [lastWriteTime+agg.span <= chunkMinTs](https://github.com/grafana/metrictank/blob/79b6a8943af80be00e6de7d091132c00fc903ec0/mdata/aggregator.go#L175). For rollups with longer spans (say 4h) that means the backfill tool would need to run for 4 hours before it would flush the tail datapoints. 

This change is to add a simple `ForceGC` function so the backfill tool can do flush everything on shutdown. I figured this was the safest way to fix this without changing the behavior of the core components.