### PR TITLE
Infinity values no longer produce invalid JSONs

### DIFF
--- a/api/models/series.go
+++ b/api/models/series.go
@@ -291,7 +291,7 @@ func (series SeriesByTarget) MarshalJSONFast(b []byte) ([]byte, error) {
 		b = append(b, `,"datapoints":[`...)
 		for _, p := range s.Datapoints {
 			b = append(b, '[')
-			if math.IsNaN(p.Val) {
+			if math.IsNaN(p.Val) || math.IsInf(p.Val, 1) || math.IsInf(p.Val, -1) {
 				b = append(b, `null,`...)
 			} else {
 				b = strconv.AppendFloat(b, p.Val, 'f', -1, 64)
@@ -330,7 +330,7 @@ func (series SeriesByTarget) MarshalJSONFastWithMeta(b []byte) ([]byte, error) {
 		b = append(b, `,"datapoints":[`...)
 		for _, p := range s.Datapoints {
 			b = append(b, '[')
-			if math.IsNaN(p.Val) {
+			if math.IsNaN(p.Val) || math.IsInf(p.Val, 1) || math.IsInf(p.Val, -1) {
 				b = append(b, `null,`...)
 			} else {
 				b = strconv.AppendFloat(b, p.Val, 'f', -1, 64)

--- a/api/models/series_test.go
+++ b/api/models/series_test.go
@@ -41,6 +41,18 @@ func TestJsonMarshal(t *testing.T) {
 		{
 			in: []Series{
 				{
+					Target: `a`,
+					Datapoints: []schema.Point{
+						{Val: math.Inf(1), Ts: 60},
+					},
+					Interval: 60,
+				},
+			},
+			out: `[{"target":"a","datapoints":[[null,60]]}]`,
+		},
+		{
+			in: []Series{
+				{
 					Target: "a",
 					Datapoints: []schema.Point{
 						{Val: 123, Ts: 60},


### PR DESCRIPTION
Previously they were being serialized as `+Inf`/`-Inf`, which resulted in an unparsable JSON