### PR TITLE
Add time ranges for tag requests

### DIFF
--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -79,21 +79,21 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 }
 
 type GraphiteTags struct {
-	tz.FromTo        // Used by GEM to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
+	tz.FromTo        // Used by downstream projects to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
 	Filter    string `json:"filter" form:"filter"`
 }
 
 type GraphiteTagsResp []GraphiteTagResp
 
 type GraphiteAutoCompleteTags struct {
-	tz.FromTo          // Used by GEM to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
+	tz.FromTo          // Used by downstream projects to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
 	Prefix    string   `json:"tagPrefix" form:"tagPrefix"`
 	Expr      []string `json:"expr" form:"expr"`
 	Limit     uint     `json:"limit" form:"limit"`
 }
 
 type GraphiteAutoCompleteTagValues struct {
-	tz.FromTo          // Used by GEM to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
+	tz.FromTo          // Used by downstream projects to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
 	Tag       string   `json:"tag" form:"tag"`
 	Prefix    string   `json:"valuePrefix" form:"valuePrefix"`
 	Expr      []string `json:"expr" form:"expr"`

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -13,6 +13,7 @@ import (
 	pickle "github.com/kisielk/og-rek"
 	opentracing "github.com/opentracing/opentracing-go"
 	traceLog "github.com/opentracing/opentracing-go/log"
+	"gopkg.in/macaron.v1"
 )
 
 //go:generate msgp

--- a/api/models/graphite.go
+++ b/api/models/graphite.go
@@ -13,7 +13,6 @@ import (
 	pickle "github.com/kisielk/og-rek"
 	opentracing "github.com/opentracing/opentracing-go"
 	traceLog "github.com/opentracing/opentracing-go/log"
-	"gopkg.in/macaron.v1"
 )
 
 //go:generate msgp
@@ -79,22 +78,25 @@ func (gr GraphiteRender) Validate(ctx *macaron.Context, errs binding.Errors) bin
 }
 
 type GraphiteTags struct {
-	Filter string `json:"filter" form:"filter"`
+	tz.FromTo        // Used by GEM to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
+	Filter    string `json:"filter" form:"filter"`
 }
 
 type GraphiteTagsResp []GraphiteTagResp
 
 type GraphiteAutoCompleteTags struct {
-	Prefix string   `json:"tagPrefix" form:"tagPrefix"`
-	Expr   []string `json:"expr" form:"expr"`
-	Limit  uint     `json:"limit" form:"limit"`
+	tz.FromTo          // Used by GEM to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
+	Prefix    string   `json:"tagPrefix" form:"tagPrefix"`
+	Expr      []string `json:"expr" form:"expr"`
+	Limit     uint     `json:"limit" form:"limit"`
 }
 
 type GraphiteAutoCompleteTagValues struct {
-	Tag    string   `json:"tag" form:"tag"`
-	Prefix string   `json:"valuePrefix" form:"valuePrefix"`
-	Expr   []string `json:"expr" form:"expr"`
-	Limit  uint     `json:"limit" form:"limit"`
+	tz.FromTo          // Used by GEM to decide what time range to return results for. Not used by upstream Graphite or Metrictank.
+	Tag       string   `json:"tag" form:"tag"`
+	Prefix    string   `json:"valuePrefix" form:"valuePrefix"`
+	Expr      []string `json:"expr" form:"expr"`
+	Limit     uint     `json:"limit" form:"limit"`
 }
 
 type GraphiteTagResp struct {


### PR DESCRIPTION
Adding time ranges to the `GraphiteTags`, `GraphiteAutoCompleteTags` and  `GraphiteAutoCompleteTagValues` models. These are needed by GEM to decide what time range to return results for.

The time range fields for `GraphiteTags` and `GraphiteAutoCompleteTags` were originally added in https://github.com/grafana/metrictank/pull/2013, though were removed in https://github.com/grafana/metrictank/pull/2015. I'm not sure why they were removed, possibly because Metrictank doesn't use them.

I've added comments explaining the fields to the models, but haven't updated docs as per https://github.com/grafana/metrictank/pull/2013#issuecomment-967537663, "In metrictank we don't actually use the fields, so we don't need to really update docs."

